### PR TITLE
Smart skip for unchanged images/charts + deployment confirmation prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ id_mappings.json
 
 # Windows
 nul
+.lock-hash

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -105,6 +105,19 @@ function Test-ImageExists {
     }
 }
 
+function Test-ImageUpToDate {
+    param($Name, $Tag)
+    try {
+        $localDigest = az acr manifest show-metadata --registry $ACR_NAME --name "${Name}:${Tag}" --query "digest" -o tsv 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $localDigest) { return $false }
+        $sharedDigest = az acr manifest show-metadata --registry "omnivecregistry" --name "${Name}:${Tag}" --query "digest" -o tsv 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not $sharedDigest) { return $false }
+        return ($localDigest.Trim() -eq $sharedDigest.Trim())
+    } catch {
+        return $false
+    }
+}
+
 # -- Helper: build a single image via docker or ACR --
 function Build-Image {
     param($Name, $Dockerfile, $Context, $Tag = "latest")
@@ -198,10 +211,12 @@ if ($DO_BUILD) {
     $imagesToImport = @()
 
     foreach ($image in $IMAGES) {
-        if (-not $FORCE_IMPORT -and (Test-ImageExists -Name $image -Tag "latest")) {
-            Write-Host "  `e[32m${image}:latest exists, skipping.`e[0m"
+        if (-not $FORCE_IMPORT -and (Test-ImageUpToDate -Name $image -Tag "latest")) {
+            Write-Host "  `e[32m${image}:latest up to date (digest match), skipping.`e[0m"
             $skipCount++
             continue
+        } elseif (-not $FORCE_IMPORT -and (Test-ImageExists -Name $image -Tag "latest")) {
+            Write-Host "  `e[36m${image}:latest exists but digest differs, re-importing...`e[0m"
         }
 
         Write-Host "  `e[36mImporting ${image}:latest...`e[0m"
@@ -322,9 +337,27 @@ Write-Host "`e[32mNamespaces and secrets created.`e[0m"
 
 Write-Host "`n`e[33mPhase 4: Deploying OmniVec via Helm...`e[0m"
 
-# Resolve helm chart dependencies (docgrok subchart)
-Write-Host "  `e[36mResolving helm dependencies...`e[0m"
-helm dependency build "$RootDir/helm/omnivec"
+# Resolve helm chart dependencies — skip if already up to date
+$chartDir = "$RootDir/helm/omnivec"
+$lockFile = "$chartDir/Chart.lock"
+$lockHashFile = "$chartDir/charts/.lock-hash"
+$currentHash = ""
+if (Test-Path $lockFile) {
+    $currentHash = (Get-FileHash $lockFile -Algorithm SHA256).Hash
+}
+$cachedHash = ""
+if (Test-Path $lockHashFile) {
+    $cachedHash = (Get-Content $lockHashFile -Raw).Trim()
+}
+if ($currentHash -and $currentHash -eq $cachedHash) {
+    Write-Host "  `e[32mHelm dependencies up to date, skipping.`e[0m"
+} else {
+    Write-Host "  `e[36mResolving helm dependencies...`e[0m"
+    helm dependency build $chartDir --quiet
+    if ($currentHash) {
+        $currentHash | Set-Content $lockHashFile -NoNewline
+    }
+}
 
 # Generate admin token if not already set
 $ADMIN_TOKEN = Get-AzdValue "OMNIVEC_ADMIN_TOKEN"

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -104,6 +104,19 @@ image_exists() {
   [ -n "$existing" ]
 }
 
+# Compare image digest between shared registry and local ACR — returns 0 if identical
+image_up_to_date() {
+  name=$1
+  tag=$2
+  # Get digest from local ACR
+  local_digest=$(az acr manifest show-metadata --registry "$ACR_NAME" --name "${name}:${tag}" --query "digest" -o tsv 2>/dev/null || true)
+  if [ -z "$local_digest" ]; then return 1; fi
+  # Get digest from shared registry
+  shared_digest=$(az acr manifest show-metadata --registry "omnivecregistry" --name "${name}:${tag}" --query "digest" -o tsv 2>/dev/null || true)
+  if [ -z "$shared_digest" ]; then return 1; fi
+  [ "$local_digest" = "$shared_digest" ]
+}
+
 # ── Helper: build a single image via docker or ACR ──────────────────────
 build_image() {
   name=$1
@@ -189,10 +202,12 @@ else
   import_pids=""
 
   for image in $IMAGES; do
-    if [ "$FORCE_IMPORT" != "true" ] && image_exists "$image" "latest"; then
-      printf "  ${GREEN}${image}:latest exists, skipping.${NC}\n"
+    if [ "$FORCE_IMPORT" != "true" ] && image_up_to_date "$image" "latest"; then
+      printf "  ${GREEN}${image}:latest up to date (digest match), skipping.${NC}\n"
       skip_count=$((skip_count + 1))
       continue
+    elif [ "$FORCE_IMPORT" != "true" ] && image_exists "$image" "latest"; then
+      printf "  ${CYAN}${image}:latest exists but digest differs, re-importing...${NC}\n"
     fi
 
     printf "  ${CYAN}Importing ${image}:latest...${NC}\n"
@@ -349,9 +364,27 @@ printf "${GREEN}Namespaces and secrets created.${NC}\n"
 
 printf "\n${YELLOW}Phase 4: Deploying OmniVec via Helm...${NC}\n"
 
-# Resolve helm chart dependencies (docgrok subchart)
-printf "  ${CYAN}Resolving helm dependencies...${NC}\n"
-helm dependency build "${ROOT_DIR}/helm/omnivec"
+# Resolve helm chart dependencies (docgrok subchart) — skip if already up to date
+CHART_DIR="${ROOT_DIR}/helm/omnivec"
+LOCK_FILE="${CHART_DIR}/Chart.lock"
+LOCK_HASH_FILE="${CHART_DIR}/charts/.lock-hash"
+CURRENT_HASH=""
+if [ -f "$LOCK_FILE" ]; then
+  CURRENT_HASH=$(sha256sum "$LOCK_FILE" 2>/dev/null | cut -d' ' -f1)
+fi
+CACHED_HASH=""
+if [ -f "$LOCK_HASH_FILE" ]; then
+  CACHED_HASH=$(cat "$LOCK_HASH_FILE" 2>/dev/null)
+fi
+if [ -n "$CURRENT_HASH" ] && [ "$CURRENT_HASH" = "$CACHED_HASH" ]; then
+  printf "  ${GREEN}Helm dependencies up to date, skipping.${NC}\n"
+else
+  printf "  ${CYAN}Resolving helm dependencies...${NC}\n"
+  helm dependency build "$CHART_DIR" --quiet
+  if [ -n "$CURRENT_HASH" ]; then
+    echo "$CURRENT_HASH" > "$LOCK_HASH_FILE"
+  fi
+fi
 
 # Image tag used for all images built in Phase 1
 # Generate admin token if not already set

--- a/hooks/preprovision.ps1
+++ b/hooks/preprovision.ps1
@@ -79,7 +79,30 @@ if ($existingAks -and $existingRg -and $existingAks -notmatch "^ERROR" -and $exi
         Write-Host "`n`e[33mExisting healthy deployment detected ($healthyPods running pods in omnivec).`e[0m"
         Write-Host "  AKS:  `e[36m$kubeCtx`e[0m"
         Write-Host "  RG:   `e[36m$($existingRg.Trim())`e[0m"
-        Write-Host "  `e[32mReusing existing resources and proceeding with in-place update.`e[0m"
+        Write-Host ""
+        Write-Host "  `e[36m1) Update in-place (default)`e[0m"
+        Write-Host "  `e[36m2) Teardown and redeploy fresh`e[0m"
+        Write-Host "  `e[36m3) Abort`e[0m"
+        Write-Host ""
+        $choice = Read-Host "  Choice [1]"
+        if (-not $choice) { $choice = "1" }
+        switch ($choice) {
+            "1" {
+                Write-Host "  `e[32mProceeding with in-place update.`e[0m"
+            }
+            "2" {
+                Write-Host "  `e[33mTearing down existing deployment first...`e[0m"
+                azd down --force --purge
+                Write-Host "  `e[32mTeardown complete. Proceeding with fresh deployment.`e[0m"
+            }
+            "3" {
+                Write-Host "  `e[31mAborted by user.`e[0m"
+                exit 0
+            }
+            default {
+                Write-Host "  `e[32mProceeding with in-place update (default).`e[0m"
+            }
+        }
     }
 }
 

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -75,7 +75,29 @@ if [ -n "$EXISTING_AKS" ] && [ -n "$EXISTING_RG" ]; then
     printf "\n${YELLOW}Existing healthy deployment detected (${HEALTHY_PODS} running pods in omnivec).${NC}\n"
     printf "  AKS:  ${CYAN}${EXISTING_AKS}${NC}\n"
     printf "  RG:   ${CYAN}${EXISTING_RG}${NC}\n"
-    printf "  ${GREEN}Reusing existing resources and proceeding with in-place update.${NC}\n"
+    printf "\n  ${CYAN}1) Update in-place (default)${NC}\n"
+    printf "  ${CYAN}2) Teardown and redeploy fresh${NC}\n"
+    printf "  ${CYAN}3) Abort${NC}\n"
+    printf "\n  Choice [1]: "
+    read -r DEPLOY_CHOICE </dev/tty 2>/dev/null || DEPLOY_CHOICE="1"
+    DEPLOY_CHOICE=${DEPLOY_CHOICE:-1}
+    case "$DEPLOY_CHOICE" in
+      1)
+        printf "  ${GREEN}Proceeding with in-place update.${NC}\n"
+        ;;
+      2)
+        printf "  ${YELLOW}Tearing down existing deployment first...${NC}\n"
+        azd down --force --purge
+        printf "  ${GREEN}Teardown complete. Proceeding with fresh deployment.${NC}\n"
+        ;;
+      3)
+        printf "  ${RED}Aborted by user.${NC}\n"
+        exit 0
+        ;;
+      *)
+        printf "  ${GREEN}Proceeding with in-place update (default).${NC}\n"
+        ;;
+    esac
   fi
 fi
 


### PR DESCRIPTION
## Changes

### 1. Skip image imports when unchanged (digest comparison)
Instead of only checking if a tag exists, compare **digests** between the shared registry and local ACR. If they match → skip. If the image exists but digest differs (rebuilt with same tag) → re-import.

### 2. Skip helm dependency build when unchanged
Hash `Chart.lock` and cache it. Skip `helm dependency build` if the lock file hasn't changed. Removes the confusing 'Deleting outdated charts' message on redeploys.

### 3. Prompt before updating existing deployment
When running `azd up` against an environment with healthy running pods, the user is now asked:
- **Update in-place** (default)
- **Teardown and redeploy fresh**
- **Abort**

Prevents accidental overwrites of healthy environments.

Updated both `hooks/postprovision.sh`, `hooks/postprovision.ps1`, `hooks/preprovision.sh`, and `hooks/preprovision.ps1`.