### PR TITLE
Fix Key Vault soft-delete detection to match only current environment

### DIFF
--- a/hooks/preprovision.ps1
+++ b/hooks/preprovision.ps1
@@ -372,18 +372,20 @@ if (Get-Command docker -ErrorAction SilentlyContinue) {
     azd env set OMNIVEC_BUILD_MODE "acr"
 }
 
-# -- Check for soft-deleted Key Vault with the expected name --
+# -- Check for soft-deleted Key Vault matching THIS environment's resource group --
 Write-Host "`n`e[33mChecking for soft-deleted Key Vaults...`e[0m"
-$softDeletedVaults = $null
+$rgName = "rg-omnivec-$($env:AZURE_ENV_NAME)"
+$softDeletedVault = $null
 $ErrorActionPreference = "SilentlyContinue"
-$softDeletedVaults = az keyvault list-deleted --query "[?contains(name,'omnivec-kv')].name" -o tsv 2>$null
+$softDeletedVault = az keyvault list-deleted --query "[?contains(properties.vaultId,'$rgName')].name" -o tsv 2>$null
 $ErrorActionPreference = "Stop"
-if ($softDeletedVaults) {
-    Write-Host "  `e[33mFound soft-deleted vault(s): $softDeletedVaults`e[0m"
+if ($softDeletedVault) {
+    $softDeletedVault = "$softDeletedVault".Trim()
+    Write-Host "  `e[33mFound soft-deleted vault for this env: $softDeletedVault`e[0m"
     Write-Host "  `e[36mBicep will recover the vault automatically (no purge needed).`e[0m"
     azd env set OMNIVEC_RECOVER_KEYVAULT "true"
 } else {
-    Write-Host "  `e[32mNo soft-deleted Key Vaults found.`e[0m"
+    Write-Host "  `e[32mNo soft-deleted Key Vault for env '$($env:AZURE_ENV_NAME)'.`e[0m"
     azd env set OMNIVEC_RECOVER_KEYVAULT "false"
 }
 

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -401,15 +401,17 @@ fi
 # it instead of failing with a "vault already exists in deleted state" error.
 
 printf "\n${YELLOW}Checking for soft-deleted Key Vaults...${NC}\n"
-# Build expected vault name: we can't know the exact resourceToken yet (Bicep computes it),
-# so we check all soft-deleted vaults with our prefix and let Bicep handle recovery.
-SOFT_DELETED_VAULTS=$(az keyvault list-deleted --query "[?contains(name,'omnivec-kv')].name" -o tsv 2>/dev/null || true)
-if [ -n "$SOFT_DELETED_VAULTS" ]; then
-  printf "  ${YELLOW}Found soft-deleted vault(s): ${SOFT_DELETED_VAULTS}${NC}\n"
+# Match only vaults that belonged to THIS environment's resource group,
+# not vaults from other environments that happen to share the omnivec-kv prefix.
+RG_NAME="rg-omnivec-${AZURE_ENV_NAME}"
+SOFT_DELETED_VAULT=$(az keyvault list-deleted --query "[?contains(properties.vaultId,'${RG_NAME}')].name" -o tsv 2>/dev/null || true)
+SOFT_DELETED_VAULT=$(printf '%s' "$SOFT_DELETED_VAULT" | tr -d '\r' | head -1)
+if [ -n "$SOFT_DELETED_VAULT" ]; then
+  printf "  ${YELLOW}Found soft-deleted vault for this env: ${SOFT_DELETED_VAULT}${NC}\n"
   printf "  ${CYAN}Bicep will recover the vault automatically (no purge needed).${NC}\n"
   azd env set OMNIVEC_RECOVER_KEYVAULT "true"
 else
-  printf "  ${GREEN}No soft-deleted Key Vaults found.${NC}\n"
+  printf "  ${GREEN}No soft-deleted Key Vault for env '${AZURE_ENV_NAME}'.${NC}\n"
   azd env set OMNIVEC_RECOVER_KEYVAULT "false"
 fi
 


### PR DESCRIPTION
## Problem

The preprovision hook checked for **any** soft-deleted vault matching `omnivec-kv-*`. When vaults from other environments existed in soft-deleted state, it incorrectly set `recoverKeyvault=true`. Bicep then tried `createMode: 'recover'` on this environment's vault — which was never soft-deleted — causing:

```
SoftDeletedVaultDoesNotExist: A soft deleted vault with the given name does not exist.
```

## Fix

Filter soft-deleted vaults by the **current environment's resource group** (`rg-omnivec-{envName}`) instead of the broad `omnivec-kv` prefix. This ensures recovery mode is only triggered when the exact vault for this deployment is actually soft-deleted.

Updated both `hooks/preprovision.sh` and `hooks/preprovision.ps1`.