### PR TITLE
E2e demo: add inline mode test, quiet flag, Linux/macOS sh version

### DIFF
--- a/scripts/e2e-demo.ps1
+++ b/scripts/e2e-demo.ps1
@@ -1,13 +1,16 @@
 # OmniVec End-to-End Demo — Fully Automated
 # Creates environment, provisions infra, registers model, creates pipeline, verifies it works
+# Tests both queue mode (CFP → jobs → worker → destination) and inline mode (CFP embeds directly into source)
 #
 # Usage:
-#   pwsh scripts/e2e-demo.ps1               # Run all steps (1-9)
+#   pwsh scripts/e2e-demo.ps1               # Run all steps (1-11)
 #   pwsh scripts/e2e-demo.ps1 -FromStep 5   # Skip infra, start from test account creation
 #   pwsh scripts/e2e-demo.ps1 -FromStep 8   # Skip to pipeline + docs (assumes resources exist)
+#   pwsh scripts/e2e-demo.ps1 -Quiet         # Minimal output (pass/fail per step)
 
 param(
     [int]$FromStep = 1,
+    [switch]$Quiet,
     [string]$AoaiEndpoint = $env:AOAI_ENDPOINT,
     [string]$AoaiKey = $env:AOAI_KEY,
     [string]$AoaiDeployment = $(if ($env:AOAI_DEPLOYMENT) { $env:AOAI_DEPLOYMENT } else { "text-embedding-3-small" }),
@@ -18,6 +21,14 @@ param(
 $ErrorActionPreference = "Stop"
 $RootDir = (Resolve-Path "$PSScriptRoot/..").Path
 $CLI = "$RootDir/bin/omnivec.exe"
+$TOTAL_STEPS = 11
+
+# ─── Logging helpers ────────────────────────────────────────────────────────
+function Log       { param([string]$Msg) if (-not $Quiet) { Write-Host $Msg } }
+function LogStep   { param([int]$N, [string]$Msg) Write-Host "`e[33m[Step $N/$TOTAL_STEPS] $Msg`e[0m" }
+function LogOk     { param([string]$Msg) Write-Host "  `e[32m$Msg`e[0m" }
+function LogWarn   { param([string]$Msg) Write-Host "  `e[33m$Msg`e[0m" }
+function LogErr    { param([string]$Msg) Write-Host "  `e[31m$Msg`e[0m" }
 
 # Auto-download CLI if not present, build from source as fallback
 if (-not (Test-Path $CLI)) {
@@ -26,7 +37,7 @@ if (-not (Test-Path $CLI)) {
 
     # Try download first (fast)
     try {
-        Write-Host "`e[33mCLI not found — downloading from GitHub release...`e[0m"
+        LogWarn "CLI not found — downloading from GitHub release..."
         # Get GitHub token from gh CLI, env var, or git credential
         $ghToken = $null
         try { $ghToken = (gh auth token 2>$null) } catch {}
@@ -45,16 +56,16 @@ if (-not (Test-Path $CLI)) {
             Invoke-WebRequest -Uri $asset.url -OutFile $CLI -Headers $dlHeaders -ErrorAction Stop
             if ((Test-Path $CLI) -and (Get-Item $CLI).Length -gt 1MB) {
                 $downloaded = $true
-                Write-Host "  `e[32mDownloaded: $CLI ($($release.tag_name))`e[0m"
+                LogOk "Downloaded: $CLI ($($release.tag_name))"
             }
         }
     } catch {
-        Write-Host "  `e[33mDownload failed ($($_.Exception.Message)), falling back to build...`e[0m"
+        LogWarn "Download failed ($($_.Exception.Message)), falling back to build..."
     }
 
     # Fallback: build from source
     if (-not $downloaded) {
-        Write-Host "`e[33mBuilding CLI from source...`e[0m"
+        LogWarn "Building CLI from source..."
         $goExe = Get-Command go -ErrorAction SilentlyContinue
         if (-not $goExe) {
             $goExe = @("$env:ProgramFiles\Go\bin\go.exe", "$env:USERPROFILE\go\bin\go.exe") | Where-Object { Test-Path $_ } | Select-Object -First 1
@@ -65,17 +76,19 @@ if (-not (Test-Path $CLI)) {
             Push-Location "$RootDir/cli"
             & $goExe build -o $CLI .
             Pop-Location
-            Write-Host "  `e[32mBuilt: $CLI`e[0m"
+            LogOk "Built: $CLI"
         } else {
-            Write-Host "`e[31mCannot obtain CLI. Install Go (https://go.dev/dl/) or place omnivec.exe in bin/`e[0m"
+            LogErr "Cannot obtain CLI. Install Go (https://go.dev/dl/) or place omnivec.exe in bin/"
             exit 1
         }
     }
 }
 
-Write-Host "`n`e[32m╔══════════════════════════════════════════════════════╗`e[0m"
-Write-Host "`e[32m║  OmniVec End-to-End Demo — Zero Manual Intervention  ║`e[0m"
-Write-Host "`e[32m╚══════════════════════════════════════════════════════╝`e[0m`n"
+if (-not $Quiet) {
+    Write-Host "`n`e[32m╔══════════════════════════════════════════════════════╗`e[0m"
+    Write-Host "`e[32m║  OmniVec End-to-End Demo — Zero Manual Intervention  ║`e[0m"
+    Write-Host "`e[32m╚══════════════════════════════════════════════════════╝`e[0m`n"
+}
 
 # ─── Configuration ───────────────────────────────────────────────────────────
 $ENV_NAME        = "omnivec-e2e-demo"
@@ -87,17 +100,17 @@ $AOAI_DEPLOYMENT = $AoaiDeployment
 $AOAI_DIMS       = $AoaiDims
 
 if (-not $AOAI_ENDPOINT) {
-    Write-Host "`e[33mAzure OpenAI endpoint not set.`e[0m"
-    Write-Host "  Example: https://<resource>.openai.azure.com"
+    LogWarn "Azure OpenAI endpoint not set."
+    Log "  Example: https://<resource>.openai.azure.com"
     $AOAI_ENDPOINT = Read-Host "  Enter Azure OpenAI endpoint"
-    if (-not $AOAI_ENDPOINT) { Write-Host "`e[31mEndpoint required.`e[0m"; exit 1 }
+    if (-not $AOAI_ENDPOINT) { LogErr "Endpoint required."; exit 1 }
 }
 if (-not $AOAI_KEY) {
-    Write-Host "`e[33mAzure OpenAI API key not set.`e[0m"
+    LogWarn "Azure OpenAI API key not set."
     $AOAI_KEY = Read-Host "  Enter Azure OpenAI API key"
-    if (-not $AOAI_KEY) { Write-Host "`e[31mAPI key required.`e[0m"; exit 1 }
+    if (-not $AOAI_KEY) { LogErr "API key required."; exit 1 }
 }
-Write-Host "  `e[32mEmbedding: $AOAI_DEPLOYMENT (${AOAI_DIMS}d) @ $AOAI_ENDPOINT`e[0m"
+LogOk "Embedding: $AOAI_DEPLOYMENT (${AOAI_DIMS}d) @ $AOAI_ENDPOINT"
 
 # ─── Helper: load azd env values ─────────────────────────────────────────────
 function Load-AzdValues {
@@ -120,7 +133,7 @@ function Invoke-PodPython {
 # STEP 1: Create azd environment
 # =============================================================================
 if ($FromStep -le 1) {
-    Write-Host "`e[33m[Step 1/9] Creating azd environment: $ENV_NAME`e[0m"
+    LogStep 1 "Creating azd environment: $ENV_NAME"
     azd env new $ENV_NAME --location $LOCATION --subscription $SUBSCRIPTION 2>$null
     azd env set OMNIVEC_METADATA_STORE "cosmosdb-serverless"
     azd env set OMNIVEC_ENABLE_BLOB_SOURCE "true"
@@ -132,23 +145,23 @@ if ($FromStep -le 1) {
     if ($SharedRegistryToken) {
         azd env set OMNIVEC_SHARED_REGISTRY_TOKEN $SharedRegistryToken
     } elseif (-not $SharedRegistryToken) {
-        Write-Host "`e[33mShared registry token not set (needed for image import).`e[0m"
+        LogWarn "Shared registry token not set (needed for image import)."
         $SharedRegistryToken = Read-Host "  Enter shared registry token (omnivecregistry.azurecr.io)"
         if ($SharedRegistryToken) {
             azd env set OMNIVEC_SHARED_REGISTRY_TOKEN $SharedRegistryToken
         }
     }
-    Write-Host "  `e[32mEnvironment configured.`e[0m"
+    LogOk "Environment configured."
 }
 
 # =============================================================================
 # STEP 2: Provision infrastructure
 # =============================================================================
 if ($FromStep -le 2) {
-    Write-Host "`n`e[33m[Step 2/9] Provisioning infrastructure (azd up ~15 min)...`e[0m"
+    LogStep 2 "Provisioning infrastructure (azd up ~15 min)..."
     azd up --no-prompt
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "  `e[33mazd up returned non-zero, continuing...`e[0m"
+        LogWarn "azd up returned non-zero, continuing..."
     }
 }
 
@@ -156,34 +169,34 @@ if ($FromStep -le 2) {
 # STEP 3: Get connection details + wait for API
 # =============================================================================
 if ($FromStep -le 3) {
-    Write-Host "`n`e[33m[Step 3/9] Retrieving connection details...`e[0m"
+    LogStep 3 "Retrieving connection details..."
 }
 # Always load azd values (needed by all subsequent steps)
 Load-AzdValues
 az aks get-credentials --resource-group $RESOURCE_GROUP --name $AKS_CLUSTER --overwrite-existing 2>$null
 
-Write-Host "  Admin Token: $ADMIN_TOKEN"
-Write-Host "  AKS:         $AKS_CLUSTER"
+Log "  Admin Token: $ADMIN_TOKEN"
+Log "  AKS:         $AKS_CLUSTER"
 
 # Wait for external IP
-Write-Host "  Waiting for external IP..."
+Log "  Waiting for external IP..."
 $SERVER = $null
 for ($i = 0; $i -lt 60; $i++) {
     $SERVER = kubectl get svc omnivec-web -n omnivec -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>$null
     if ($SERVER) { break }
     Start-Sleep -Seconds 5
 }
-if (-not $SERVER) { Write-Host "`e[31mFailed to get external IP`e[0m"; exit 1 }
+if (-not $SERVER) { LogErr "Failed to get external IP"; exit 1 }
 $SERVER_URL = "http://$SERVER"
-Write-Host "  `e[32mServer: $SERVER_URL`e[0m"
+LogOk "Server: $SERVER_URL"
 
 # Wait for API
-Write-Host "  Waiting for API health..."
+Log "  Waiting for API health..."
 for ($i = 0; $i -lt 30; $i++) {
     try { $h = Invoke-RestMethod -Uri "$SERVER_URL/health" -TimeoutSec 5 2>$null; if ($h.status -eq "healthy") { break } } catch {}
     Start-Sleep -Seconds 5
 }
-Write-Host "  `e[32mAPI healthy.`e[0m"
+LogOk "API healthy."
 
 # Auth headers for all API calls
 $headers = @{ "Authorization" = "Bearer $ADMIN_TOKEN"; "Content-Type" = "application/json" }
@@ -192,7 +205,7 @@ $headers = @{ "Authorization" = "Bearer $ADMIN_TOKEN"; "Content-Type" = "applica
 # STEP 4: Configure CLI
 # =============================================================================
 if ($FromStep -le 4) {
-    Write-Host "`n`e[33m[Step 4/9] Configuring CLI...`e[0m"
+    LogStep 4 "Configuring CLI..."
     & $CLI config set server $SERVER_URL
     & $CLI config set token $ADMIN_TOKEN
     & $CLI status
@@ -202,11 +215,11 @@ if ($FromStep -le 4) {
 # STEP 5: Create test CosmosDB account + containers
 # =============================================================================
 if ($FromStep -le 5) {
-    Write-Host "`n`e[33m[Step 5/9] Creating test CosmosDB account...`e[0m"
+    LogStep 5 "Creating test CosmosDB account..."
     $TEST_COSMOS_ENDPOINT = az cosmosdb show --name $TEST_COSMOS_ACCOUNT --resource-group $RESOURCE_GROUP --query documentEndpoint -o tsv 2>$null
 
     if (-not $TEST_COSMOS_ENDPOINT) {
-        Write-Host "  Creating account: $TEST_COSMOS_ACCOUNT"
+        Log "  Creating account: $TEST_COSMOS_ACCOUNT"
         $armPayload = @{
             location = $LOCATION; kind = "GlobalDocumentDB"
             properties = @{
@@ -223,7 +236,7 @@ if ($FromStep -le 5) {
         az rest --method PUT --url $armUrl --body "@$armFile" -o none
         Remove-Item $armFile -ErrorAction SilentlyContinue
 
-        Write-Host "  Waiting for provisioning..."
+        Log "  Waiting for provisioning..."
         for ($i = 0; $i -lt 40; $i++) {
             $st = az cosmosdb show --name $TEST_COSMOS_ACCOUNT --resource-group $RESOURCE_GROUP --query provisioningState -o tsv 2>$null
             if ($st -eq "Succeeded") { break }
@@ -231,39 +244,43 @@ if ($FromStep -le 5) {
         }
         $TEST_COSMOS_ENDPOINT = az cosmosdb show --name $TEST_COSMOS_ACCOUNT --resource-group $RESOURCE_GROUP --query documentEndpoint -o tsv 2>$null
     }
-    Write-Host "  `e[32mEndpoint: $TEST_COSMOS_ENDPOINT`e[0m"
+    LogOk "Endpoint: $TEST_COSMOS_ENDPOINT"
 
     # Grant RBAC
-    Write-Host "  Granting RBAC..."
+    Log "  Granting RBAC..."
     $PRINCIPAL_ID = az identity show --name "omnivec-identity-$INSTANCE_TOKEN" --resource-group $RESOURCE_GROUP --query principalId -o tsv 2>$null
     if (-not $PRINCIPAL_ID) { $PRINCIPAL_ID = az identity list --resource-group $RESOURCE_GROUP --query "[0].principalId" -o tsv 2>$null }
 
     az cosmosdb sql role assignment create --account-name $TEST_COSMOS_ACCOUNT --resource-group $RESOURCE_GROUP --role-definition-id "00000000-0000-0000-0000-000000000002" --principal-id $PRINCIPAL_ID --scope "/" -o none 2>$null
     $scope = "/subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DocumentDB/databaseAccounts/$TEST_COSMOS_ACCOUNT"
     az role assignment create --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal --role "Cosmos DB Account Reader Role" --scope $scope -o none 2>$null
-    Write-Host "  `e[32mRBAC assigned (Data Contributor + Account Reader). Waiting 30s...`e[0m"
+    LogOk "RBAC assigned (Data Contributor + Account Reader). Waiting 30s..."
     Start-Sleep -Seconds 30
 
     # Create database + containers
-    Write-Host "  Creating containers..."
+    Log "  Creating containers..."
     az cosmosdb sql database create --account-name $TEST_COSMOS_ACCOUNT --name testdb --resource-group $RESOURCE_GROUP -o none 2>$null
     az cosmosdb sql container create --account-name $TEST_COSMOS_ACCOUNT --database-name testdb --name test-documents --resource-group $RESOURCE_GROUP --partition-key-path "/id" -o none 2>$null
-    Write-Host "  `e[32mtest-documents created.`e[0m"
+    LogOk "test-documents created."
 
     # Vectors container with vector policy (via API pod)
     Invoke-PodPython @"
 import os
 from azure.cosmos import CosmosClient
+from azure.cosmos.exceptions import CosmosResourceExistsError
 from azure.identity import DefaultAzureCredential
 cred = DefaultAzureCredential(managed_identity_client_id=os.environ.get("AZURE_CLIENT_ID"))
 client = CosmosClient("$TEST_COSMOS_ENDPOINT", credential=cred)
 db = client.get_database_client("testdb")
 vp = {"vectorEmbeddings": [{"path": "/embedding", "dataType": "float32", "distanceFunction": "cosine", "dimensions": $AOAI_DIMS}]}
 ip = {"includedPaths": [{"path": "/*"}], "excludedPaths": [{"path": "/embedding/*"}], "vectorIndexes": [{"path": "/embedding", "type": "quantizedFlat"}]}
-db.create_container(id="vectors", partition_key={"paths": ["/id"], "kind": "Hash"}, vector_embedding_policy=vp, indexing_policy=ip)
-print("  vectors created (${AOAI_DIMS}d, cosine, quantizedFlat)")
+try:
+    db.create_container(id="vectors", partition_key={"paths": ["/id"], "kind": "Hash"}, vector_embedding_policy=vp, indexing_policy=ip)
+    print("  vectors created (${AOAI_DIMS}d, cosine, quantizedFlat)")
+except CosmosResourceExistsError:
+    print("  vectors container already exists")
 "@
-    Write-Host "  `e[32mAll containers ready.`e[0m"
+    LogOk "All containers ready."
 } else {
     # Load test endpoint for later steps
     $TEST_COSMOS_ENDPOINT = az cosmosdb show --name $TEST_COSMOS_ACCOUNT --resource-group $RESOURCE_GROUP --query documentEndpoint -o tsv 2>$null
@@ -273,7 +290,7 @@ print("  vectors created (${AOAI_DIMS}d, cosine, quantizedFlat)")
 # STEP 6: Register embedding model
 # =============================================================================
 if ($FromStep -le 6) {
-    Write-Host "`n`e[33m[Step 6/9] Registering Azure OpenAI embedding model...`e[0m"
+    LogStep 6 "Registering Azure OpenAI embedding model..."
     $modelBody = @{
         name = "azure-openai-embed"; type = "azure-openai"; endpoint = $AOAI_ENDPOINT
         api_key = $AOAI_KEY; model = $AOAI_DEPLOYMENT; deployment = $AOAI_DEPLOYMENT
@@ -281,7 +298,7 @@ if ($FromStep -le 6) {
     } | ConvertTo-Json
     $modelResult = Invoke-RestMethod -Uri "$SERVER_URL/api/models" -Method POST -Headers $headers -Body $modelBody
     $MODEL_ID = $modelResult.id
-    Write-Host "  `e[32mModel: $MODEL_ID ($AOAI_DEPLOYMENT, ${AOAI_DIMS}d)`e[0m"
+    LogOk "Model: $MODEL_ID ($AOAI_DEPLOYMENT, ${AOAI_DIMS}d)"
 } else {
     $models = Invoke-RestMethod -Uri "$SERVER_URL/api/models" -Headers $headers
     $MODEL_ID = $models.models[0].id
@@ -291,7 +308,7 @@ if ($FromStep -le 6) {
 # STEP 7: Create source + destination
 # =============================================================================
 if ($FromStep -le 7) {
-    Write-Host "`n`e[33m[Step 7/9] Creating source and destination...`e[0m"
+    LogStep 7 "Creating source and destination..."
 
     # Clean up any existing resources from previous runs
     $existing = Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines" -Headers $headers
@@ -307,7 +324,7 @@ if ($FromStep -le 7) {
     }} | ConvertTo-Json -Depth 5
     $srcResult = Invoke-RestMethod -Uri "$SERVER_URL/api/sources" -Method POST -Headers $headers -Body $srcBody
     $SOURCE_ID = $srcResult.source.id
-    Write-Host "  `e[32mSource: $SOURCE_ID`e[0m"
+    LogOk "Source: $SOURCE_ID"
 
     $dstBody = @{ name = "demo-vector-store"; type = "cosmosdb-vector"; config = @{
         endpoint = $TEST_COSMOS_ENDPOINT; database = "testdb"; container = "vectors"
@@ -315,7 +332,7 @@ if ($FromStep -le 7) {
     }} | ConvertTo-Json -Depth 5
     $dstResult = Invoke-RestMethod -Uri "$SERVER_URL/api/destinations" -Method POST -Headers $headers -Body $dstBody
     $DEST_ID = $dstResult.destination.id
-    Write-Host "  `e[32mDestination: $DEST_ID`e[0m"
+    LogOk "Destination: $DEST_ID"
 } else {
     $srcs = Invoke-RestMethod -Uri "$SERVER_URL/api/sources" -Headers $headers
     $SOURCE_ID = $srcs.sources[0].id
@@ -324,22 +341,23 @@ if ($FromStep -le 7) {
 }
 
 # =============================================================================
-# STEP 8: Create pipeline (paused) + insert docs + resume
+# STEP 8: Queue mode — create pipeline, insert docs, resume
 # =============================================================================
 if ($FromStep -le 8) {
-    Write-Host "`n`e[33m[Step 8/9] Creating pipeline, inserting docs, activating...`e[0m"
+    LogStep 8 "Queue mode — creating pipeline, inserting docs, activating..."
 
-    # Pipeline (paused)
+    # Pipeline (paused, queue mode is default)
     $pipBody = @{
-        name = "demo-pipeline"; sources = @(@{ source_id = $SOURCE_ID; filters = @{} })
+        name = "demo-pipeline-queue"; sources = @(@{ source_id = $SOURCE_ID; filters = @{} })
         destination_id = $DEST_ID; docgrok_pipeline = $MODEL_ID; process_existing = $true
+        processing_mode = "queue"
     } | ConvertTo-Json -Depth 5
     $pipResult = Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines" -Method POST -Headers $headers -Body $pipBody
     $PIP_ID = $pipResult.pipeline.id
-    Write-Host "  `e[32mPipeline (paused): $PIP_ID`e[0m"
+    LogOk "Pipeline (paused, queue mode): $PIP_ID"
 
     # Insert test documents
-    Write-Host "  Inserting test documents..."
+    Log "  Inserting test documents..."
     Invoke-PodPython @"
 import os
 from azure.cosmos import CosmosClient
@@ -358,10 +376,10 @@ for doc in docs:
 "@
 
     # Resume pipeline
-    Write-Host "  Resuming pipeline..."
+    Log "  Resuming pipeline..."
     Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines/$PIP_ID/resume" -Method POST -Headers $headers | Out-Null
     Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines/$PIP_ID/run" -Method POST -Headers $headers | Out-Null
-    Write-Host "  `e[32mPipeline activated. Waiting 60s for change feed processing...`e[0m"
+    LogOk "Pipeline activated (queue mode). Waiting 60s for processing..."
     Start-Sleep -Seconds 60
 } else {
     $pips = Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines" -Headers $headers
@@ -369,56 +387,179 @@ for doc in docs:
 }
 
 # =============================================================================
-# STEP 9: Verify results
+# STEP 9: Verify queue mode results
 # =============================================================================
-Write-Host "`n`e[33m[Step 9/9] Checking results...`e[0m"
-& $CLI pipeline show $PIP_ID
-Write-Host ""
-& $CLI job list
-
-$jobsResult = Invoke-RestMethod -Uri "$SERVER_URL/api/jobs?status=completed&limit=5" -Headers $headers
-$completedCount = $jobsResult.jobs.Count
-
-Write-Host ""
-if ($completedCount -gt 0) {
-    Write-Host "`e[32m  $completedCount documents successfully embedded!`e[0m"
-
-    # Vector search test
-    Write-Host "`e[33m  Testing vector search...`e[0m"
-    $searchBody = @{ query = "what is cosmos db"; destination_id = $DEST_ID; top_k = 3 } | ConvertTo-Json
-    try {
-        $searchResult = Invoke-RestMethod -Uri "$SERVER_URL/api/playground/search" -Method POST -Headers $headers -Body $searchBody
-        Write-Host "`e[32m  Search returned $($searchResult.results.Count) results:`e[0m"
-        foreach ($r in $searchResult.results) {
-            Write-Host "    [$([math]::Round($r.score, 4))] $($r.id)"
-        }
-    } catch {
-        Write-Host "`e[33m  Search test skipped (may need more processing time)`e[0m"
+if ($PIP_ID) {
+    LogStep 9 "Verifying queue mode results..."
+    if (-not $Quiet) {
+        & $CLI pipeline show $PIP_ID
+        Write-Host ""
+        & $CLI job list
     }
 
-    # Pipeline reset test
-    Write-Host ""
-    Write-Host "`e[33m  Testing pipeline reset...`e[0m"
-    & $CLI pipeline reset $PIP_ID -y
+    $jobsResult = Invoke-RestMethod -Uri "$SERVER_URL/api/jobs?status=completed&limit=5" -Headers $headers
+    $completedCount = $jobsResult.jobs.Count
+
+    if ($completedCount -gt 0) {
+        LogOk "$completedCount documents embedded via queue mode!"
+
+        # Vector search test
+        Log "  Testing vector search..."
+        $searchBody = @{ query = "what is cosmos db"; destination_id = $DEST_ID; top_k = 3 } | ConvertTo-Json
+        try {
+            $searchResult = Invoke-RestMethod -Uri "$SERVER_URL/api/playground/search" -Method POST -Headers $headers -Body $searchBody
+            LogOk "Search returned $($searchResult.results.Count) results:"
+            foreach ($r in $searchResult.results) {
+                Log "    [$([math]::Round($r.score, 4))] $($r.id)"
+            }
+        } catch {
+            LogWarn "Search test skipped (may need more processing time)"
+        }
+
+        # Pipeline reset test
+        Log "  Testing pipeline reset..."
+        & $CLI pipeline reset $PIP_ID -y
+    } else {
+        LogWarn "No completed jobs yet. Check: omnivec pipeline show $PIP_ID"
+    }
+
+    # Stats
+    $stats = Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines/$PIP_ID" -Headers $headers
+    Log "  Processed:  $($stats.stats.documents_processed)"
+    Log "  Embedded:   $($stats.stats.embedded_count)"
+    Log "  Completion: $($stats.stats.completion_pct)%"
+
+    # Clean up queue pipeline before starting inline — they share the same source,
+    # so only one should be active at a time to avoid change feed contention.
+    Log "  Removing queue pipeline before inline test..."
+    try { Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines/$PIP_ID" -Method DELETE -Headers $headers | Out-Null } catch {}
 } else {
-    Write-Host "`e[33m  No completed jobs yet. Check: omnivec pipeline show $PIP_ID`e[0m"
+    LogStep 9 "Skipping queue mode verify (no queue pipeline)"
+    # Clean up any existing pipelines when jumping to inline test
+    $existing = Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines" -Headers $headers
+    foreach ($p in $existing.pipelines) { try { Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines/$($p.id)" -Method DELETE -Headers $headers 2>$null } catch {} }
 }
 
-# Stats
-$stats = Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines/$PIP_ID" -Headers $headers
-Write-Host ""
-Write-Host "  Processed:  $($stats.stats.documents_processed)"
-Write-Host "  Embedded:   $($stats.stats.embedded_count)"
-Write-Host "  Completion: $($stats.stats.completion_pct)%"
+# =============================================================================
+# STEP 10: Inline mode — create pipeline, resume, then insert docs
+# =============================================================================
+if ($FromStep -le 10) {
+    LogStep 10 "Inline mode — creating pipeline, activating, inserting docs..."
 
-Write-Host "`n`e[32m╔══════════════════════════════════════════════════════╗`e[0m"
-Write-Host "`e[32m║           End-to-End Demo Complete!                   ║`e[0m"
+    # Pipeline (paused, inline mode — CFP embeds directly into source container)
+    $inlinePipBody = @{
+        name = "demo-pipeline-inline"; sources = @(@{ source_id = $SOURCE_ID; filters = @{} })
+        destination_id = $DEST_ID; docgrok_pipeline = $MODEL_ID; process_existing = $true
+        processing_mode = "inline"
+    } | ConvertTo-Json -Depth 5
+    $inlinePipResult = Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines" -Method POST -Headers $headers -Body $inlinePipBody
+    $INLINE_PIP_ID = $inlinePipResult.pipeline.id
+    LogOk "Pipeline (paused, inline mode): $INLINE_PIP_ID"
+
+    # Resume inline pipeline FIRST so CFP picks up changes in inline mode
+    Log "  Resuming inline pipeline..."
+    Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines/$INLINE_PIP_ID/resume" -Method POST -Headers $headers | Out-Null
+    Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines/$INLINE_PIP_ID/run" -Method POST -Headers $headers | Out-Null
+    LogOk "Pipeline active (inline mode). Waiting 30s for CFP lease rebalance..."
+    Start-Sleep -Seconds 30
+
+    # Insert test documents AFTER pipeline is active so CFP processes them in inline mode
+    Log "  Inserting inline test documents..."
+    Invoke-PodPython @"
+import os
+from azure.cosmos import CosmosClient
+from azure.identity import DefaultAzureCredential
+cred = DefaultAzureCredential(managed_identity_client_id=os.environ.get("AZURE_CLIENT_ID"))
+client = CosmosClient("$TEST_COSMOS_ENDPOINT", credential=cred)
+c = client.get_database_client("testdb").get_container_client("test-documents")
+docs = [
+    {"id": "doc-inline-001", "title": "Azure Functions", "content": "Azure Functions is an event-driven serverless compute platform that lets you run code without provisioning or managing infrastructure.", "category": "compute"},
+    {"id": "doc-inline-002", "title": "Azure AI Search", "content": "Azure AI Search provides secure information retrieval at scale over user-owned content in traditional and generative AI search applications.", "category": "ai"},
+    {"id": "doc-inline-003", "title": "Azure Service Bus", "content": "Azure Service Bus is a fully managed enterprise message broker with message queues and publish-subscribe topics for decoupled applications.", "category": "messaging"},
+]
+for doc in docs:
+    c.upsert_item(doc)
+    print(f"  Inserted: {doc['id']} - {doc['title']}")
+"@
+    LogOk "Docs inserted. Waiting 90s for inline processing..."
+    Start-Sleep -Seconds 90
+} else {
+    # Load inline pipeline if skipping
+    $allPips = Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines" -Headers $headers
+    $INLINE_PIP_ID = ($allPips.pipelines | Where-Object { $_.processing_mode -eq "inline" } | Select-Object -First 1).id
+}
+
+# =============================================================================
+# STEP 11: Verify inline mode results
+# =============================================================================
+LogStep 11 "Verifying inline mode results..."
+if (-not $Quiet) {
+    & $CLI pipeline show $INLINE_PIP_ID
+}
+
+# Inline mode embeds directly into the source container — check for embedding field
+Log "  Checking source container for inline embeddings..."
+$inlineCheck = $null
+try {
+    $inlineCheck = Invoke-PodPython @"
+import os, json
+from azure.cosmos import CosmosClient
+from azure.identity import DefaultAzureCredential
+cred = DefaultAzureCredential(managed_identity_client_id=os.environ.get("AZURE_CLIENT_ID"))
+client = CosmosClient("$TEST_COSMOS_ENDPOINT", credential=cred)
+c = client.get_database_client("testdb").get_container_client("test-documents")
+embedded = 0
+checked = 0
+for doc in c.query_items("SELECT c.id, IS_DEFINED(c.embedding) as has_emb FROM c WHERE STARTSWITH(c.id, 'doc-inline-')", enable_cross_partition_query=True):
+    checked += 1
+    if doc.get('has_emb'):
+        embedded += 1
+        print(f"  {doc['id']}: embedding present")
+    else:
+        print(f"  {doc['id']}: no embedding yet")
+print(f"INLINE_RESULT:{embedded}/{checked}")
+"@
+    Write-Host $inlineCheck
+} catch {
+    LogWarn "Could not query inline embeddings: $($_.Exception.Message)"
+}
+
+# For inline mode, the source container is the source of truth — embeddings are
+# patched directly into source docs. Pipeline stats may lag behind.
+$inlineEmbeddedCount = 0
+$inlineTotal = 0
+$inlineCheckStr = if ($inlineCheck -is [array]) { $inlineCheck -join "`n" } else { "$inlineCheck" }
+if ($inlineCheckStr -match "INLINE_RESULT:(\d+)/(\d+)") {
+    $inlineEmbeddedCount = [int]$Matches[1]
+    $inlineTotal = [int]$Matches[2]
+}
+
+$inlineStats = Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines/$INLINE_PIP_ID" -Headers $headers
+Log "  Pipeline stats — Processed: $($inlineStats.stats.documents_processed), Embedded: $($inlineStats.stats.embedded_count)"
+Log "  Source container — Embedded: $inlineEmbeddedCount/$inlineTotal"
+
+if ($inlineEmbeddedCount -gt 0) {
+    LogOk "Inline mode working — $inlineEmbeddedCount/$inlineTotal documents embedded directly into source container!"
+} else {
+    LogWarn "No inline embeddings yet. The CFP may still be processing. Check: omnivec pipeline show $INLINE_PIP_ID"
+}
+
+# =============================================================================
+# Summary
+# =============================================================================
+Write-Host ""
+Write-Host "`e[32m╔══════════════════════════════════════════════════════╗`e[0m"
+Write-Host "`e[32m║           End-to-End Demo Complete!                  ║`e[0m"
 Write-Host "`e[32m╚══════════════════════════════════════════════════════╝`e[0m"
 Write-Host ""
-Write-Host "  Server:      `e[36m$SERVER_URL`e[0m"
-Write-Host "  Admin Token: `e[36m$ADMIN_TOKEN`e[0m"
-Write-Host "  Source:      `e[36m$SOURCE_ID`e[0m"
-Write-Host "  Destination: `e[36m$DEST_ID`e[0m"
-Write-Host "  Pipeline:    `e[36m$PIP_ID`e[0m"
-Write-Host "  Model:       `e[36m$MODEL_ID ($AOAI_DEPLOYMENT)`e[0m"
+Write-Host "  Server:          `e[36m$SERVER_URL`e[0m"
+Write-Host "  Admin Token:     `e[36m$ADMIN_TOKEN`e[0m"
+Write-Host "  Source:          `e[36m$SOURCE_ID`e[0m"
+Write-Host "  Destination:     `e[36m$DEST_ID`e[0m"
+Write-Host "  Queue Pipeline:  `e[36m$PIP_ID`e[0m"
+Write-Host "  Inline Pipeline: `e[36m$INLINE_PIP_ID`e[0m"
+Write-Host "  Model:           `e[36m$MODEL_ID ($AOAI_DEPLOYMENT)`e[0m"
+Write-Host ""
+Write-Host "  `e[36mQueue mode:`e[0m  CFP detects changes -> creates jobs -> .NET worker embeds -> writes to destination"
+Write-Host "  `e[36mInline mode:`e[0m CFP detects changes -> embeds directly -> patches back to source container"
 Write-Host ""

--- a/scripts/e2e-demo.ps1
+++ b/scripts/e2e-demo.ps1
@@ -252,8 +252,12 @@ if ($FromStep -le 5) {
     if (-not $PRINCIPAL_ID) { $PRINCIPAL_ID = az identity list --resource-group $RESOURCE_GROUP --query "[0].principalId" -o tsv 2>$null }
 
     az cosmosdb sql role assignment create --account-name $TEST_COSMOS_ACCOUNT --resource-group $RESOURCE_GROUP --role-definition-id "00000000-0000-0000-0000-000000000002" --principal-id $PRINCIPAL_ID --scope "/" -o none 2>$null
+    # ARM role: Cosmos DB Account Reader (required for readMetadata)
+    # Use az rest because az role assignment create has API version bugs in some az CLI versions
+    $roleAssignId = [guid]::NewGuid().ToString()
     $scope = "/subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DocumentDB/databaseAccounts/$TEST_COSMOS_ACCOUNT"
-    az role assignment create --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal --role "Cosmos DB Account Reader Role" --scope $scope -o none 2>$null
+    $roleBody = @{ properties = @{ roleDefinitionId = "/subscriptions/$SUBSCRIPTION/providers/Microsoft.Authorization/roleDefinitions/fbdf93bf-df7d-467e-a4d2-9458aa1360c8"; principalId = $PRINCIPAL_ID; principalType = "ServicePrincipal" } } | ConvertTo-Json -Depth 5
+    az rest --method PUT --url "${scope}/providers/Microsoft.Authorization/roleAssignments/${roleAssignId}?api-version=2022-04-01" --body $roleBody -o none 2>$null
     LogOk "RBAC assigned (Data Contributor + Account Reader). Waiting 60s for propagation..."
     Start-Sleep -Seconds 60
 

--- a/scripts/e2e-demo.ps1
+++ b/scripts/e2e-demo.ps1
@@ -254,8 +254,8 @@ if ($FromStep -le 5) {
     az cosmosdb sql role assignment create --account-name $TEST_COSMOS_ACCOUNT --resource-group $RESOURCE_GROUP --role-definition-id "00000000-0000-0000-0000-000000000002" --principal-id $PRINCIPAL_ID --scope "/" -o none 2>$null
     $scope = "/subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DocumentDB/databaseAccounts/$TEST_COSMOS_ACCOUNT"
     az role assignment create --assignee-object-id $PRINCIPAL_ID --assignee-principal-type ServicePrincipal --role "Cosmos DB Account Reader Role" --scope $scope -o none 2>$null
-    LogOk "RBAC assigned (Data Contributor + Account Reader). Waiting 30s..."
-    Start-Sleep -Seconds 30
+    LogOk "RBAC assigned (Data Contributor + Account Reader). Waiting 60s for propagation..."
+    Start-Sleep -Seconds 60
 
     # Create database + containers
     Log "  Creating containers..."
@@ -264,10 +264,12 @@ if ($FromStep -le 5) {
     LogOk "test-documents created."
 
     # Vectors container with vector policy (via API pod)
-    Invoke-PodPython @"
+    # Retry up to 3 times — RBAC propagation can take longer than expected
+    for ($attempt = 1; $attempt -le 3; $attempt++) {
+        $vectorsOutput = Invoke-PodPython @"
 import os
 from azure.cosmos import CosmosClient
-from azure.cosmos.exceptions import CosmosResourceExistsError
+from azure.cosmos.exceptions import CosmosResourceExistsError, CosmosHttpResponseError
 from azure.identity import DefaultAzureCredential
 cred = DefaultAzureCredential(managed_identity_client_id=os.environ.get("AZURE_CLIENT_ID"))
 client = CosmosClient("$TEST_COSMOS_ENDPOINT", credential=cred)
@@ -276,10 +278,22 @@ vp = {"vectorEmbeddings": [{"path": "/embedding", "dataType": "float32", "distan
 ip = {"includedPaths": [{"path": "/*"}], "excludedPaths": [{"path": "/embedding/*"}], "vectorIndexes": [{"path": "/embedding", "type": "quantizedFlat"}]}
 try:
     db.create_container(id="vectors", partition_key={"paths": ["/id"], "kind": "Hash"}, vector_embedding_policy=vp, indexing_policy=ip)
-    print("  vectors created (${AOAI_DIMS}d, cosine, quantizedFlat)")
+    print("OK: vectors created (${AOAI_DIMS}d, cosine, quantizedFlat)")
 except CosmosResourceExistsError:
-    print("  vectors container already exists")
+    print("OK: vectors container already exists")
+except CosmosHttpResponseError as e:
+    if "Forbidden" in str(e) or "403" in str(e):
+        print("RBAC_WAIT")
+    else:
+        raise
 "@
+        Write-Host $vectorsOutput
+        if ($vectorsOutput -match "^OK:") { break }
+        if ($vectorsOutput -match "RBAC_WAIT") {
+            LogWarn "RBAC not yet propagated, waiting 30s (attempt $attempt/3)..."
+            Start-Sleep -Seconds 30
+        } else { break }
+    }
     LogOk "All containers ready."
 } else {
     # Load test endpoint for later steps

--- a/scripts/e2e-demo.sh
+++ b/scripts/e2e-demo.sh
@@ -294,9 +294,14 @@ ARMEOF
 
   az cosmosdb sql role assignment create --account-name "$TEST_COSMOS_ACCOUNT" --resource-group "$RESOURCE_GROUP" \
     --role-definition-id "00000000-0000-0000-0000-000000000002" --principal-id "$PRINCIPAL_ID" --scope "/" -o none 2>/dev/null || true
+  # ARM role: Cosmos DB Account Reader (required for readMetadata)
+  # Use az rest because az role assignment create has API version bugs in some az CLI versions
+  ROLE_ASSIGN_ID=$(powershell -Command "[guid]::NewGuid().ToString()" 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || python3 -c "import uuid; print(uuid.uuid4())")
   SCOPE="/subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DocumentDB/databaseAccounts/$TEST_COSMOS_ACCOUNT"
-  az role assignment create --assignee-object-id "$PRINCIPAL_ID" --assignee-principal-type ServicePrincipal \
-    --role "Cosmos DB Account Reader Role" --scope "$SCOPE" -o none 2>/dev/null || true
+  az rest --method PUT \
+    --url "${SCOPE}/providers/Microsoft.Authorization/roleAssignments/${ROLE_ASSIGN_ID}?api-version=2022-04-01" \
+    --body "{\"properties\":{\"roleDefinitionId\":\"/subscriptions/$SUBSCRIPTION/providers/Microsoft.Authorization/roleDefinitions/fbdf93bf-df7d-467e-a4d2-9458aa1360c8\",\"principalId\":\"$PRINCIPAL_ID\",\"principalType\":\"ServicePrincipal\"}}" \
+    -o none 2>/dev/null || true
   log_ok "RBAC assigned (Data Contributor + Account Reader). Waiting 60s for propagation..."
   sleep 60
 

--- a/scripts/e2e-demo.sh
+++ b/scripts/e2e-demo.sh
@@ -1,0 +1,606 @@
+#!/bin/sh
+# OmniVec End-to-End Demo — Fully Automated (Linux/macOS)
+# Creates environment, provisions infra, registers model, creates pipeline, verifies it works
+# Tests both queue mode (CFP -> jobs -> worker -> destination) and inline mode (CFP embeds directly into source)
+#
+# Usage:
+#   ./scripts/e2e-demo.sh                    # Run all steps (1-11)
+#   ./scripts/e2e-demo.sh --from-step 5      # Skip infra, start from test account creation
+#   ./scripts/e2e-demo.sh --from-step 8      # Skip to pipeline + docs (assumes resources exist)
+#   ./scripts/e2e-demo.sh --quiet            # Minimal output (pass/fail per step)
+
+set -eu
+
+# ─── Parse arguments ─────────────────────────────────────────────────────────
+FROM_STEP=1
+QUIET=false
+AOAI_ENDPOINT="${AOAI_ENDPOINT:-}"
+AOAI_KEY="${AOAI_KEY:-}"
+AOAI_DEPLOYMENT="${AOAI_DEPLOYMENT:-text-embedding-3-small}"
+AOAI_DIMS="${AOAI_DIMS:-1536}"
+SHARED_REGISTRY_TOKEN="${OMNIVEC_SHARED_REGISTRY_TOKEN:-}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --from-step) FROM_STEP="$2"; shift 2 ;;
+    --quiet|-q) QUIET=true; shift ;;
+    --endpoint) AOAI_ENDPOINT="$2"; shift 2 ;;
+    --key) AOAI_KEY="$2"; shift 2 ;;
+    --deployment) AOAI_DEPLOYMENT="$2"; shift 2 ;;
+    --dims) AOAI_DIMS="$2"; shift 2 ;;
+    --registry-token) SHARED_REGISTRY_TOKEN="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TOTAL_STEPS=11
+
+# Detect CLI binary name (omnivec on Linux/macOS, omnivec.exe on Windows/WSL)
+if [ -f "$ROOT_DIR/bin/omnivec" ]; then
+  CLI="$ROOT_DIR/bin/omnivec"
+elif [ -f "$ROOT_DIR/bin/omnivec.exe" ]; then
+  CLI="$ROOT_DIR/bin/omnivec.exe"
+else
+  CLI="$ROOT_DIR/bin/omnivec"
+fi
+
+# ─── Colors & logging ────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+log()      { if [ "$QUIET" = "false" ]; then echo "$1"; fi; }
+log_step() { printf "${YELLOW}[Step %s/%s] %s${NC}\n" "$1" "$TOTAL_STEPS" "$2"; }
+log_ok()   { printf "  ${GREEN}%s${NC}\n" "$1"; }
+log_warn() { printf "  ${YELLOW}%s${NC}\n" "$1"; }
+log_err()  { printf "  ${RED}%s${NC}\n" "$1"; }
+
+# ─── Helper: run Python on API pod via stdin ─────────────────────────────────
+pod_python() {
+  echo "$1" | kubectl exec -i deployment/omnivec-api -n omnivec -- python3 -
+}
+
+# ─── Helper: HTTP calls via curl ─────────────────────────────────────────────
+api_get() {
+  curl -sfS -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" "$SERVER_URL$1"
+}
+
+api_post() {
+  curl -sfS -X POST -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" -d "$2" "$SERVER_URL$1"
+}
+
+api_delete() {
+  curl -sfS -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" "$SERVER_URL$1" 2>/dev/null || true
+}
+
+# ─── Auto-download CLI if not present ────────────────────────────────────────
+if [ ! -f "$CLI" ]; then
+  mkdir -p "$ROOT_DIR/bin"
+  downloaded=false
+
+  # Try download first
+  log_warn "CLI not found — downloading from GitHub release..."
+  GH_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+  if [ -z "$GH_TOKEN" ] && command -v gh >/dev/null 2>&1; then
+    GH_TOKEN=$(gh auth token 2>/dev/null || true)
+  fi
+
+  GH_AUTH=""
+  if [ -n "$GH_TOKEN" ]; then GH_AUTH="-H \"Authorization: token $GH_TOKEN\""; fi
+
+  # Detect platform
+  OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+  ARCH=$(uname -m)
+  case "$ARCH" in
+    x86_64) ARCH="amd64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+  esac
+  CLI_ASSET="omnivec-${OS}-${ARCH}"
+
+  RELEASE_URL="https://api.github.com/repos/AzureCosmosDB/OmniVec/releases/latest"
+  ASSET_URL=$(eval curl -sfS -H "Accept: application/vnd.github.v3+json" $GH_AUTH "$RELEASE_URL" 2>/dev/null | \
+    grep -o "\"browser_download_url\":\"[^\"]*${CLI_ASSET}[^\"]*\"" | head -1 | cut -d'"' -f4) || true
+
+  if [ -n "$ASSET_URL" ]; then
+    eval curl -sfSL $GH_AUTH -o "$CLI" "$ASSET_URL" 2>/dev/null && chmod +x "$CLI" && downloaded=true
+  fi
+
+  # Fallback: build from source
+  if [ "$downloaded" = "false" ]; then
+    log_warn "Download failed, building CLI from source..."
+    GO_EXE=$(command -v go 2>/dev/null || true)
+    if [ -n "$GO_EXE" ]; then
+      (cd "$ROOT_DIR/cli" && go build -o "$CLI" .)
+      log_ok "Built: $CLI"
+    else
+      log_err "Cannot obtain CLI. Install Go (https://go.dev/dl/) or place omnivec binary in bin/"
+      exit 1
+    fi
+  else
+    log_ok "Downloaded: $CLI"
+  fi
+fi
+
+# ─── Banner ──────────────────────────────────────────────────────────────────
+if [ "$QUIET" = "false" ]; then
+  printf "\n${GREEN}╔══════════════════════════════════════════════════════╗${NC}\n"
+  printf "${GREEN}║  OmniVec End-to-End Demo — Zero Manual Intervention  ║${NC}\n"
+  printf "${GREEN}╚══════════════════════════════════════════════════════╝${NC}\n\n"
+fi
+
+# ─── Configuration ───────────────────────────────────────────────────────────
+ENV_NAME="omnivec-e2e-demo"
+LOCATION="eastus2"
+SUBSCRIPTION="074d02eb-4d74-486a-b299-b262264d1536"
+
+if [ -z "$AOAI_ENDPOINT" ]; then
+  log_warn "Azure OpenAI endpoint not set."
+  log "  Example: https://<resource>.openai.azure.com"
+  printf "  Enter Azure OpenAI endpoint: "
+  read -r AOAI_ENDPOINT
+  if [ -z "$AOAI_ENDPOINT" ]; then log_err "Endpoint required."; exit 1; fi
+fi
+if [ -z "$AOAI_KEY" ]; then
+  log_warn "Azure OpenAI API key not set."
+  printf "  Enter Azure OpenAI API key: "
+  read -r AOAI_KEY
+  if [ -z "$AOAI_KEY" ]; then log_err "API key required."; exit 1; fi
+fi
+log_ok "Embedding: $AOAI_DEPLOYMENT (${AOAI_DIMS}d) @ $AOAI_ENDPOINT"
+
+# ─── Helper: load azd env values ────────────────────────────────────────────
+load_azd_values() {
+  ADMIN_TOKEN=$(azd env get-value OMNIVEC_ADMIN_TOKEN 2>/dev/null || true)
+  AKS_CLUSTER=$(azd env get-value AZURE_AKS_CLUSTER_NAME 2>/dev/null || true)
+  RESOURCE_GROUP=$(azd env get-value AZURE_RESOURCE_GROUP 2>/dev/null || true)
+  IDENTITY_CLIENT_ID=$(azd env get-value AZURE_IDENTITY_CLIENT_ID 2>/dev/null || true)
+  COSMOS_ENDPOINT=$(azd env get-value AZURE_COSMOS_ENDPOINT 2>/dev/null || true)
+  INSTANCE_TOKEN=$(echo "$AKS_CLUSTER" | sed 's/omnivec-aks-//')
+  TEST_COSMOS_ACCOUNT="omnivec-test-${INSTANCE_TOKEN}"
+}
+
+# =============================================================================
+# STEP 1: Create azd environment
+# =============================================================================
+if [ "$FROM_STEP" -le 1 ]; then
+  log_step 1 "Creating azd environment: $ENV_NAME"
+  azd env new "$ENV_NAME" --location "$LOCATION" --subscription "$SUBSCRIPTION" 2>/dev/null || true
+  azd env set OMNIVEC_METADATA_STORE "cosmosdb-serverless"
+  azd env set OMNIVEC_ENABLE_BLOB_SOURCE "true"
+  azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE "Standard_D4ds_v5"
+  azd env set OMNIVEC_SYSTEM_NODE_COUNT 2
+  azd env set OMNIVEC_GPU_NODE_VM_SIZE "Standard_NC6s_v3"
+  azd env set OMNIVEC_GPU_NODE_COUNT 0
+  azd env set OMNIVEC_BUILD_MODE "acr"
+  if [ -n "$SHARED_REGISTRY_TOKEN" ]; then
+    azd env set OMNIVEC_SHARED_REGISTRY_TOKEN "$SHARED_REGISTRY_TOKEN"
+  else
+    log_warn "Shared registry token not set (needed for image import)."
+    printf "  Enter shared registry token (omnivecregistry.azurecr.io): "
+    read -r SHARED_REGISTRY_TOKEN
+    if [ -n "$SHARED_REGISTRY_TOKEN" ]; then
+      azd env set OMNIVEC_SHARED_REGISTRY_TOKEN "$SHARED_REGISTRY_TOKEN"
+    fi
+  fi
+  log_ok "Environment configured."
+fi
+
+# =============================================================================
+# STEP 2: Provision infrastructure
+# =============================================================================
+if [ "$FROM_STEP" -le 2 ]; then
+  log_step 2 "Provisioning infrastructure (azd up ~15 min)..."
+  azd up --no-prompt || log_warn "azd up returned non-zero, continuing..."
+fi
+
+# =============================================================================
+# STEP 3: Get connection details + wait for API
+# =============================================================================
+if [ "$FROM_STEP" -le 3 ]; then
+  log_step 3 "Retrieving connection details..."
+fi
+# Always load azd values (needed by all subsequent steps)
+load_azd_values
+az aks get-credentials --resource-group "$RESOURCE_GROUP" --name "$AKS_CLUSTER" --overwrite-existing 2>/dev/null
+
+log "  Admin Token: $ADMIN_TOKEN"
+log "  AKS:         $AKS_CLUSTER"
+
+# Wait for external IP
+log "  Waiting for external IP..."
+SERVER=""
+i=0
+while [ $i -lt 60 ]; do
+  SERVER=$(kubectl get svc omnivec-web -n omnivec -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+  if [ -n "$SERVER" ]; then break; fi
+  sleep 5
+  i=$((i + 1))
+done
+if [ -z "$SERVER" ]; then log_err "Failed to get external IP"; exit 1; fi
+SERVER_URL="http://$SERVER"
+log_ok "Server: $SERVER_URL"
+
+# Wait for API
+log "  Waiting for API health..."
+i=0
+while [ $i -lt 30 ]; do
+  health=$(curl -sf --max-time 5 "$SERVER_URL/health" 2>/dev/null || true)
+  if echo "$health" | grep -q '"healthy"'; then break; fi
+  sleep 5
+  i=$((i + 1))
+done
+log_ok "API healthy."
+
+# =============================================================================
+# STEP 4: Configure CLI
+# =============================================================================
+if [ "$FROM_STEP" -le 4 ]; then
+  log_step 4 "Configuring CLI..."
+  "$CLI" config set server "$SERVER_URL"
+  "$CLI" config set token "$ADMIN_TOKEN"
+  "$CLI" status
+fi
+
+# =============================================================================
+# STEP 5: Create test CosmosDB account + containers
+# =============================================================================
+if [ "$FROM_STEP" -le 5 ]; then
+  log_step 5 "Creating test CosmosDB account..."
+  TEST_COSMOS_ENDPOINT=$(az cosmosdb show --name "$TEST_COSMOS_ACCOUNT" --resource-group "$RESOURCE_GROUP" --query documentEndpoint -o tsv 2>/dev/null || true)
+
+  if [ -z "$TEST_COSMOS_ENDPOINT" ]; then
+    log "  Creating account: $TEST_COSMOS_ACCOUNT"
+    ARM_FILE=$(mktemp)
+    cat > "$ARM_FILE" <<ARMEOF
+{
+  "location": "$LOCATION",
+  "kind": "GlobalDocumentDB",
+  "properties": {
+    "databaseAccountOfferType": "Standard",
+    "disableLocalAuth": true,
+    "enableAutomaticFailover": false,
+    "consistencyPolicy": { "defaultConsistencyLevel": "Session" },
+    "locations": [{ "locationName": "$LOCATION", "failoverPriority": 0, "isZoneRedundant": false }],
+    "capabilities": [{ "name": "EnableServerless" }, { "name": "EnableNoSQLVectorSearch" }]
+  }
+}
+ARMEOF
+    ARM_URL="https://management.azure.com/subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DocumentDB/databaseAccounts/${TEST_COSMOS_ACCOUNT}?api-version=2024-05-15"
+    az rest --method PUT --url "$ARM_URL" --body "@$ARM_FILE" -o none
+    rm -f "$ARM_FILE"
+
+    log "  Waiting for provisioning..."
+    i=0
+    while [ $i -lt 40 ]; do
+      st=$(az cosmosdb show --name "$TEST_COSMOS_ACCOUNT" --resource-group "$RESOURCE_GROUP" --query provisioningState -o tsv 2>/dev/null || true)
+      if [ "$st" = "Succeeded" ]; then break; fi
+      sleep 10
+      i=$((i + 1))
+    done
+    TEST_COSMOS_ENDPOINT=$(az cosmosdb show --name "$TEST_COSMOS_ACCOUNT" --resource-group "$RESOURCE_GROUP" --query documentEndpoint -o tsv 2>/dev/null || true)
+  fi
+  log_ok "Endpoint: $TEST_COSMOS_ENDPOINT"
+
+  # Grant RBAC
+  log "  Granting RBAC..."
+  PRINCIPAL_ID=$(az identity show --name "omnivec-identity-$INSTANCE_TOKEN" --resource-group "$RESOURCE_GROUP" --query principalId -o tsv 2>/dev/null || true)
+  if [ -z "$PRINCIPAL_ID" ]; then
+    PRINCIPAL_ID=$(az identity list --resource-group "$RESOURCE_GROUP" --query "[0].principalId" -o tsv 2>/dev/null || true)
+  fi
+
+  az cosmosdb sql role assignment create --account-name "$TEST_COSMOS_ACCOUNT" --resource-group "$RESOURCE_GROUP" \
+    --role-definition-id "00000000-0000-0000-0000-000000000002" --principal-id "$PRINCIPAL_ID" --scope "/" -o none 2>/dev/null || true
+  SCOPE="/subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DocumentDB/databaseAccounts/$TEST_COSMOS_ACCOUNT"
+  az role assignment create --assignee-object-id "$PRINCIPAL_ID" --assignee-principal-type ServicePrincipal \
+    --role "Cosmos DB Account Reader Role" --scope "$SCOPE" -o none 2>/dev/null || true
+  log_ok "RBAC assigned (Data Contributor + Account Reader). Waiting 30s..."
+  sleep 30
+
+  # Create database + containers
+  log "  Creating containers..."
+  az cosmosdb sql database create --account-name "$TEST_COSMOS_ACCOUNT" --name testdb --resource-group "$RESOURCE_GROUP" -o none 2>/dev/null || true
+  az cosmosdb sql container create --account-name "$TEST_COSMOS_ACCOUNT" --database-name testdb --name test-documents \
+    --resource-group "$RESOURCE_GROUP" --partition-key-path "/id" -o none 2>/dev/null || true
+  log_ok "test-documents created."
+
+  # Vectors container with vector policy (via API pod)
+  pod_python "
+import os
+from azure.cosmos import CosmosClient
+from azure.cosmos.exceptions import CosmosResourceExistsError
+from azure.identity import DefaultAzureCredential
+cred = DefaultAzureCredential(managed_identity_client_id=os.environ.get('AZURE_CLIENT_ID'))
+client = CosmosClient('$TEST_COSMOS_ENDPOINT', credential=cred)
+db = client.get_database_client('testdb')
+vp = {'vectorEmbeddings': [{'path': '/embedding', 'dataType': 'float32', 'distanceFunction': 'cosine', 'dimensions': $AOAI_DIMS}]}
+ip = {'includedPaths': [{'path': '/*'}], 'excludedPaths': [{'path': '/embedding/*'}], 'vectorIndexes': [{'path': '/embedding', 'type': 'quantizedFlat'}]}
+try:
+    db.create_container(id='vectors', partition_key={'paths': ['/id'], 'kind': 'Hash'}, vector_embedding_policy=vp, indexing_policy=ip)
+    print('  vectors created (${AOAI_DIMS}d, cosine, quantizedFlat)')
+except CosmosResourceExistsError:
+    print('  vectors container already exists')
+"
+  log_ok "All containers ready."
+else
+  # Load test endpoint for later steps
+  TEST_COSMOS_ENDPOINT=$(az cosmosdb show --name "$TEST_COSMOS_ACCOUNT" --resource-group "$RESOURCE_GROUP" --query documentEndpoint -o tsv 2>/dev/null || true)
+fi
+
+# =============================================================================
+# STEP 6: Register embedding model
+# =============================================================================
+if [ "$FROM_STEP" -le 6 ]; then
+  log_step 6 "Registering Azure OpenAI embedding model..."
+  MODEL_BODY=$(cat <<MEOF
+{"name":"azure-openai-embed","type":"azure-openai","endpoint":"$AOAI_ENDPOINT","api_key":"$AOAI_KEY","model":"$AOAI_DEPLOYMENT","deployment":"$AOAI_DEPLOYMENT","dimensions":$AOAI_DIMS,"api_version":"2024-06-01"}
+MEOF
+  )
+  MODEL_RESULT=$(api_post "/api/models" "$MODEL_BODY")
+  MODEL_ID=$(echo "$MODEL_RESULT" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+  log_ok "Model: $MODEL_ID ($AOAI_DEPLOYMENT, ${AOAI_DIMS}d)"
+else
+  MODELS_RESULT=$(api_get "/api/models")
+  MODEL_ID=$(echo "$MODELS_RESULT" | grep -o '"id":"mdl-[^"]*"' | head -1 | cut -d'"' -f4)
+fi
+
+# =============================================================================
+# STEP 7: Create source + destination
+# =============================================================================
+if [ "$FROM_STEP" -le 7 ]; then
+  log_step 7 "Creating source and destination..."
+
+  # Clean up any existing resources from previous runs
+  for pip_id in $(api_get "/api/pipelines" | grep -o '"id":"pip-[^"]*"' | cut -d'"' -f4); do
+    api_delete "/api/pipelines/$pip_id" >/dev/null
+  done
+  for src_id in $(api_get "/api/sources" | grep -o '"id":"src-[^"]*"' | cut -d'"' -f4); do
+    api_delete "/api/sources/$src_id" >/dev/null
+  done
+  for dst_id in $(api_get "/api/destinations" | grep -o '"id":"dst-[^"]*"' | cut -d'"' -f4); do
+    api_delete "/api/destinations/$dst_id" >/dev/null
+  done
+
+  SRC_BODY=$(cat <<SEOF
+{"name":"demo-cosmosdb-source","type":"cosmosdb","config":{"endpoint":"$TEST_COSMOS_ENDPOINT","database":"testdb","container":"test-documents","auth_type":"managed-identity","client_id":"$IDENTITY_CLIENT_ID"}}
+SEOF
+  )
+  SRC_RESULT=$(api_post "/api/sources" "$SRC_BODY")
+  SOURCE_ID=$(echo "$SRC_RESULT" | grep -o '"id":"src-[^"]*"' | head -1 | cut -d'"' -f4)
+  log_ok "Source: $SOURCE_ID"
+
+  DST_BODY=$(cat <<DEOF
+{"name":"demo-vector-store","type":"cosmosdb-vector","config":{"endpoint":"$TEST_COSMOS_ENDPOINT","database":"testdb","container":"vectors","auth_type":"managed-identity","client_id":"$IDENTITY_CLIENT_ID","vector_dimensions":$AOAI_DIMS}}
+DEOF
+  )
+  DST_RESULT=$(api_post "/api/destinations" "$DST_BODY")
+  DEST_ID=$(echo "$DST_RESULT" | grep -o '"id":"dst-[^"]*"' | head -1 | cut -d'"' -f4)
+  log_ok "Destination: $DEST_ID"
+else
+  SRCS_RESULT=$(api_get "/api/sources")
+  SOURCE_ID=$(echo "$SRCS_RESULT" | grep -o '"id":"src-[^"]*"' | head -1 | cut -d'"' -f4)
+  DSTS_RESULT=$(api_get "/api/destinations")
+  DEST_ID=$(echo "$DSTS_RESULT" | grep -o '"id":"dst-[^"]*"' | head -1 | cut -d'"' -f4)
+fi
+
+# =============================================================================
+# STEP 8: Queue mode — create pipeline, insert docs, resume
+# =============================================================================
+PIP_ID=""
+if [ "$FROM_STEP" -le 8 ]; then
+  log_step 8 "Queue mode — creating pipeline, inserting docs, activating..."
+
+  PIP_BODY=$(cat <<PEOF
+{"name":"demo-pipeline-queue","sources":[{"source_id":"$SOURCE_ID","filters":{}}],"destination_id":"$DEST_ID","docgrok_pipeline":"$MODEL_ID","process_existing":true,"processing_mode":"queue"}
+PEOF
+  )
+  PIP_RESULT=$(api_post "/api/pipelines" "$PIP_BODY")
+  PIP_ID=$(echo "$PIP_RESULT" | grep -o '"id":"pip-[^"]*"' | head -1 | cut -d'"' -f4)
+  log_ok "Pipeline (paused, queue mode): $PIP_ID"
+
+  # Insert test documents
+  log "  Inserting test documents..."
+  pod_python "
+import os
+from azure.cosmos import CosmosClient
+from azure.identity import DefaultAzureCredential
+cred = DefaultAzureCredential(managed_identity_client_id=os.environ.get('AZURE_CLIENT_ID'))
+client = CosmosClient('$TEST_COSMOS_ENDPOINT', credential=cred)
+c = client.get_database_client('testdb').get_container_client('test-documents')
+docs = [
+    {'id': 'doc-001', 'title': 'Azure Cosmos DB', 'content': 'Azure Cosmos DB is a globally distributed multi-model database service providing turnkey global distribution with elastic scaling.', 'category': 'database'},
+    {'id': 'doc-002', 'title': 'Azure Kubernetes Service', 'content': 'AKS simplifies deploying managed Kubernetes clusters in Azure by offloading operational overhead.', 'category': 'compute'},
+    {'id': 'doc-003', 'title': 'Azure Blob Storage', 'content': 'Azure Blob Storage stores massive amounts of unstructured data like documents and images optimized for cloud scale.', 'category': 'storage'},
+]
+for doc in docs:
+    c.upsert_item(doc)
+    print(f'  Inserted: {doc[\"id\"]} - {doc[\"title\"]}')
+"
+
+  # Resume pipeline
+  log "  Resuming pipeline..."
+  api_post "/api/pipelines/$PIP_ID/resume" "{}" >/dev/null
+  api_post "/api/pipelines/$PIP_ID/run" "{}" >/dev/null
+  log_ok "Pipeline activated (queue mode). Waiting 60s for processing..."
+  sleep 60
+else
+  PIPS_RESULT=$(api_get "/api/pipelines")
+  PIP_ID=$(echo "$PIPS_RESULT" | grep -o '"id":"pip-[^"]*"' | head -1 | cut -d'"' -f4)
+fi
+
+# =============================================================================
+# STEP 9: Verify queue mode results
+# =============================================================================
+if [ -n "$PIP_ID" ]; then
+  log_step 9 "Verifying queue mode results..."
+  if [ "$QUIET" = "false" ]; then
+    "$CLI" pipeline show "$PIP_ID"
+    echo ""
+    "$CLI" job list
+  fi
+
+  JOBS_RESULT=$(api_get "/api/jobs?status=completed&limit=5")
+  COMPLETED_COUNT=$(echo "$JOBS_RESULT" | grep -o '"id":"job-[^"]*"' | wc -l)
+
+  if [ "$COMPLETED_COUNT" -gt 0 ]; then
+    log_ok "$COMPLETED_COUNT documents embedded via queue mode!"
+
+    # Vector search test
+    log "  Testing vector search..."
+    SEARCH_BODY="{\"query\":\"what is cosmos db\",\"destination_id\":\"$DEST_ID\",\"top_k\":3}"
+    SEARCH_RESULT=$(api_post "/api/playground/search" "$SEARCH_BODY" 2>/dev/null || true)
+    if [ -n "$SEARCH_RESULT" ]; then
+      SEARCH_COUNT=$(echo "$SEARCH_RESULT" | grep -o '"id":' | wc -l)
+      log_ok "Search returned $SEARCH_COUNT results"
+    else
+      log_warn "Search test skipped (may need more processing time)"
+    fi
+
+    # Pipeline reset test
+    log "  Testing pipeline reset..."
+    "$CLI" pipeline reset "$PIP_ID" -y
+  else
+    log_warn "No completed jobs yet. Check: omnivec pipeline show $PIP_ID"
+  fi
+
+  # Stats
+  STATS_RESULT=$(api_get "/api/pipelines/$PIP_ID")
+  PROCESSED=$(echo "$STATS_RESULT" | grep -o '"documents_processed":[0-9]*' | cut -d: -f2)
+  EMBEDDED=$(echo "$STATS_RESULT" | grep -o '"embedded_count":[0-9]*' | cut -d: -f2)
+  COMPLETION=$(echo "$STATS_RESULT" | grep -o '"completion_pct":[0-9.]*' | cut -d: -f2)
+  log "  Processed:  $PROCESSED"
+  log "  Embedded:   $EMBEDDED"
+  log "  Completion: ${COMPLETION}%"
+
+  # Clean up queue pipeline before starting inline
+  log "  Removing queue pipeline before inline test..."
+  api_delete "/api/pipelines/$PIP_ID" >/dev/null
+else
+  log_step 9 "Skipping queue mode verify (no queue pipeline)"
+  # Clean up any existing pipelines when jumping to inline test
+  for pip_id in $(api_get "/api/pipelines" | grep -o '"id":"pip-[^"]*"' | cut -d'"' -f4); do
+    api_delete "/api/pipelines/$pip_id" >/dev/null
+  done
+fi
+
+# =============================================================================
+# STEP 10: Inline mode — create pipeline, resume, then insert docs
+# =============================================================================
+INLINE_PIP_ID=""
+if [ "$FROM_STEP" -le 10 ]; then
+  log_step 10 "Inline mode — creating pipeline, activating, inserting docs..."
+
+  INLINE_PIP_BODY=$(cat <<IPEOF
+{"name":"demo-pipeline-inline","sources":[{"source_id":"$SOURCE_ID","filters":{}}],"destination_id":"$DEST_ID","docgrok_pipeline":"$MODEL_ID","process_existing":true,"processing_mode":"inline"}
+IPEOF
+  )
+  INLINE_PIP_RESULT=$(api_post "/api/pipelines" "$INLINE_PIP_BODY")
+  INLINE_PIP_ID=$(echo "$INLINE_PIP_RESULT" | grep -o '"id":"pip-[^"]*"' | head -1 | cut -d'"' -f4)
+  log_ok "Pipeline (paused, inline mode): $INLINE_PIP_ID"
+
+  # Resume inline pipeline FIRST so CFP picks up changes in inline mode
+  log "  Resuming inline pipeline..."
+  api_post "/api/pipelines/$INLINE_PIP_ID/resume" "{}" >/dev/null
+  api_post "/api/pipelines/$INLINE_PIP_ID/run" "{}" >/dev/null
+  log_ok "Pipeline active (inline mode). Waiting 30s for CFP lease rebalance..."
+  sleep 30
+
+  # Insert test documents AFTER pipeline is active so CFP processes them in inline mode
+  log "  Inserting inline test documents..."
+  pod_python "
+import os
+from azure.cosmos import CosmosClient
+from azure.identity import DefaultAzureCredential
+cred = DefaultAzureCredential(managed_identity_client_id=os.environ.get('AZURE_CLIENT_ID'))
+client = CosmosClient('$TEST_COSMOS_ENDPOINT', credential=cred)
+c = client.get_database_client('testdb').get_container_client('test-documents')
+docs = [
+    {'id': 'doc-inline-001', 'title': 'Azure Functions', 'content': 'Azure Functions is an event-driven serverless compute platform that lets you run code without provisioning or managing infrastructure.', 'category': 'compute'},
+    {'id': 'doc-inline-002', 'title': 'Azure AI Search', 'content': 'Azure AI Search provides secure information retrieval at scale over user-owned content in traditional and generative AI search applications.', 'category': 'ai'},
+    {'id': 'doc-inline-003', 'title': 'Azure Service Bus', 'content': 'Azure Service Bus is a fully managed enterprise message broker with message queues and publish-subscribe topics for decoupled applications.', 'category': 'messaging'},
+]
+for doc in docs:
+    c.upsert_item(doc)
+    print(f'  Inserted: {doc[\"id\"]} - {doc[\"title\"]}')
+"
+  log_ok "Docs inserted. Waiting 90s for inline processing..."
+  sleep 90
+else
+  # Load inline pipeline if skipping
+  ALL_PIPS=$(api_get "/api/pipelines")
+  INLINE_PIP_ID=$(echo "$ALL_PIPS" | grep -o '"id":"pip-[^"]*"' | head -1 | cut -d'"' -f4)
+fi
+
+# =============================================================================
+# STEP 11: Verify inline mode results
+# =============================================================================
+log_step 11 "Verifying inline mode results..."
+if [ "$QUIET" = "false" ]; then
+  "$CLI" pipeline show "$INLINE_PIP_ID"
+fi
+
+# Inline mode embeds directly into the source container — check for embedding field
+log "  Checking source container for inline embeddings..."
+INLINE_CHECK=""
+INLINE_CHECK=$(pod_python "
+import os, json
+from azure.cosmos import CosmosClient
+from azure.identity import DefaultAzureCredential
+cred = DefaultAzureCredential(managed_identity_client_id=os.environ.get('AZURE_CLIENT_ID'))
+client = CosmosClient('$TEST_COSMOS_ENDPOINT', credential=cred)
+c = client.get_database_client('testdb').get_container_client('test-documents')
+embedded = 0
+checked = 0
+for doc in c.query_items('SELECT c.id, IS_DEFINED(c.embedding) as has_emb FROM c WHERE STARTSWITH(c.id, \"doc-inline-\")', enable_cross_partition_query=True):
+    checked += 1
+    if doc.get('has_emb'):
+        embedded += 1
+        print(f'  {doc[\"id\"]}: embedding present')
+    else:
+        print(f'  {doc[\"id\"]}: no embedding yet')
+print(f'INLINE_RESULT:{embedded}/{checked}')
+" 2>/dev/null || true)
+echo "$INLINE_CHECK"
+
+# For inline mode, the source container is the source of truth
+INLINE_EMBEDDED=0
+INLINE_TOTAL=0
+if echo "$INLINE_CHECK" | grep -q "INLINE_RESULT:"; then
+  INLINE_EMBEDDED=$(echo "$INLINE_CHECK" | grep -o 'INLINE_RESULT:[0-9]*/[0-9]*' | cut -d: -f2 | cut -d/ -f1)
+  INLINE_TOTAL=$(echo "$INLINE_CHECK" | grep -o 'INLINE_RESULT:[0-9]*/[0-9]*' | cut -d: -f2 | cut -d/ -f2)
+fi
+
+INLINE_STATS=$(api_get "/api/pipelines/$INLINE_PIP_ID")
+INLINE_PROCESSED=$(echo "$INLINE_STATS" | grep -o '"documents_processed":[0-9]*' | cut -d: -f2)
+INLINE_STATS_EMBEDDED=$(echo "$INLINE_STATS" | grep -o '"embedded_count":[0-9]*' | cut -d: -f2)
+log "  Pipeline stats — Processed: $INLINE_PROCESSED, Embedded: $INLINE_STATS_EMBEDDED"
+log "  Source container — Embedded: $INLINE_EMBEDDED/$INLINE_TOTAL"
+
+if [ "$INLINE_EMBEDDED" -gt 0 ] 2>/dev/null; then
+  log_ok "Inline mode working — $INLINE_EMBEDDED/$INLINE_TOTAL documents embedded directly into source container!"
+else
+  log_warn "No inline embeddings yet. The CFP may still be processing. Check: omnivec pipeline show $INLINE_PIP_ID"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+printf "${GREEN}╔══════════════════════════════════════════════════════╗${NC}\n"
+printf "${GREEN}║           End-to-End Demo Complete!                  ║${NC}\n"
+printf "${GREEN}╚══════════════════════════════════════════════════════╝${NC}\n"
+echo ""
+printf "  Server:          ${CYAN}${SERVER_URL}${NC}\n"
+printf "  Admin Token:     ${CYAN}${ADMIN_TOKEN}${NC}\n"
+printf "  Source:          ${CYAN}${SOURCE_ID}${NC}\n"
+printf "  Destination:     ${CYAN}${DEST_ID}${NC}\n"
+printf "  Queue Pipeline:  ${CYAN}${PIP_ID}${NC}\n"
+printf "  Inline Pipeline: ${CYAN}${INLINE_PIP_ID}${NC}\n"
+printf "  Model:           ${CYAN}${MODEL_ID} (${AOAI_DEPLOYMENT})${NC}\n"
+echo ""
+printf "  ${CYAN}Queue mode:${NC}  CFP detects changes -> creates jobs -> .NET worker embeds -> writes to destination\n"
+printf "  ${CYAN}Inline mode:${NC} CFP detects changes -> embeds directly -> patches back to source container\n"
+echo ""

--- a/scripts/e2e-demo.sh
+++ b/scripts/e2e-demo.sh
@@ -297,8 +297,8 @@ ARMEOF
   SCOPE="/subscriptions/$SUBSCRIPTION/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DocumentDB/databaseAccounts/$TEST_COSMOS_ACCOUNT"
   az role assignment create --assignee-object-id "$PRINCIPAL_ID" --assignee-principal-type ServicePrincipal \
     --role "Cosmos DB Account Reader Role" --scope "$SCOPE" -o none 2>/dev/null || true
-  log_ok "RBAC assigned (Data Contributor + Account Reader). Waiting 30s..."
-  sleep 30
+  log_ok "RBAC assigned (Data Contributor + Account Reader). Waiting 60s for propagation..."
+  sleep 60
 
   # Create database + containers
   log "  Creating containers..."
@@ -308,10 +308,13 @@ ARMEOF
   log_ok "test-documents created."
 
   # Vectors container with vector policy (via API pod)
-  pod_python "
-import os
+  # Retry up to 3 times — RBAC propagation can take longer than expected
+  vectors_ok=false
+  for attempt in 1 2 3; do
+    vectors_output=$(pod_python "
+import os, time
 from azure.cosmos import CosmosClient
-from azure.cosmos.exceptions import CosmosResourceExistsError
+from azure.cosmos.exceptions import CosmosResourceExistsError, CosmosHttpResponseError
 from azure.identity import DefaultAzureCredential
 cred = DefaultAzureCredential(managed_identity_client_id=os.environ.get('AZURE_CLIENT_ID'))
 client = CosmosClient('$TEST_COSMOS_ENDPOINT', credential=cred)
@@ -320,10 +323,30 @@ vp = {'vectorEmbeddings': [{'path': '/embedding', 'dataType': 'float32', 'distan
 ip = {'includedPaths': [{'path': '/*'}], 'excludedPaths': [{'path': '/embedding/*'}], 'vectorIndexes': [{'path': '/embedding', 'type': 'quantizedFlat'}]}
 try:
     db.create_container(id='vectors', partition_key={'paths': ['/id'], 'kind': 'Hash'}, vector_embedding_policy=vp, indexing_policy=ip)
-    print('  vectors created (${AOAI_DIMS}d, cosine, quantizedFlat)')
+    print('OK: vectors created (${AOAI_DIMS}d, cosine, quantizedFlat)')
 except CosmosResourceExistsError:
-    print('  vectors container already exists')
-"
+    print('OK: vectors container already exists')
+except CosmosHttpResponseError as e:
+    if 'Forbidden' in str(e) or '403' in str(e):
+        print('RBAC_WAIT')
+    else:
+        raise
+" 2>&1) && true
+    echo "$vectors_output"
+    if echo "$vectors_output" | grep -q "^OK:"; then
+      vectors_ok=true
+      break
+    elif echo "$vectors_output" | grep -q "RBAC_WAIT"; then
+      log_warn "RBAC not yet propagated, waiting 30s (attempt $attempt/3)..."
+      sleep 30
+    else
+      break
+    fi
+  done
+  if [ "$vectors_ok" != "true" ]; then
+    log_err "Failed to create vectors container after retries"
+    exit 1
+  fi
   log_ok "All containers ready."
 else
   # Load test endpoint for later steps


### PR DESCRIPTION
## Summary
- E2e demo: expand from 9 to 11 steps testing both queue and inline processing modes
- Add quiet flag and from-step for flexible e2e runs
- Add e2e-demo.sh for Linux/macOS/Git Bash
- Fix ARM role assignment and RBAC propagation

## Test plan
- [x] Full e2e-demo.ps1 from scratch queue 3/3, inline 3/3
- [x] Full e2e-demo.sh on Git Bash queue 3/3, inline 3/3