### PR TITLE
Upgrade ACR to Premium SKU and improve import error handling

### DIFF
--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -214,7 +214,7 @@ if ($DO_BUILD) {
             $importError = az acr import --name $ACR --source "${SHARED}/${IMG}:latest" --image "${IMG}:latest" @authArgs --force 2>&1
             if ($LASTEXITCODE -eq 0) { return "OK" }
             # Retry once on transient errors
-            if ($importError -notmatch "unauthorized|authentication|401|not found|does not exist") {
+            if ($importError -notmatch "unauthorized|authentication|401|not found|does not exist|InvalidHostName|could not be resolved") {
                 Start-Sleep -Seconds 2
                 az acr import --name $ACR --source "${SHARED}/${IMG}:latest" --image "${IMG}:latest" @authArgs --force 2>&1
                 if ($LASTEXITCODE -eq 0) { return "OK" }

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -213,7 +213,7 @@ else
             --force 2>&1) && import_success=true || import_success=false
 
         if [ "$import_success" = "true" ]; then break; fi
-        if echo "$import_error" | grep -qi "unauthorized\|authentication\|401\|not found\|does not exist"; then break; fi
+        if echo "$import_error" | grep -qi "unauthorized\|authentication\|401\|not found\|does not exist\|InvalidHostName\|could not be resolved"; then break; fi
         if [ "$attempt" -lt 2 ]; then sleep 2; fi
       done
 

--- a/infra/modules/acr.bicep
+++ b/infra/modules/acr.bicep
@@ -1,4 +1,4 @@
-// Azure Container Registry — Basic tier
+// Azure Container Registry — Premium tier (faster imports, geo-replication, throughput)
 param registryName string
 param location string
 param tags object = {}
@@ -7,7 +7,7 @@ resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
   name: registryName
   location: location
   sku: {
-    name: 'Basic'
+    name: 'Premium'
   }
   properties: {
     adminUserEnabled: false


### PR DESCRIPTION
## Changes

- **Upgrade ACR SKU from Basic to Premium** in `infra/modules/acr.bicep` for faster image imports, higher throughput, and geo-replication support
- **Skip retries on unresolvable shared registry** — added `InvalidHostName` and DNS resolution errors to the non-retryable error list in both `hooks/postprovision.sh` and `hooks/postprovision.ps1`, so import failures against an unreachable shared registry fail fast instead of wasting time on a futile retry

## Testing

Validated with full teardown + `azd up` cycles:

| Run | Scenario | Time |
|---|---|---|
| Before (Basic, no shared registry) | Build from source | 24 min 15 sec |
| After (Premium shared registry) | Import from registry | 8-10 min |

E2E demo (steps 3-11) passed on fresh environment — both queue and inline modes working.