### PR TITLE
Add managed identity auth, kubectl context isolation, worker resilience

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -3352,15 +3352,21 @@ async def create_model(payload: dict):
         # Map UI field names to DocGrok registry fields
         model_name = payload.get("name", payload.get("model", "")).strip()
         model_category = payload.get("model_category", "embedding")  # "embedding" or "chat"
+        auth_type = payload.get("auth_type", "key")  # "key" or "managed-identity"
         reg_payload = {
             "name": model_name,
             "type": payload.get("provider_type", payload.get("type", "azure-openai")),
             "endpoint": payload.get("endpoint", "").strip(),
+            "auth_type": auth_type,
             "api_key": payload.get("api_key", "").strip(),
             "deployment": payload.get("deployment", payload.get("name", "")).strip(),
             "embedding_dim": int(payload.get("embedding_dim", payload.get("dimensions", 1536))),
             "api_version": payload.get("api_version", "2024-06-01"),
         }
+        if auth_type == "managed-identity":
+            client_id = payload.get("client_id", "").strip()
+            if client_id:
+                reg_payload["client_id"] = client_id
         # Preserve stored ID â€” look up by name in CosmosDB so DocGrok always
         # gets the same ID even after restart (prevents ID drift).
         store = get_store()

--- a/cli/cmd_model.go
+++ b/cli/cmd_model.go
@@ -69,7 +69,7 @@ func newModelListCmd() *cobra.Command {
 }
 
 func newModelAddCmd() *cobra.Command {
-	var provider, providerType, endpoint, apiKey, apiVersion, modelName string
+	var provider, providerType, endpoint, apiKey, apiVersion, modelName, authType, clientID string
 	var dimensions int
 	cmd := &cobra.Command{
 		Use:   "add",
@@ -87,11 +87,18 @@ func newModelAddCmd() *cobra.Command {
 			if modelName == "" {
 				exitErr("--model is required")
 			}
+			if authType == "managed-identity" && apiKey != "" {
+				exitErr("--api-key and --auth-type managed-identity are mutually exclusive")
+			}
+			if authType == "key" && apiKey == "" {
+				exitErr("--api-key is required when --auth-type is key")
+			}
 			body := map[string]any{
-				"name":     provider,
-				"type":     providerType,
-				"endpoint": endpoint,
-				"model":    modelName,
+				"name":      provider,
+				"type":      providerType,
+				"endpoint":  endpoint,
+				"model":     modelName,
+				"auth_type": authType,
 			}
 			if apiKey != "" {
 				body["api_key"] = apiKey
@@ -102,19 +109,24 @@ func newModelAddCmd() *cobra.Command {
 			if dimensions > 0 {
 				body["dimensions"] = dimensions
 			}
+			if clientID != "" {
+				body["client_id"] = clientID
+			}
 			c := getClient()
 			_, err := c.Post("/api/models", body)
 			if err != nil {
 				exitErr("%v", err)
 			}
-			exitOK("External model added: %s (%s)", provider, modelName)
+			exitOK("External model added: %s (%s, auth: %s)", provider, modelName, authType)
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&provider, "provider", "", "Provider name (e.g., my-azure-openai)")
 	cmd.Flags().StringVarP(&providerType, "type", "t", "", "Provider type (azure-openai, openai, cohere, custom)")
 	cmd.Flags().StringVar(&endpoint, "endpoint", "", "Endpoint URL")
-	cmd.Flags().StringVar(&apiKey, "api-key", "", "API key")
+	cmd.Flags().StringVar(&apiKey, "api-key", "", "API key (for key auth)")
+	cmd.Flags().StringVar(&authType, "auth-type", "key", "Auth method: key or managed-identity")
+	cmd.Flags().StringVar(&clientID, "client-id", "", "Managed identity client ID (optional, defaults to workload identity)")
 	cmd.Flags().StringVar(&apiVersion, "api-version", "", "API version (Azure only)")
 	cmd.Flags().StringVar(&modelName, "model", "", "Model/deployment name")
 	cmd.Flags().IntVar(&dimensions, "dimensions", 0, "Embedding dimensions")

--- a/connectors/worker/dotnet/Program.cs
+++ b/connectors/worker/dotnet/Program.cs
@@ -12,10 +12,16 @@ var builder = Host.CreateApplicationBuilder(args);
 builder.Services.Configure<WorkerOptions>(
     builder.Configuration.GetSection("Worker"));
 
-// Service Bus client
+// Service Bus client — only register when namespace is configured
 builder.Services.AddSingleton(sp =>
 {
     var opts = sp.GetRequiredService<IOptions<WorkerOptions>>().Value;
+    if (string.IsNullOrWhiteSpace(opts.ServiceBusNamespace))
+    {
+        var log = sp.GetRequiredService<ILogger<Program>>();
+        log.LogWarning("Service Bus namespace not configured — worker will start but cannot process queue messages");
+        return (ServiceBusClient?)null;
+    }
     return new ServiceBusClient(opts.ServiceBusNamespace, new DefaultAzureCredential());
 });
 

--- a/connectors/worker/dotnet/Services/EmbeddingWorkerService.cs
+++ b/connectors/worker/dotnet/Services/EmbeddingWorkerService.cs
@@ -16,7 +16,7 @@ namespace OmniVec.Worker.Services;
 public class EmbeddingWorkerService : BackgroundService
 {
     private readonly WorkerOptions _options;
-    private readonly ServiceBusClient _sbClient;
+    private readonly ServiceBusClient? _sbClient;
     private readonly DocGrokClient _docGrok;
     private readonly MetricsReporter _metrics;
     private readonly Dictionary<string, IDestinationWriter> _writers;
@@ -24,7 +24,7 @@ public class EmbeddingWorkerService : BackgroundService
 
     public EmbeddingWorkerService(
         IOptions<WorkerOptions> options,
-        ServiceBusClient sbClient,
+        ServiceBusClient? sbClient,
         DocGrokClient docGrok,
         MetricsReporter metrics,
         IEnumerable<IDestinationWriter> writers,
@@ -40,6 +40,14 @@ public class EmbeddingWorkerService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken ct)
     {
+        if (_sbClient is null)
+        {
+            _logger.LogWarning("Service Bus not configured — worker idle. Set Worker__ServiceBusNamespace to enable queue processing.");
+            // Stay alive but idle — don't crash the pod
+            await Task.Delay(Timeout.Infinite, ct);
+            return;
+        }
+
         _logger.LogInformation(
             "Embedding worker starting: topic={Topic}, sub={Sub}, batchSize={BatchSize}",
             _options.TopicName, _options.SubscriptionName, _options.EmbedBatchSize);

--- a/deploy.sh
+++ b/deploy.sh
@@ -56,7 +56,8 @@ echo -e "${GREEN}Infrastructure deployed!${NC}"
 
 # Step 2: Get AKS credentials
 echo -e "\n${YELLOW}Step 2: Connecting to AKS...${NC}"
-az aks get-credentials --resource-group "$RESOURCE_GROUP" --name "$AKS_CLUSTER_NAME" --overwrite-existing
+KUBE_CONTEXT="${AKS_CLUSTER_NAME}"
+az aks get-credentials --resource-group "$RESOURCE_GROUP" --name "$AKS_CLUSTER_NAME" --context "$KUBE_CONTEXT" --overwrite-existing 2>/dev/null || true
 
 # Step 3: Login to ACR
 echo -e "\n${YELLOW}Step 3: Logging into ACR...${NC}"
@@ -84,6 +85,7 @@ echo -e "\n${YELLOW}Step 5: Deploying with Helm...${NC}"
 cd "$SCRIPT_DIR/helm"
 
 helm upgrade --install omnivec ./omnivec \
+  --kube-context "$KUBE_CONTEXT" \
   --namespace omnivec \
   --create-namespace \
   --set global.imageRegistry="$ACR_LOGIN_SERVER" \
@@ -99,7 +101,7 @@ echo -e "${GREEN}Deployment complete!${NC}"
 # Step 6: Get service URL
 echo -e "\n${YELLOW}Getting service URL...${NC}"
 sleep 10
-EXTERNAL_IP=$(kubectl get svc omnivec-api -n omnivec -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+EXTERNAL_IP=$(kubectl --context "$KUBE_CONTEXT" get svc omnivec-api -n omnivec -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
 echo -e "\n${GREEN}╔══════════════════════════════════════════╗${NC}"
 echo -e "${GREEN}║         Deployment Successful!           ║${NC}"

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -221,10 +221,12 @@ fi
 # =============================================================================
 
 printf "\n${YELLOW}Phase 2: Getting AKS credentials...${NC}\n"
+KUBE_CONTEXT="${AKS_CLUSTER}"
 az aks get-credentials \
   --resource-group "$RESOURCE_GROUP" \
   --name "$AKS_CLUSTER" \
-  --overwrite-existing
+  --context "$KUBE_CONTEXT" \
+  --overwrite-existing 2>/dev/null || true
 
 # WSL: az writes kubeconfig to Windows home — symlink to Linux home for helm/kubectl
 if [ ! -f "$HOME/.kube/config" ] && [ -f "/mnt/c/Users/$(whoami)/.kube/config" ] 2>/dev/null; then
@@ -239,7 +241,8 @@ elif [ ! -f "$HOME/.kube/config" ]; then
   fi
 fi
 
-printf "${GREEN}Connected to AKS cluster: ${AKS_CLUSTER}${NC}\n"
+export KUBE_CONTEXT
+printf "${GREEN}Connected to AKS cluster: ${AKS_CLUSTER} (context: ${KUBE_CONTEXT})${NC}\n"
 
 # =============================================================================
 # PHASE 3: Create namespaces and K8s secrets
@@ -248,18 +251,18 @@ printf "${GREEN}Connected to AKS cluster: ${AKS_CLUSTER}${NC}\n"
 printf "\n${YELLOW}Phase 3: Creating namespaces and secrets...${NC}\n"
 
 # Create namespaces and label for Helm ownership
-kubectl create namespace omnivec --dry-run=client -o yaml | kubectl apply -f -
-kubectl create namespace docgrok --dry-run=client -o yaml | kubectl apply -f -
-kubectl label namespace omnivec app.kubernetes.io/managed-by=Helm --overwrite
-kubectl annotate namespace omnivec meta.helm.sh/release-name=omnivec meta.helm.sh/release-namespace=omnivec --overwrite
+kubectl --context "$KUBE_CONTEXT" create namespace omnivec 2>/dev/null || true
+kubectl --context "$KUBE_CONTEXT" create namespace docgrok 2>/dev/null || true
+kubectl --context "$KUBE_CONTEXT" label namespace omnivec app.kubernetes.io/managed-by=Helm --overwrite
+kubectl --context "$KUBE_CONTEXT" annotate namespace omnivec meta.helm.sh/release-name=omnivec meta.helm.sh/release-namespace=omnivec --overwrite
 
 # Storage connection string secret (only when blob source is enabled)
 if [ "$ENABLE_BLOB_SOURCE" = "true" ]; then
-  kubectl create secret generic omnivec-storage \
+  kubectl --context "$KUBE_CONTEXT" create secret generic omnivec-storage \
     --namespace omnivec \
     --from-literal=account-name="$STORAGE_ACCOUNT" \
     --from-literal=queue-endpoint="$STORAGE_QUEUE_ENDPOINT" \
-    --dry-run=client -o yaml | kubectl apply -f -
+    --dry-run=client -o yaml | kubectl --context "$KUBE_CONTEXT" apply -f -
   printf "  ${GREEN}omnivec-storage secret created.${NC}\n"
 fi
 
@@ -290,6 +293,7 @@ IMAGE_TAG="latest"
 
 # Build helm command (POSIX-compatible — no bash arrays)
 HELM_CMD="helm upgrade --install omnivec ${ROOT_DIR}/helm/omnivec \
+  --kube-context ${KUBE_CONTEXT} \
   --namespace omnivec \
   --set global.imageRegistry=${ACR_LOGIN_SERVER} \
   --set azure.workloadIdentity.clientId=${IDENTITY_CLIENT_ID} \
@@ -338,17 +342,17 @@ printf "${GREEN}Helm deployment complete.${NC}\n"
 printf "\n${YELLOW}Phase 5: Verifying deployment...${NC}\n"
 
 printf "\n${CYAN}OmniVec pods:${NC}\n"
-kubectl get pods -n omnivec --no-headers 2>/dev/null || true
+kubectl --context "$KUBE_CONTEXT" get pods -n omnivec --no-headers 2>/dev/null || true
 
 printf "\n${CYAN}DocGrok pods:${NC}\n"
-kubectl get pods -n docgrok --no-headers 2>/dev/null || true
+kubectl --context "$KUBE_CONTEXT" get pods -n docgrok --no-headers 2>/dev/null || true
 
 # Wait for external IP
 printf "\n${YELLOW}Waiting for external IP...${NC}\n"
 EXTERNAL_IP=""
 i=0
 while [ $i -lt 30 ]; do
-  EXTERNAL_IP=$(kubectl get svc omnivec-web -n omnivec -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+  EXTERNAL_IP=$(kubectl --context "$KUBE_CONTEXT" get svc omnivec-web -n omnivec -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
   if [ -n "$EXTERNAL_IP" ]; then
     break
   fi

--- a/scripts/bench_run.sh
+++ b/scripts/bench_run.sh
@@ -2,6 +2,7 @@
 # Benchmark run: delete leases, reset, scale to 10, measure, scale down
 set -e
 
+KUBE_CONTEXT="${KUBE_CONTEXT:-$(kubectl config current-context)}"
 RUN=$1
 echo "=========================================="
 echo "  RUN $RUN"
@@ -19,15 +20,15 @@ curl -s -X POST "http://20.242.139.166/api/pipelines/pip-27bbd3f9/reset" > /dev/
 
 # Scale up
 echo "[$(date -u +%H:%M:%S)] Scaling to 10 pods..."
-kubectl scale deployment/omnivec-changefeed -n omnivec --replicas=10 > /dev/null
-kubectl rollout status deployment/omnivec-changefeed -n omnivec --timeout=120s > /dev/null 2>&1
+kubectl --context "$KUBE_CONTEXT" scale deployment/omnivec-changefeed -n omnivec --replicas=10 > /dev/null
+kubectl --context "$KUBE_CONTEXT" rollout status deployment/omnivec-changefeed -n omnivec --timeout=120s > /dev/null 2>&1
 
 # Wait for processing to start (first Inline embed)
 echo "[$(date -u +%H:%M:%S)] Waiting for processing to start..."
 for i in $(seq 1 60); do
     started=0
-    for pod in $(kubectl get pods -n omnivec -l app=omnivec-changefeed -o jsonpath='{.items[*].metadata.name}'); do
-        if kubectl logs $pod -n omnivec --timestamps 2>&1 | grep -q "Inline embed"; then
+    for pod in $(kubectl --context "$KUBE_CONTEXT" get pods -n omnivec -l app=omnivec-changefeed -o jsonpath='{.items[*].metadata.name}'); do
+        if kubectl --context "$KUBE_CONTEXT" logs $pod -n omnivec --timestamps 2>&1 | grep -q "Inline embed"; then
             started=1
             break
         fi
@@ -43,8 +44,8 @@ stable_count=0
 while true; do
     sleep 15
     total=0
-    for pod in $(kubectl get pods -n omnivec -l app=omnivec-changefeed -o jsonpath='{.items[*].metadata.name}'); do
-        count=$(kubectl logs $pod -n omnivec --timestamps 2>&1 | grep "Inline complete" | grep -oP '\d+/\d+ docs' | awk -F'/' '{sum += $1} END {print sum+0}')
+    for pod in $(kubectl --context "$KUBE_CONTEXT" get pods -n omnivec -l app=omnivec-changefeed -o jsonpath='{.items[*].metadata.name}'); do
+        count=$(kubectl --context "$KUBE_CONTEXT" logs $pod -n omnivec --timestamps 2>&1 | grep "Inline complete" | grep -oP '\d+/\d+ docs' | awk -F'/' '{sum += $1} END {print sum+0}')
         total=$((total + count))
     done
     echo "[$(date -u +%H:%M:%S)] Progress: $total patched"
@@ -64,10 +65,10 @@ done
 first_ts=""
 last_ts=""
 errors=0
-for pod in $(kubectl get pods -n omnivec -l app=omnivec-changefeed -o jsonpath='{.items[*].metadata.name}'); do
-    ft=$(kubectl logs $pod -n omnivec --timestamps 2>&1 | grep "Inline embed" | head -1 | awk '{print $1}')
-    lt=$(kubectl logs $pod -n omnivec --timestamps 2>&1 | grep "Inline complete" | tail -1 | awk '{print $1}')
-    e=$(kubectl logs $pod -n omnivec --timestamps 2>&1 | grep "Inline complete" | grep -v "0 failed" | wc -l)
+for pod in $(kubectl --context "$KUBE_CONTEXT" get pods -n omnivec -l app=omnivec-changefeed -o jsonpath='{.items[*].metadata.name}'); do
+    ft=$(kubectl --context "$KUBE_CONTEXT" logs $pod -n omnivec --timestamps 2>&1 | grep "Inline embed" | head -1 | awk '{print $1}')
+    lt=$(kubectl --context "$KUBE_CONTEXT" logs $pod -n omnivec --timestamps 2>&1 | grep "Inline complete" | tail -1 | awk '{print $1}')
+    e=$(kubectl --context "$KUBE_CONTEXT" logs $pod -n omnivec --timestamps 2>&1 | grep "Inline complete" | grep -v "0 failed" | wc -l)
     errors=$((errors + e))
     if [ -n "$ft" ]; then
         if [ -z "$first_ts" ] || [[ "$ft" < "$first_ts" ]]; then first_ts="$ft"; fi
@@ -92,7 +93,7 @@ echo "RUN $RUN RESULT: $total patched in ${duration}s = ${rate} docs/sec (errors
 echo "$RUN,$total,$duration,$rate,$errors" >> /home/cdbmvs/omnivec/scripts/bench_results.csv
 
 # Scale down
-kubectl scale deployment/omnivec-changefeed -n omnivec --replicas=0 > /dev/null
-kubectl rollout status deployment/omnivec-changefeed -n omnivec --timeout=30s > /dev/null 2>&1
+kubectl --context "$KUBE_CONTEXT" scale deployment/omnivec-changefeed -n omnivec --replicas=0 > /dev/null
+kubectl --context "$KUBE_CONTEXT" rollout status deployment/omnivec-changefeed -n omnivec --timeout=30s > /dev/null 2>&1
 echo "[$(date -u +%H:%M:%S)] Scaled down"
 echo ""

--- a/scripts/e2e-demo.sh
+++ b/scripts/e2e-demo.sh
@@ -123,7 +123,7 @@ az_query() {
 
 # ─── Helper: run Python on API pod via stdin ─────────────────────────────────
 pod_python() {
-  echo "$1" | kubectl exec -i deployment/omnivec-api -n omnivec -- python3 -
+  echo "$1" | kubectl --context "$KUBE_CONTEXT" exec -i deployment/omnivec-api -n omnivec -- python3 -
 }
 
 # ─── Helper: HTTP calls via curl ─────────────────────────────────────────────
@@ -286,7 +286,8 @@ if [ "$FROM_STEP" -le 3 ]; then
 fi
 # Always load azd values (needed by all subsequent steps)
 load_azd_values
-az aks get-credentials --resource-group "$RESOURCE_GROUP" --name "$AKS_CLUSTER" --overwrite-existing 2>/dev/null
+KUBE_CONTEXT="${AKS_CLUSTER}"
+az aks get-credentials --resource-group "$RESOURCE_GROUP" --name "$AKS_CLUSTER" --context "$KUBE_CONTEXT" --overwrite-existing 2>/dev/null || true
 ensure_kubeconfig
 
 log "  Admin Token: $ADMIN_TOKEN"
@@ -297,7 +298,7 @@ log "  Waiting for external IP..."
 SERVER=""
 i=0
 while [ $i -lt 60 ]; do
-  SERVER=$(kubectl get svc omnivec-web -n omnivec -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null | tr -d '\r' || true)
+  SERVER=$(kubectl --context "$KUBE_CONTEXT" get svc omnivec-web -n omnivec -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null | tr -d '\r' || true)
   if [ -n "$SERVER" ]; then break; fi
   sleep 5
   i=$((i + 1))

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2249,8 +2249,20 @@
                         <input type="text" class="form-input" name="endpoint" placeholder="https://...">
                     </div>
                     <div class="form-group">
+                        <label class="form-label">Authentication</label>
+                        <select class="form-input" name="auth_type" onchange="toggleAuthFields(this.value)">
+                            <option value="key">API Key</option>
+                            <option value="managed-identity">Managed Identity</option>
+                        </select>
+                        <small style="color: var(--text-tertiary); font-size: 12px;">Use managed identity for keyless access via Azure workload identity</small>
+                    </div>
+                    <div class="form-group" id="api-key-group">
                         <label class="form-label">API Key</label>
                         <input type="password" class="form-input" name="apiKey" placeholder="Enter API key">
+                    </div>
+                    <div class="form-group" id="client-id-group" style="display: none;">
+                        <label class="form-label">Client ID (optional)</label>
+                        <input type="text" class="form-input" name="clientId" placeholder="Managed identity client ID (uses workload identity if empty)">
                     </div>
                     <div class="form-group">
                         <label class="form-label">API Version (Azure only)</label>
@@ -6798,6 +6810,10 @@
                                 <span style="color: var(--text-secondary);">Endpoint</span>
                                 <span class="mono" style="word-break: break-all; text-align: right; max-width: 60%;">${extModel.endpoint}</span>
                             </div>
+                            <div style="display: flex; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid var(--border-subtle);">
+                                <span style="color: var(--text-secondary);">Authentication</span>
+                                <span class="mono">${extModel.auth_type === 'managed-identity' ? 'Managed Identity' : 'API Key'}</span>
+                            </div>
                             ${extModel.api_version ? `
                             <div style="display: flex; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid var(--border-subtle);">
                                 <span style="color: var(--text-secondary);">API Version</span>
@@ -6929,24 +6945,47 @@
             if (dimsGroup) dimsGroup.style.display = category === 'chat' ? 'none' : 'block';
         }
 
+        function toggleAuthFields(authType) {
+            const keyGroup = document.getElementById('api-key-group');
+            const clientIdGroup = document.getElementById('client-id-group');
+            if (authType === 'managed-identity') {
+                if (keyGroup) keyGroup.style.display = 'none';
+                if (clientIdGroup) clientIdGroup.style.display = 'block';
+            } else {
+                if (keyGroup) keyGroup.style.display = 'block';
+                if (clientIdGroup) clientIdGroup.style.display = 'none';
+            }
+        }
+
         async function addDgExternalModel() {
             const form = document.getElementById('dg-external-model-form');
             const formData = new FormData(form);
             const modelCategory = formData.get('model_category') || 'embedding';
+            const authType = formData.get('auth_type') || 'key';
             const data = {
                 name: formData.get('name'),
                 type: formData.get('type'),
                 model_category: modelCategory,
                 endpoint: formData.get('endpoint'),
-                api_key: formData.get('apiKey'),
+                auth_type: authType,
                 api_version: formData.get('apiVersion'),
                 deployment: formData.get('deployment'),
                 embedding_dim: modelCategory === 'chat' ? 0 : parseInt(formData.get('dimensions'))
             };
 
-            if (!data.name || !data.endpoint || !data.api_key) {
-                alert('Please fill in all required fields');
-                return;
+            if (authType === 'key') {
+                data.api_key = formData.get('apiKey');
+                if (!data.name || !data.endpoint || !data.api_key) {
+                    alert('Please fill in all required fields (name, endpoint, API key)');
+                    return;
+                }
+            } else {
+                const clientId = formData.get('clientId');
+                if (clientId) data.client_id = clientId;
+                if (!data.name || !data.endpoint) {
+                    alert('Please fill in all required fields (name, endpoint)');
+                    return;
+                }
             }
 
             try {


### PR DESCRIPTION
## Summary
- **Managed identity auth for external models**: Azure OpenAI / AI Foundry models can now use workload identity instead of API keys (`auth_type: managed-identity`). Supported in API, CLI (`--auth-type`, `--client-id`), and web UI (auth type dropdown).
- **Context-specific kubectl/helm**: All kubectl calls use explicit `--context` and helm uses `--kube-context`, preventing cross-deployment conflicts when multiple `azd up` runs happen in parallel.
- **Dotnet worker resilience**: Worker handles missing Service Bus config gracefully (stays idle) instead of crashing with `ArgumentException`.
- **Namespace creation tolerance**: `kubectl create namespace` no longer fails if namespace already exists.

## Test plan
- [x] Full teardown + e2e-demo from scratch — all 11 steps passed
- [x] Managed identity model registered and used in pipeline (3/3 docs embedded keyless)
- [x] Context-specific kubectl verified in logs (`context: omnivec-aks-4lmtkol4x62pq`)
- [x] CLI compiles clean (`go build`)