### PR TITLE
Harden azd and e2e recovery paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ Thumbs.db
 
 # Logs
 *.log
+.e2e-checkpoint
 
 # Secrets
 *.env

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -52,6 +52,11 @@ foreach ($var in @("INSTANCE_ID","AKS_CLUSTER","ACR_LOGIN_SERVER","ACR_NAME","CO
     }
 }
 
+if ($ENABLE_BLOB_SOURCE -eq "true" -and -not $SB_ENDPOINT) {
+    Write-Host "`e[31mMissing Service Bus endpoint while blob source is enabled.`e[0m"
+    exit 1
+}
+
 Write-Host "`n`e[36mConfiguration:`e[0m"
 Write-Host "  Instance ID:     $INSTANCE_ID"
 Write-Host "  AKS cluster:     $AKS_CLUSTER"
@@ -136,6 +141,33 @@ function Build-AllImages {
     }
 }
 
+function Build-MissingImages {
+    param([string[]]$Images)
+
+    foreach ($image in $Images) {
+        switch ($image) {
+            "omnivec-api"             { Build-Image -Name $image -Dockerfile "$RootDir/api/Dockerfile" -Context $RootDir -Tag "latest" }
+            "omnivec-web"             { Build-Image -Name $image -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag "latest" }
+            "omnivec-changefeed"      { Build-Image -Name $image -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag "latest" }
+            "omnivec-dotnet-worker"   { Build-Image -Name $image -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag "latest" }
+            "docgrok-pipeline-worker" {
+                if (Test-Path "$RootDir/docgrok/pipeline-worker/Dockerfile") {
+                    Build-Image -Name $image -Dockerfile "$RootDir/docgrok/pipeline-worker/Dockerfile" -Context "$RootDir/docgrok/pipeline-worker/" -Tag "latest"
+                } else {
+                    Write-Host "  `e[33mSkipping ${image}: source not present in repo.`e[0m"
+                }
+            }
+            "docgrok-router" {
+                if (Test-Path "$RootDir/docgrok/router/Dockerfile") {
+                    Build-Image -Name $image -Dockerfile "$RootDir/docgrok/router/Dockerfile" -Context "$RootDir/docgrok/router/" -Tag "latest"
+                } else {
+                    Write-Host "  `e[33mSkipping ${image}: source not present in repo.`e[0m"
+                }
+            }
+        }
+    }
+}
+
 # -- If not explicitly set to build, try import --
 if (-not $DO_BUILD) {
     Write-Host "`n`e[33mPhase 1: Importing pre-built images from shared registry...`e[0m"
@@ -213,12 +245,11 @@ if ($DO_BUILD) {
 
     Write-Host "`e[32mImage import complete: $importCount imported, $skipCount skipped.`e[0m"
 
-    # If no images available, abort before Helm deploy
+    # If import yielded no usable images, auto-fallback to source builds
     $totalAvailable = $importCount + $skipCount
     if ($totalAvailable -eq 0) {
-        Write-Host "`n`e[31mERROR: No images available in ACR. Cannot proceed with Helm deploy.`e[0m"
-        Write-Host "  Fix the issue above, then re-run: azd hooks run postprovision"
-        exit 1
+        Write-Host "`n`e[33mImport provided no usable images. Falling back to source build mode...`e[0m"
+        Build-AllImages
     }
 }
 
@@ -236,17 +267,20 @@ foreach ($image in $IMAGES) {
 
 if ($missingImages.Count -gt 0) {
     Write-Host "`n`e[33mBuilding missing images from source...`e[0m"
+    Build-MissingImages -Images $missingImages
+
+    $stillMissing = @()
     foreach ($image in $missingImages) {
-        switch ($image) {
-            "omnivec-api"             { Build-Image -Name $image -Dockerfile "$RootDir/api/Dockerfile" -Context $RootDir -Tag "latest" }
-            "omnivec-web"             { Build-Image -Name $image -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag "latest" }
-            "omnivec-changefeed"      { Build-Image -Name $image -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag "latest" }
-            "omnivec-dotnet-worker"   { Build-Image -Name $image -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag "latest" }
-            "docgrok-pipeline-worker" { if (Test-Path "$RootDir/docgrok/pipeline-worker") { Build-Image -Name $image -Dockerfile "$RootDir/docgrok/pipeline-worker/Dockerfile" -Context "$RootDir/docgrok/pipeline-worker/" -Tag "latest" } }
-            "docgrok-router"          { if (Test-Path "$RootDir/docgrok/router") { Build-Image -Name $image -Dockerfile "$RootDir/docgrok/router/Dockerfile" -Context "$RootDir/docgrok/router/" -Tag "latest" } }
+        if (-not (Test-ImageExists -Name $image -Tag "latest")) {
+            $stillMissing += $image
         }
     }
-    Write-Host "`e[32mMissing images built.`e[0m"
+    if ($stillMissing.Count -gt 0) {
+        Write-Host "`n`e[31mERROR: Required images are still missing after build attempt: $($stillMissing -join ', ')`e[0m"
+        Write-Host "  Ensure docgrok source/submodule exists, then re-run: azd hooks run postprovision"
+        exit 1
+    }
+    Write-Host "`e[32mMissing images built and verified.`e[0m"
 } else {
     Write-Host "`e[32mAll required images present in ACR.`e[0m"
 }
@@ -348,7 +382,25 @@ if ($ENABLE_BLOB_SOURCE -eq "true") {
 
 $helmArgs += @("--kube-context", $KUBE_CONTEXT, "--wait", "--timeout", "10m")
 
-helm @helmArgs
+& helm @helmArgs
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "`e[31mHelm deploy failed. Collecting pod diagnostics...`e[0m"
+    kubectl --context $KUBE_CONTEXT get pods -n omnivec -o wide
+
+    $problemPods = kubectl --context $KUBE_CONTEXT get pods -n omnivec --no-headers 2>$null | `
+        Where-Object { $_ -match "ImagePullBackOff|ErrImagePull|CrashLoopBackOff|Error|Pending" }
+
+    foreach ($line in $problemPods) {
+        $parts = ($line -replace '\s+', ' ').Trim().Split(' ')
+        if ($parts.Count -lt 3) { continue }
+        $podName = $parts[0]
+        $status = $parts[2]
+        Write-Host "`n`e[33m=== $podName ($status) ===`e[0m"
+        kubectl --context $KUBE_CONTEXT describe pod $podName -n omnivec | Select-String -Pattern "Events:" -Context 0,60
+        kubectl --context $KUBE_CONTEXT logs $podName -n omnivec --tail=80 2>$null
+    }
+    exit 1
+}
 
 Write-Host "`e[32mHelm deployment complete.`e[0m"
 
@@ -362,7 +414,8 @@ Write-Host "`n`e[36mOmniVec pods:`e[0m"
 kubectl --context $KUBE_CONTEXT get pods -n omnivec --no-headers 2>$null
 
 Write-Host "`n`e[36mDocGrok pods:`e[0m"
-kubectl --context $KUBE_CONTEXT get pods -n docgrok --no-headers 2>$null
+kubectl --context $KUBE_CONTEXT get pods -n omnivec -l app=docgrok --no-headers 2>$null
+kubectl --context $KUBE_CONTEXT get pods -n omnivec -l app=docgrok-controller --no-headers 2>$null
 
 # Wait for external IP
 Write-Host "`n`e[33mWaiting for external IP...`e[0m"
@@ -371,6 +424,12 @@ for ($i = 0; $i -lt 30; $i++) {
     $externalIp = kubectl --context $KUBE_CONTEXT get svc omnivec-web -n omnivec -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>$null
     if ($externalIp) { break }
     Start-Sleep -Seconds 5
+}
+
+kubectl --context $KUBE_CONTEXT rollout status deployment/omnivec-api -n omnivec --timeout=5m 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "`e[31mAPI deployment did not become ready.`e[0m"
+    exit 1
 }
 
 Write-Host ""

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -62,6 +62,11 @@ for var in INSTANCE_ID AKS_CLUSTER ACR_LOGIN_SERVER ACR_NAME COSMOS_ENDPOINT IDE
   fi
 done
 
+if [ "$ENABLE_BLOB_SOURCE" = "true" ] && [ -z "$SB_ENDPOINT" ]; then
+  printf "${RED}Missing Service Bus endpoint while blob source is enabled.${NC}\n"
+  exit 1
+fi
+
 printf "\n${CYAN}Configuration:${NC}\n"
 echo "  Instance ID:     $INSTANCE_ID"
 echo "  AKS cluster:    $AKS_CLUSTER"
@@ -127,12 +132,37 @@ build_all_images() {
   build_image "omnivec-web" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest"
   build_image "omnivec-changefeed" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest"
   build_image "omnivec-dotnet-worker" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest"
-  if [ -d "${ROOT_DIR}/docgrok/pipeline-worker" ]; then
+  if [ -f "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" ]; then
     build_image "docgrok-pipeline-worker" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "latest"
   fi
-  if [ -d "${ROOT_DIR}/docgrok/router" ]; then
+  if [ -f "${ROOT_DIR}/docgrok/router/Dockerfile" ]; then
     build_image "docgrok-router" "${ROOT_DIR}/docgrok/router/Dockerfile" "${ROOT_DIR}/docgrok/router/" "latest"
   fi
+}
+
+build_missing_images() {
+  for image in "$@"; do
+    case "$image" in
+      omnivec-api)              build_image "$image" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "latest" ;;
+      omnivec-web)              build_image "$image" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest" ;;
+      omnivec-changefeed)       build_image "$image" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest" ;;
+      omnivec-dotnet-worker)    build_image "$image" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest" ;;
+      docgrok-pipeline-worker)
+        if [ -f "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" ]; then
+          build_image "$image" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "latest"
+        else
+          printf "  ${YELLOW}Skipping ${image}: source not present in repo.${NC}\n"
+        fi
+        ;;
+      docgrok-router)
+        if [ -f "${ROOT_DIR}/docgrok/router/Dockerfile" ]; then
+          build_image "$image" "${ROOT_DIR}/docgrok/router/Dockerfile" "${ROOT_DIR}/docgrok/router/" "latest"
+        else
+          printf "  ${YELLOW}Skipping ${image}: source not present in repo.${NC}\n"
+        fi
+        ;;
+    esac
+  done
 }
 
 # ── If not explicitly set to build, try import ──────────────────────────
@@ -198,7 +228,7 @@ else
 
   # Wait for all imports
   for pid in $import_pids; do
-    wait "$pid" 2>/dev/null || true
+    wait "$pid"
   done
 
   # Report results
@@ -218,12 +248,12 @@ else
 
   printf "${GREEN}Image import complete: $import_count imported, $skip_count skipped.${NC}\n"
 
-  # If no images available, abort before Helm deploy
+  # If no images available from import, auto-fallback to build mode
   total_available=$((import_count + skip_count))
   if [ "$total_available" -eq 0 ]; then
-    printf "\n${RED}ERROR: No images available in ACR. Cannot proceed with Helm deploy.${NC}\n"
-    printf "  Fix the issue above, then re-run: azd hooks run postprovision\n"
-    exit 1
+    printf "\n${YELLOW}Import provided no usable images. Falling back to source build mode...${NC}\n"
+    BUILD_MODE=${BUILD_MODE:-acr}
+    build_all_images
   fi
 fi
 
@@ -241,17 +271,21 @@ done
 
 if [ -n "$MISSING_IMAGES" ]; then
   printf "\n${YELLOW}Building missing images from source...${NC}\n"
+  # shellcheck disable=SC2086
+  build_missing_images $MISSING_IMAGES
+
+  STILL_MISSING=""
   for image in $MISSING_IMAGES; do
-    case "$image" in
-      omnivec-api)              build_image "$image" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "latest" ;;
-      omnivec-web)              build_image "$image" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest" ;;
-      omnivec-changefeed)       build_image "$image" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest" ;;
-      omnivec-dotnet-worker)    build_image "$image" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest" ;;
-      docgrok-pipeline-worker)  [ -d "${ROOT_DIR}/docgrok/pipeline-worker" ] && build_image "$image" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "latest" ;;
-      docgrok-router)           [ -d "${ROOT_DIR}/docgrok/router" ] && build_image "$image" "${ROOT_DIR}/docgrok/router/Dockerfile" "${ROOT_DIR}/docgrok/router/" "latest" ;;
-    esac
+    if ! image_exists "$image" "latest"; then
+      STILL_MISSING="$STILL_MISSING $image"
+    fi
   done
-  printf "${GREEN}Missing images built.${NC}\n"
+  if [ -n "$STILL_MISSING" ]; then
+    printf "\n${RED}ERROR: Required images are still missing after build attempt:${NC} $STILL_MISSING\n"
+    printf "  Ensure docgrok submodule/source exists, then re-run: azd hooks run postprovision\n"
+    exit 1
+  fi
+  printf "${GREEN}Missing images built and verified.${NC}\n"
 else
   printf "${GREEN}All required images present in ACR.${NC}\n"
 fi
@@ -266,7 +300,7 @@ az aks get-credentials \
   --resource-group "$RESOURCE_GROUP" \
   --name "$AKS_CLUSTER" \
   --context "$KUBE_CONTEXT" \
-  --overwrite-existing 2>/dev/null || true
+  --overwrite-existing >/dev/null
 
 # WSL: az writes kubeconfig to Windows home — symlink to Linux home for helm/kubectl
 if [ ! -f "$HOME/.kube/config" ] && [ -f "/mnt/c/Users/$(whoami)/.kube/config" ] 2>/dev/null; then
@@ -282,6 +316,7 @@ elif [ ! -f "$HOME/.kube/config" ]; then
 fi
 
 export KUBE_CONTEXT
+kubectl --context "$KUBE_CONTEXT" get nodes >/dev/null
 printf "${GREEN}Connected to AKS cluster: ${AKS_CLUSTER} (context: ${KUBE_CONTEXT})${NC}\n"
 
 # =============================================================================
@@ -371,7 +406,27 @@ fi
 HELM_CMD="$HELM_CMD --wait --timeout 10m"
 
 # Execute
+set +e
 eval $HELM_CMD
+helm_rc=$?
+set -e
+
+if [ "$helm_rc" -ne 0 ]; then
+  printf "${RED}Helm deploy failed. Collecting pod diagnostics...${NC}\n"
+  kubectl --context "$KUBE_CONTEXT" get pods -n omnivec -o wide || true
+  kubectl --context "$KUBE_CONTEXT" get pods -n omnivec --no-headers 2>/dev/null | while read -r line; do
+    pod=$(echo "$line" | awk '{print $1}')
+    status=$(echo "$line" | awk '{print $3}')
+    case "$status" in
+      ImagePullBackOff|ErrImagePull|CrashLoopBackOff|Error|Pending)
+        printf "\n${YELLOW}=== %s (%s) ===${NC}\n" "$pod" "$status"
+        kubectl --context "$KUBE_CONTEXT" describe pod "$pod" -n omnivec | sed -n '/Events:/,$p' || true
+        kubectl --context "$KUBE_CONTEXT" logs "$pod" -n omnivec --tail=80 || true
+        ;;
+    esac
+  done
+  exit "$helm_rc"
+fi
 
 printf "${GREEN}Helm deployment complete.${NC}\n"
 
@@ -385,7 +440,8 @@ printf "\n${CYAN}OmniVec pods:${NC}\n"
 kubectl --context "$KUBE_CONTEXT" get pods -n omnivec --no-headers 2>/dev/null || true
 
 printf "\n${CYAN}DocGrok pods:${NC}\n"
-kubectl --context "$KUBE_CONTEXT" get pods -n docgrok --no-headers 2>/dev/null || true
+kubectl --context "$KUBE_CONTEXT" get pods -n omnivec -l app=docgrok --no-headers 2>/dev/null || true
+kubectl --context "$KUBE_CONTEXT" get pods -n omnivec -l app=docgrok-controller --no-headers 2>/dev/null || true
 
 # Wait for external IP
 printf "\n${YELLOW}Waiting for external IP...${NC}\n"
@@ -399,6 +455,11 @@ while [ $i -lt 30 ]; do
   sleep 5
   i=$((i + 1))
 done
+
+if ! kubectl --context "$KUBE_CONTEXT" rollout status deployment/omnivec-api -n omnivec --timeout=5m >/dev/null; then
+  printf "${RED}API deployment did not become ready.${NC}\n"
+  exit 1
+fi
 
 echo ""
 printf "${GREEN}╔══════════════════════════════════════════╗${NC}\n"

--- a/hooks/preprovision.ps1
+++ b/hooks/preprovision.ps1
@@ -76,16 +76,10 @@ if ($existingAks -and $existingRg -and $existingAks -notmatch "^ERROR" -and $exi
     } catch {}
 
     if ($healthyPods -gt 0) {
-        Write-Host "`n`e[33mWARNING: Existing deployment detected and running ($healthyPods healthy pods in omnivec namespace).`e[0m"
+        Write-Host "`n`e[33mExisting healthy deployment detected ($healthyPods running pods in omnivec).`e[0m"
         Write-Host "  AKS:  `e[36m$kubeCtx`e[0m"
         Write-Host "  RG:   `e[36m$($existingRg.Trim())`e[0m"
-        Write-Host "  Re-running azd up will update the deployment in place."
-        $confirmRedeploy = Read-Host "  Continue with re-deployment? [y/N]"
-        if ($confirmRedeploy -notmatch "^[yY]") {
-            Write-Host "  `e[31mAborting. Use 'azd down' to tear down first, or re-run and confirm.`e[0m"
-            exit 0
-        }
-        Write-Host "  `e[32mProceeding with update...`e[0m"
+        Write-Host "  `e[32mReusing existing resources and proceeding with in-place update.`e[0m"
     }
 }
 

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -72,16 +72,10 @@ if [ -n "$EXISTING_AKS" ] && [ -n "$EXISTING_RG" ]; then
   HEALTHY_PODS=$(kubectl --context "$KUBE_CTX" get pods -n omnivec --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l | tr -d ' ' || echo "0")
 
   if [ "$HEALTHY_PODS" -gt 0 ]; then
-    printf "\n${YELLOW}WARNING: Existing deployment detected and running (${HEALTHY_PODS} healthy pods in omnivec namespace).${NC}\n"
+    printf "\n${YELLOW}Existing healthy deployment detected (${HEALTHY_PODS} running pods in omnivec).${NC}\n"
     printf "  AKS:  ${CYAN}${EXISTING_AKS}${NC}\n"
     printf "  RG:   ${CYAN}${EXISTING_RG}${NC}\n"
-    printf "  Re-running azd up will update the deployment in place.\n"
-    printf "  ${YELLOW}Continue with re-deployment? [y/N]: ${NC}"
-    read -r confirm_redeploy || true
-    case "$confirm_redeploy" in
-      [yY]*) printf "  ${GREEN}Proceeding with update...${NC}\n" ;;
-      *)     printf "  ${RED}Aborting. Use 'azd down' to tear down first, or re-run and confirm.${NC}\n"; exit 0 ;;
-    esac
+    printf "  ${GREEN}Reusing existing resources and proceeding with in-place update.${NC}\n"
   fi
 fi
 

--- a/scripts/e2e-demo.ps1
+++ b/scripts/e2e-demo.ps1
@@ -112,23 +112,31 @@ if (-not $Quiet) {
 $ENV_NAME        = "omnivec-e2e-demo"
 $LOCATION        = "eastus2"
 $SUBSCRIPTION    = "074d02eb-4d74-486a-b299-b262264d1536"
+$MODEL_NAME      = "azure-openai-embed"
+$SOURCE_NAME     = "demo-cosmosdb-source"
+$DEST_NAME       = "demo-vector-store"
+$PIPELINE_NAME   = "demo-pipeline"
 $AOAI_ENDPOINT   = $AoaiEndpoint
 $AOAI_KEY        = $AoaiKey
 $AOAI_DEPLOYMENT = $AoaiDeployment
 $AOAI_DIMS       = $AoaiDims
 
-if (-not $AOAI_ENDPOINT) {
-    LogWarn "Azure OpenAI endpoint not set."
-    Log "  Example: https://<resource>.openai.azure.com"
-    $AOAI_ENDPOINT = Read-Host "  Enter Azure OpenAI endpoint"
-    if (-not $AOAI_ENDPOINT) { LogErr "Endpoint required."; exit 1 }
+if ($FromStep -le 6) {
+    if (-not $AOAI_ENDPOINT) {
+        LogWarn "Azure OpenAI endpoint not set."
+        Log "  Example: https://<resource>.openai.azure.com"
+        $AOAI_ENDPOINT = Read-Host "  Enter Azure OpenAI endpoint"
+        if (-not $AOAI_ENDPOINT) { LogErr "Endpoint required."; exit 1 }
+    }
+    if (-not $AOAI_KEY) {
+        LogWarn "Azure OpenAI API key not set."
+        $AOAI_KEY = Read-Host "  Enter Azure OpenAI API key"
+        if (-not $AOAI_KEY) { LogErr "API key required."; exit 1 }
+    }
+    LogOk "Embedding: $AOAI_DEPLOYMENT (${AOAI_DIMS}d) @ $AOAI_ENDPOINT"
+} else {
+    Log "  Skipping Azure OpenAI prompts (resuming from step $FromStep)."
 }
-if (-not $AOAI_KEY) {
-    LogWarn "Azure OpenAI API key not set."
-    $AOAI_KEY = Read-Host "  Enter Azure OpenAI API key"
-    if (-not $AOAI_KEY) { LogErr "API key required."; exit 1 }
-}
-LogOk "Embedding: $AOAI_DEPLOYMENT (${AOAI_DIMS}d) @ $AOAI_ENDPOINT"
 
 # ─── Helper: load azd env values ─────────────────────────────────────────────
 function Load-AzdValues {
@@ -147,12 +155,29 @@ function Invoke-PodPython {
     $Script | kubectl exec -i deployment/omnivec-api -n omnivec -- python3 -
 }
 
+function Normalize-CommandOutput {
+    param($Output)
+    if ($Output -is [System.Array]) {
+        return ($Output -join "`n")
+    }
+    return "$Output"
+}
+
 # =============================================================================
 # STEP 1: Create azd environment
 # =============================================================================
 if ($FromStep -le 1) {
     LogStep 1 "Creating azd environment: $ENV_NAME"
     azd env new $ENV_NAME --location $LOCATION --subscription $SUBSCRIPTION 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        azd env select $ENV_NAME 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            LogWarn "Environment already exists. Reusing: $ENV_NAME"
+        } else {
+            LogErr "Failed to create/select environment: $ENV_NAME"
+            exit 1
+        }
+    }
     azd env set OMNIVEC_METADATA_STORE "cosmosdb-serverless"
     azd env set OMNIVEC_ENABLE_BLOB_SOURCE "true"
     azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE "Standard_D4ds_v6"
@@ -180,7 +205,8 @@ if ($FromStep -le 2) {
     LogStep 2 "Provisioning infrastructure (azd up ~15 min)..."
     azd up --no-prompt
     if ($LASTEXITCODE -ne 0) {
-        LogWarn "azd up returned non-zero, continuing..."
+        LogErr "azd up failed. Resolve the deployment error and re-run."
+        exit 1
     }
     Save-Checkpoint 2
 }
@@ -193,6 +219,10 @@ if ($FromStep -le 3) {
 }
 # Always load azd values (needed by all subsequent steps)
 Load-AzdValues
+if (-not $AKS_CLUSTER -or -not $RESOURCE_GROUP -or -not $ADMIN_TOKEN) {
+    LogErr "Missing required azd outputs (AKS cluster/resource group/admin token)."
+    exit 1
+}
 az aks get-credentials --resource-group $RESOURCE_GROUP --name $AKS_CLUSTER --overwrite-existing 2>$null
 
 Log "  Admin Token: $ADMIN_TOKEN"
@@ -212,9 +242,20 @@ LogOk "Server: $SERVER_URL"
 
 # Wait for API
 Log "  Waiting for API health..."
+$apiHealthy = $false
 for ($i = 0; $i -lt 30; $i++) {
-    try { $h = Invoke-RestMethod -Uri "$SERVER_URL/health" -TimeoutSec 5 2>$null; if ($h.status -eq "healthy") { break } } catch {}
+    try {
+        $h = Invoke-RestMethod -Uri "$SERVER_URL/health" -TimeoutSec 5 2>$null
+        if ($h.status -eq "healthy") {
+            $apiHealthy = $true
+            break
+        }
+    } catch {}
     Start-Sleep -Seconds 5
+}
+if (-not $apiHealthy) {
+    LogErr "API did not become healthy in time."
+    exit 1
 }
 LogOk "API healthy."
 Save-Checkpoint 3
@@ -290,15 +331,16 @@ if ($FromStep -le 5) {
     LogOk "test-documents created."
 
     # Vectors container with vector policy (via API pod)
-    # Retry up to 3 times — RBAC propagation can take longer than expected
-    for ($attempt = 1; $attempt -le 5; $attempt++) {
-        $vectorsOutput = Invoke-PodPython @"
+    # Retry on RBAC propagation and transient Cosmos connectivity timeouts
+    $vectorsOk = $false
+    for ($attempt = 1; $attempt -le 8; $attempt++) {
+        $vectorsOutput = (Invoke-PodPython @"
 import os
 from azure.cosmos import CosmosClient
 from azure.cosmos.exceptions import CosmosResourceExistsError, CosmosHttpResponseError
 from azure.identity import DefaultAzureCredential
 cred = DefaultAzureCredential(managed_identity_client_id=os.environ.get("AZURE_CLIENT_ID"))
-client = CosmosClient("$TEST_COSMOS_ENDPOINT", credential=cred)
+client = CosmosClient("$TEST_COSMOS_ENDPOINT", credential=cred, connection_timeout=30)
 db = client.get_database_client("testdb")
 vp = {"vectorEmbeddings": [{"path": "/embedding", "dataType": "float32", "distanceFunction": "cosine", "dimensions": $AOAI_DIMS}]}
 ip = {"includedPaths": [{"path": "/*"}], "excludedPaths": [{"path": "/embedding/*"}], "vectorIndexes": [{"path": "/embedding", "type": "quantizedFlat"}]}
@@ -310,15 +352,36 @@ except CosmosResourceExistsError:
 except CosmosHttpResponseError as e:
     if "Forbidden" in str(e) or "403" in str(e):
         print("RBAC_WAIT")
+    elif "timed out" in str(e).lower() or "timeout" in str(e).lower():
+        print("RETRY_TIMEOUT")
+    else:
+        raise
+except Exception as e:
+    if "timed out" in str(e).lower() or "timeout" in str(e).lower():
+        print("RETRY_TIMEOUT")
     else:
         raise
 "@
-        Write-Host $vectorsOutput
-        if ($vectorsOutput -match "^OK:") { break }
-        if ($vectorsOutput -match "RBAC_WAIT") {
-            LogWarn "RBAC not yet propagated, waiting 30s (attempt $attempt/5)..."
-            Start-Sleep -Seconds 30
-        } else { break }
+        ) 2>&1
+        $vectorsText = Normalize-CommandOutput $vectorsOutput
+        if ($vectorsText) { Write-Host $vectorsText }
+
+        if ($vectorsText -match "^OK:") {
+            $vectorsOk = $true
+            break
+        }
+        if ($vectorsText -match "RBAC_WAIT|RETRY_TIMEOUT|ServiceRequestTimeoutError|timed out|timeout") {
+            if ($attempt -lt 8) {
+                LogWarn "Vectors container not ready yet, retrying in 30s (attempt $attempt/8)..."
+                Start-Sleep -Seconds 30
+                continue
+            }
+        }
+        break
+    }
+    if (-not $vectorsOk) {
+        LogErr "Failed to create vectors container after retries"
+        exit 1
     }
     LogOk "All containers ready."
     Save-Checkpoint 5
@@ -333,7 +396,7 @@ except CosmosHttpResponseError as e:
 if ($FromStep -le 6) {
     LogStep 6 "Registering Azure OpenAI embedding model..."
     $modelBody = @{
-        name = "azure-openai-embed"; type = "azure-openai"; endpoint = $AOAI_ENDPOINT
+        name = $MODEL_NAME; type = "azure-openai"; endpoint = $AOAI_ENDPOINT
         api_key = $AOAI_KEY; model = $AOAI_DEPLOYMENT; deployment = $AOAI_DEPLOYMENT
         dimensions = $AOAI_DIMS; api_version = "2024-06-01"
     } | ConvertTo-Json
@@ -343,7 +406,12 @@ if ($FromStep -le 6) {
     Save-Checkpoint 6
 } else {
     $models = Invoke-RestMethod -Uri "$SERVER_URL/api/models" -Headers $headers
-    $MODEL_ID = $models.models[0].id
+    $model = $models.models | Where-Object { $_.name -eq $MODEL_NAME } | Select-Object -First 1
+    if (-not $model) {
+        LogErr "Required model '$MODEL_NAME' not found. Re-run from step 6."
+        exit 1
+    }
+    $MODEL_ID = $model.id
 }
 
 # =============================================================================
@@ -360,7 +428,7 @@ if ($FromStep -le 7) {
     $existing = Invoke-RestMethod -Uri "$SERVER_URL/api/destinations" -Headers $headers
     foreach ($d in $existing.destinations) { try { Invoke-RestMethod -Uri "$SERVER_URL/api/destinations/$($d.id)" -Method DELETE -Headers $headers 2>$null } catch {} }
 
-    $srcBody = @{ name = "demo-cosmosdb-source"; type = "cosmosdb"; config = @{
+    $srcBody = @{ name = $SOURCE_NAME; type = "cosmosdb"; config = @{
         endpoint = $TEST_COSMOS_ENDPOINT; database = "testdb"; container = "test-documents"
         auth_type = "managed-identity"; client_id = $IDENTITY_CLIENT_ID
     }} | ConvertTo-Json -Depth 5
@@ -368,7 +436,7 @@ if ($FromStep -le 7) {
     $SOURCE_ID = $srcResult.source.id
     LogOk "Source: $SOURCE_ID"
 
-    $dstBody = @{ name = "demo-vector-store"; type = "cosmosdb-vector"; config = @{
+    $dstBody = @{ name = $DEST_NAME; type = "cosmosdb-vector"; config = @{
         endpoint = $TEST_COSMOS_ENDPOINT; database = "testdb"; container = "vectors"
         auth_type = "managed-identity"; client_id = $IDENTITY_CLIENT_ID; vector_dimensions = $AOAI_DIMS
     }} | ConvertTo-Json -Depth 5
@@ -378,9 +446,19 @@ if ($FromStep -le 7) {
     Save-Checkpoint 7
 } else {
     $srcs = Invoke-RestMethod -Uri "$SERVER_URL/api/sources" -Headers $headers
-    $SOURCE_ID = $srcs.sources[0].id
+    $src = $srcs.sources | Where-Object { $_.name -eq $SOURCE_NAME } | Select-Object -First 1
+    if (-not $src) {
+        LogErr "Required source '$SOURCE_NAME' not found. Re-run from step 7."
+        exit 1
+    }
+    $SOURCE_ID = $src.id
     $dsts = Invoke-RestMethod -Uri "$SERVER_URL/api/destinations" -Headers $headers
-    $DEST_ID = $dsts.destinations[0].id
+    $dst = $dsts.destinations | Where-Object { $_.name -eq $DEST_NAME } | Select-Object -First 1
+    if (-not $dst) {
+        LogErr "Required destination '$DEST_NAME' not found. Re-run from step 7."
+        exit 1
+    }
+    $DEST_ID = $dst.id
 }
 
 # =============================================================================
@@ -389,8 +467,18 @@ if ($FromStep -le 7) {
 if ($FromStep -le 8) {
     LogStep 8 "Creating pipeline (queue mode), inserting docs, activating..."
 
+    # Clean up an existing demo pipeline to make step-8 resume idempotent
+    try {
+        $existingPipelines = Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines" -Headers $headers
+        foreach ($p in $existingPipelines.pipelines) {
+            if ($p.name -eq $PIPELINE_NAME) {
+                try { Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines/$($p.id)" -Method DELETE -Headers $headers 2>$null | Out-Null } catch {}
+            }
+        }
+    } catch {}
+
     $pipBody = @{
-        name = "demo-pipeline"; sources = @(@{ source_id = $SOURCE_ID; filters = @{} })
+        name = $PIPELINE_NAME; sources = @(@{ source_id = $SOURCE_ID; filters = @{} })
         destination_id = $DEST_ID; docgrok_pipeline = $MODEL_ID; process_existing = $true
         processing_mode = "queue"
     } | ConvertTo-Json -Depth 5
@@ -398,14 +486,16 @@ if ($FromStep -le 8) {
     $PIP_ID = $pipResult.pipeline.id
     LogOk "Pipeline created (queue mode): $PIP_ID"
 
-    # Insert test documents
+    # Insert test documents with retries for transient Cosmos timeout errors
     Log "  Inserting test documents..."
-    Invoke-PodPython @"
+    $docsInserted = $false
+    for ($attempt = 1; $attempt -le 8; $attempt++) {
+        $docInsertOutput = (Invoke-PodPython @"
 import os
 from azure.cosmos import CosmosClient
 from azure.identity import DefaultAzureCredential
 cred = DefaultAzureCredential(managed_identity_client_id=os.environ.get("AZURE_CLIENT_ID"))
-client = CosmosClient("$TEST_COSMOS_ENDPOINT", credential=cred)
+client = CosmosClient("$TEST_COSMOS_ENDPOINT", credential=cred, connection_timeout=30)
 c = client.get_database_client("testdb").get_container_client("test-documents")
 docs = [
     {"id": "doc-001", "title": "Azure Cosmos DB", "content": "Azure Cosmos DB is a globally distributed multi-model database service providing turnkey global distribution with elastic scaling.", "category": "database"},
@@ -415,24 +505,73 @@ docs = [
 for doc in docs:
     c.upsert_item(doc)
     print(f"  Inserted: {doc['id']} - {doc['title']}")
+print("DOCS_OK")
 "@
+        ) 2>&1
+        $docInsertText = Normalize-CommandOutput $docInsertOutput
+        if ($docInsertText) { Write-Host $docInsertText }
+        if ($docInsertText -match "DOCS_OK") {
+            $docsInserted = $true
+            break
+        }
+        if ($docInsertText -match "ServiceRequestTimeoutError|timed out|timeout|Connection to .* timed out") {
+            if ($attempt -lt 8) {
+                LogWarn "Document insert timed out, retrying in 30s (attempt $attempt/8)..."
+                Start-Sleep -Seconds 30
+                continue
+            }
+        }
+        break
+    }
+    if (-not $docsInserted) {
+        LogErr "Failed to insert test documents after retries."
+        exit 1
+    }
+
+    Log "  Waiting for worker pods to be ready..."
+    kubectl wait --for=condition=ready pod -l app=omnivec-dotnet-worker -n omnivec --timeout=300s 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        LogErr "dotnet-worker pods did not become ready."
+        exit 1
+    }
+    kubectl wait --for=condition=ready pod -l app=omnivec-cosmos-changefeed -n omnivec --timeout=300s 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        LogErr "cosmos-changefeed pods did not become ready."
+        exit 1
+    }
 
     # Resume pipeline
     Log "  Resuming pipeline..."
     Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines/$PIP_ID/resume" -Method POST -Headers $headers | Out-Null
     Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines/$PIP_ID/run" -Method POST -Headers $headers | Out-Null
     LogOk "Pipeline activated (queue mode). Waiting for processing..."
-    for ($i = 0; $i -lt 12; $i++) {
+    $queueEmbedded = $false
+    for ($i = 0; $i -lt 24; $i++) {
         try {
             $poll = Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines/$PIP_ID" -Headers $headers
-            if ($poll.stats.embedded_count -gt 0) { break }
+            if ($poll.stats.embedded_count -gt 0) {
+                $queueEmbedded = $true
+                break
+            }
         } catch {}
         Start-Sleep -Seconds 10
+    }
+    if (-not $queueEmbedded) {
+        LogErr "Queue mode did not produce embeddings within timeout."
+        try { kubectl get pods -n omnivec } catch {}
+        try { kubectl logs deployment/omnivec-dotnet-worker -n omnivec --tail=120 2>$null } catch {}
+        try { kubectl logs deployment/omnivec-cosmos-changefeed -n omnivec --tail=120 2>$null } catch {}
+        exit 1
     }
     Save-Checkpoint 8
 } else {
     $pips = Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines" -Headers $headers
-    $PIP_ID = $pips.pipelines[0].id
+    $pipeline = $pips.pipelines | Where-Object { $_.name -eq $PIPELINE_NAME } | Select-Object -First 1
+    if (-not $pipeline) {
+        LogErr "Required pipeline '$PIPELINE_NAME' not found. Re-run from step 8."
+        exit 1
+    }
+    $PIP_ID = $pipeline.id
 }
 
 # =============================================================================
@@ -449,12 +588,13 @@ if ($PIP_ID) {
     if ($stats.stats.embedded_count -gt 0) {
         LogOk "Queue mode: $($stats.stats.embedded_count) documents embedded to destination!"
     } else {
-        LogWarn "No completed embeddings yet. Check: omnivec pipeline show $PIP_ID"
+        LogErr "Queue mode verification failed: embedded_count is 0."
+        exit 1
     }
     Save-Checkpoint 9
 } else {
-    LogStep 9 "Skipping queue mode verify (no pipeline)"
-    Save-Checkpoint 9
+    LogErr "No pipeline found for queue-mode verification."
+    exit 1
 }
 
 # =============================================================================
@@ -480,6 +620,7 @@ if ($FromStep -le 10 -and $PIP_ID) {
     LogOk "Pipeline resumed (inline mode). Waiting for reprocessing..."
 
     # Poll source container until embeddings appear or 120s timeout
+    $inlineReady = $false
     for ($i = 0; $i -lt 12; $i++) {
         $pollResult = Invoke-PodPython @"
 import os
@@ -491,16 +632,30 @@ c = client.get_database_client("testdb").get_container_client("test-documents")
 count = sum(1 for d in c.query_items("SELECT c.id FROM c WHERE IS_DEFINED(c.embedding)", enable_cross_partition_query=True))
 print(count)
 "@
-        if ($pollResult -match "3") { break }
+        if ($pollResult -match "3") {
+            $inlineReady = $true
+            break
+        }
         Start-Sleep -Seconds 10
     }
+    if (-not $inlineReady) {
+        LogErr "Inline mode did not reprocess all documents within timeout."
+        exit 1
+    }
     Save-Checkpoint 10
+} elseif ($FromStep -le 10) {
+    LogErr "No pipeline found for inline-mode reset."
+    exit 1
 }
 
 # =============================================================================
 # STEP 11: Verify inline mode results
 # =============================================================================
 LogStep 11 "Verifying inline mode results..."
+if (-not $PIP_ID) {
+    LogErr "No pipeline found for inline-mode verification."
+    exit 1
+}
 if (-not $Quiet -and $PIP_ID) { & $CLI pipeline show $PIP_ID }
 
 # Inline mode embeds directly into the source container — check for embedding field
@@ -541,7 +696,8 @@ if ($inlineCheckStr -match "INLINE_RESULT:(\d+)/(\d+)") {
 if ($inlineEmbeddedCount -gt 0) {
     LogOk "Inline mode: $inlineEmbeddedCount/$inlineTotal documents embedded directly into source container!"
 } else {
-    LogWarn "No inline embeddings yet. The CFP may still be processing. Check: omnivec pipeline show $PIP_ID"
+    LogErr "Inline mode verification failed: no embeddings detected in source container."
+    exit 1
 }
 
 # =============================================================================

--- a/scripts/e2e-demo.sh
+++ b/scripts/e2e-demo.sh
@@ -269,7 +269,14 @@ ensure_kubeconfig() {
 # =============================================================================
 if [ "$FROM_STEP" -le 1 ]; then
   log_step 1 "Creating azd environment: $ENV_NAME"
-  azd env new "$ENV_NAME" --location "$LOCATION" --subscription "$SUBSCRIPTION" 2>/dev/null || true
+  if ! azd env new "$ENV_NAME" --location "$LOCATION" --subscription "$SUBSCRIPTION" 2>/dev/null; then
+    if azd env select "$ENV_NAME" >/dev/null 2>&1; then
+      log_warn "Environment already exists. Reusing: $ENV_NAME"
+    else
+      log_err "Failed to create/select environment: $ENV_NAME"
+      exit 1
+    fi
+  fi
   azd env set OMNIVEC_METADATA_STORE "cosmosdb-serverless"
   azd env set OMNIVEC_ENABLE_BLOB_SOURCE "true"
   azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE "Standard_D4ds_v6"
@@ -296,7 +303,10 @@ fi
 # =============================================================================
 if [ "$FROM_STEP" -le 2 ]; then
   log_step 2 "Provisioning infrastructure (azd up ~15 min)..."
-  azd up --no-prompt || log_warn "azd up returned non-zero, continuing..."
+  if ! azd up --no-prompt; then
+    log_err "azd up failed. Resolve the deployment error and re-run."
+    exit 1
+  fi
   save_checkpoint 2
 fi
 
@@ -308,8 +318,12 @@ if [ "$FROM_STEP" -le 3 ]; then
 fi
 # Always load azd values (needed by all subsequent steps)
 load_azd_values
+if [ -z "${AKS_CLUSTER:-}" ] || [ -z "${RESOURCE_GROUP:-}" ] || [ -z "${ADMIN_TOKEN:-}" ]; then
+  log_err "Missing required azd outputs (AKS cluster/resource group/admin token)."
+  exit 1
+fi
 KUBE_CONTEXT="${AKS_CLUSTER}"
-az aks get-credentials --resource-group "$RESOURCE_GROUP" --name "$AKS_CLUSTER" --context "$KUBE_CONTEXT" --overwrite-existing 2>/dev/null || true
+az aks get-credentials --resource-group "$RESOURCE_GROUP" --name "$AKS_CLUSTER" --context "$KUBE_CONTEXT" --overwrite-existing >/dev/null
 ensure_kubeconfig
 
 log "  Admin Token: $ADMIN_TOKEN"
@@ -332,12 +346,20 @@ log_ok "Server: $SERVER_URL"
 # Wait for API
 log "  Waiting for API health..."
 i=0
+api_healthy=false
 while [ $i -lt 30 ]; do
   health=$(curl -sf --max-time 5 "$SERVER_URL/health" 2>/dev/null || true)
-  if echo "$health" | grep -q '"healthy"'; then break; fi
+  if echo "$health" | grep -q '"healthy"'; then
+    api_healthy=true
+    break
+  fi
   sleep 5
   i=$((i + 1))
 done
+if [ "$api_healthy" != "true" ]; then
+  log_err "API did not become healthy in time."
+  exit 1
+fi
 log_ok "API healthy."
 save_checkpoint 3
 
@@ -588,14 +610,22 @@ print('DOCS_OK')
   api_post "/api/pipelines/$PIP_ID/resume" "{}" >/dev/null
   api_post "/api/pipelines/$PIP_ID/run" "{}" >/dev/null
   log_ok "Pipeline activated (queue mode). Waiting for processing..."
+  queue_embedded=false
   i=0
   while [ $i -lt 12 ]; do
     POLL=$(api_get "/api/pipelines/$PIP_ID" 2>/dev/null || true)
     POLL_EMB=$(echo "$POLL" | grep -o '"embedded_count":[0-9]*' | cut -d: -f2)
-    if [ -n "$POLL_EMB" ] && [ "$POLL_EMB" -gt 0 ] 2>/dev/null; then break; fi
+    if [ -n "$POLL_EMB" ] && [ "$POLL_EMB" -gt 0 ] 2>/dev/null; then
+      queue_embedded=true
+      break
+    fi
     sleep 10
     i=$((i + 1))
   done
+  if [ "$queue_embedded" != "true" ]; then
+    log_err "Queue mode did not produce embeddings within timeout."
+    exit 1
+  fi
   save_checkpoint 8
 else
   PIPS_RESULT=$(api_get "/api/pipelines")
@@ -620,12 +650,13 @@ if [ -n "$PIP_ID" ]; then
   if [ -n "$EMBEDDED" ] && [ "$EMBEDDED" -gt 0 ] 2>/dev/null; then
     log_ok "Queue mode: $EMBEDDED documents embedded to destination!"
   else
-    log_warn "No completed embeddings yet. Check: omnivec pipeline show $PIP_ID"
+    log_err "Queue mode verification failed: embedded_count is 0."
+    exit 1
   fi
   save_checkpoint 9
 else
-  log_step 9 "Skipping queue mode verify (no pipeline)"
-  save_checkpoint 9
+  log_err "No pipeline found for queue-mode verification."
+  exit 1
 fi
 
 # =============================================================================
@@ -651,6 +682,7 @@ if [ "$FROM_STEP" -le 10 ] && [ -n "$PIP_ID" ]; then
   log_ok "Pipeline resumed (inline mode). Waiting for reprocessing..."
 
   # Poll source container until embeddings appear or 120s timeout
+  inline_ready=false
   i=0
   while [ $i -lt 12 ]; do
     poll_check=$(pod_python "
@@ -663,17 +695,31 @@ c = client.get_database_client('testdb').get_container_client('test-documents')
 count = sum(1 for d in c.query_items('SELECT c.id FROM c WHERE IS_DEFINED(c.embedding)', enable_cross_partition_query=True))
 print(count)
 " 2>/dev/null || echo "0")
-    if echo "$poll_check" | grep -q "3"; then break; fi
+    if echo "$poll_check" | grep -q "3"; then
+      inline_ready=true
+      break
+    fi
     sleep 10
     i=$((i + 1))
   done
+  if [ "$inline_ready" != "true" ]; then
+    log_err "Inline mode did not reprocess all documents within timeout."
+    exit 1
+  fi
   save_checkpoint 10
+elif [ "$FROM_STEP" -le 10 ]; then
+  log_err "No pipeline found for inline-mode reset."
+  exit 1
 fi
 
 # =============================================================================
 # STEP 11: Verify inline mode results
 # =============================================================================
 log_step 11 "Verifying inline mode results..."
+if [ -z "$PIP_ID" ]; then
+  log_err "No pipeline found for inline-mode verification."
+  exit 1
+fi
 if [ "$QUIET" = "false" ] && [ -n "$PIP_ID" ]; then
   "$CLI" pipeline show "$PIP_ID" || true
 fi
@@ -718,7 +764,8 @@ log "  Source container — Embedded: $INLINE_EMBEDDED/$INLINE_TOTAL"
 if [ "$INLINE_EMBEDDED" -gt 0 ] 2>/dev/null; then
   log_ok "Inline mode working — $INLINE_EMBEDDED/$INLINE_TOTAL documents embedded directly into source container!"
 else
-  log_warn "No inline embeddings yet. The CFP may still be processing. Check: omnivec pipeline show $PIP_ID"
+  log_err "Inline mode verification failed: no embeddings detected in source container."
+  exit 1
 fi
 
 # =============================================================================


### PR DESCRIPTION
- Reuse healthy existing preprovisioned resources instead of failing on reruns
- Add import->build fallback and missing-image verification in postprovision hooks
- Add stricter readiness/error diagnostics for Helm and API rollouts
- Harden e2e demo scripts with fail-fast checks, retries, resume-safe lookup by resource names, and non-interactive resume behavior