### PR TITLE
Remove explicit Key Vault createMode — let Azure handle soft-delete automatically

### DIFF
--- a/hooks/preprovision.ps1
+++ b/hooks/preprovision.ps1
@@ -372,23 +372,6 @@ if (Get-Command docker -ErrorAction SilentlyContinue) {
     azd env set OMNIVEC_BUILD_MODE "acr"
 }
 
-# -- Check for soft-deleted Key Vault matching THIS environment's resource group --
-Write-Host "`n`e[33mChecking for soft-deleted Key Vaults...`e[0m"
-$rgName = "rg-omnivec-$($env:AZURE_ENV_NAME)"
-$softDeletedVault = $null
-$ErrorActionPreference = "SilentlyContinue"
-$softDeletedVault = az keyvault list-deleted --query "[?contains(properties.vaultId,'$rgName')].name" -o tsv 2>$null
-$ErrorActionPreference = "Stop"
-if ($softDeletedVault) {
-    $softDeletedVault = "$softDeletedVault".Trim()
-    Write-Host "  `e[33mFound soft-deleted vault for this env: $softDeletedVault`e[0m"
-    Write-Host "  `e[36mBicep will recover the vault automatically (no purge needed).`e[0m"
-    azd env set OMNIVEC_RECOVER_KEYVAULT "true"
-} else {
-    Write-Host "  `e[32mNo soft-deleted Key Vault for env '$($env:AZURE_ENV_NAME)'.`e[0m"
-    azd env set OMNIVEC_RECOVER_KEYVAULT "false"
-}
-
 Write-Host "`n`e[32mPre-provision checks passed. Proceeding with Bicep deployment...`e[0m"
 Write-Host "`e[36mEnvironment: $env:AZURE_ENV_NAME`e[0m"
 Write-Host "`e[36mEach installation gets a unique resource token derived from (subscription + resource group + env name).`e[0m"

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -400,21 +400,6 @@ fi
 # We check if a soft-deleted vault with that name exists so Bicep can recover
 # it instead of failing with a "vault already exists in deleted state" error.
 
-printf "\n${YELLOW}Checking for soft-deleted Key Vaults...${NC}\n"
-# Match only vaults that belonged to THIS environment's resource group,
-# not vaults from other environments that happen to share the omnivec-kv prefix.
-RG_NAME="rg-omnivec-${AZURE_ENV_NAME}"
-SOFT_DELETED_VAULT=$(az keyvault list-deleted --query "[?contains(properties.vaultId,'${RG_NAME}')].name" -o tsv 2>/dev/null || true)
-SOFT_DELETED_VAULT=$(printf '%s' "$SOFT_DELETED_VAULT" | tr -d '\r' | head -1)
-if [ -n "$SOFT_DELETED_VAULT" ]; then
-  printf "  ${YELLOW}Found soft-deleted vault for this env: ${SOFT_DELETED_VAULT}${NC}\n"
-  printf "  ${CYAN}Bicep will recover the vault automatically (no purge needed).${NC}\n"
-  azd env set OMNIVEC_RECOVER_KEYVAULT "true"
-else
-  printf "  ${GREEN}No soft-deleted Key Vault for env '${AZURE_ENV_NAME}'.${NC}\n"
-  azd env set OMNIVEC_RECOVER_KEYVAULT "false"
-fi
-
 printf "\n${GREEN}Pre-provision checks passed. Proceeding with Bicep deployment...${NC}\n"
 printf "${CYAN}Environment: ${AZURE_ENV_NAME}${NC}\n"
 printf "${CYAN}Each installation gets a unique resource token derived from (subscription + resource group + env name).${NC}\n"

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -31,9 +31,6 @@ param gpuNodeCount int = 4
 @description('Enable blob storage as a document source (creates Storage Account, Service Bus, Event Grid)')
 param enableBlobSource bool = true
 
-@description('Recover Key Vault from soft-deleted state instead of creating fresh (set by preprovision hook)')
-param recoverKeyvault bool = false
-
 // =============================================================================
 // NAMING (must be computed before resource group to avoid circular dependency)
 // =============================================================================
@@ -98,7 +95,6 @@ module keyvault 'modules/keyvault.bicep' = {
     location: location
     tags: tags
     identityPrincipalId: identity.outputs.principalId
-    recoverSoftDeleted: recoverKeyvault
   }
 }
 

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -25,9 +25,6 @@
     },
     "enableBlobSource": {
       "value": "${OMNIVEC_ENABLE_BLOB_SOURCE}"
-    },
-    "recoverKeyvault": {
-      "value": "${OMNIVEC_RECOVER_KEYVAULT}"
     }
   }
 }

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -6,9 +6,6 @@ param location string
 param tags object = {}
 param identityPrincipalId string
 
-@description('Set to true when a soft-deleted vault with this name exists and should be recovered instead of created fresh.')
-param recoverSoftDeleted bool = false
-
 resource vault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: vaultName
   location: location
@@ -21,8 +18,9 @@ resource vault 'Microsoft.KeyVault/vaults@2023-07-01' = {
     enableRbacAuthorization: true
     enableSoftDelete: true
     softDeleteRetentionInDays: 7
-    // Recover from soft-delete if a previous vault exists, otherwise create fresh
-    createMode: recoverSoftDeleted ? 'recover' : 'default'
+    // Let Azure handle createMode automatically:
+    // - If a soft-deleted vault with this name exists, Azure recovers it
+    // - Otherwise, creates fresh
     // Note: enablePurgeProtection should be true in production
     // Disabled here for dev/test to allow clean teardown with azd down --purge
   }


### PR DESCRIPTION
## Problem

Key Vault creation kept failing with `SoftDeletedVaultDoesNotExist` due to the `createMode: 'recover'` / `'default'` toggle. The preprovision hook couldn't reliably detect vault state, and cached env values caused stale `recover` mode on vaults that were never soft-deleted.

## Fix

Remove `createMode` from the Bicep entirely. When omitted, Azure handles it automatically:
- Soft-deleted vault exists → Azure recovers it
- No vault exists → Azure creates fresh

No more env flags, no detection hooks, no race conditions.

### Removed
- `recoverSoftDeleted` param from `keyvault.bicep`
- `recoverKeyvault` param from `main.bicep`
- `OMNIVEC_RECOVER_KEYVAULT` from `main.parameters.json`
- Soft-deleted vault detection from both preprovision hooks