### PR TITLE
Auto-detect vector embedding path from container policy

### DIFF
--- a/connectors/ingestion/dotnet/Services/SourceWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/SourceWatcher.cs
@@ -28,6 +28,7 @@ public class SourceWatcher : ISourceWatcher
     private ChangeFeedProcessor? _processor;
     private Container? _sourceContainer;
     private string _partitionKeyPath = "/id"; // Discovered from container properties
+    private string _vectorField = "embedding"; // Discovered from container's vector embedding policy
     private volatile bool _running;
 
     private const int MaxPatchRetries = 20; // Cap retries to prevent infinite loops on permanent errors
@@ -122,6 +123,14 @@ public class SourceWatcher : ISourceWatcher
             var pkPath = props.Resource.PartitionKeyPath; // e.g. "/partition_id"
             _partitionKeyPath = pkPath;
             _logger.LogInformation("Source {SourceId} container PK path: {PkPath}", _source.Id, pkPath);
+
+            // Discover vector embedding path from container's vector policy
+            var vecPolicy = props.Resource.VectorEmbeddingPolicy;
+            if (vecPolicy?.Embeddings?.Count > 0)
+            {
+                _vectorField = vecPolicy.Embeddings[0].Path?.TrimStart('/') ?? "embedding";
+                _logger.LogInformation("Source {SourceId} vector field: {VectorField}", _source.Id, _vectorField);
+            }
         }
         catch (Exception ex)
         {
@@ -568,7 +577,7 @@ public class SourceWatcher : ISourceWatcher
                     var floats = EmbeddingToFloatList(embedding);
                     var ops = new List<PatchOperation>
                     {
-                        PatchOperation.Set("/embedding", floats),
+                        PatchOperation.Set($"/{_vectorField}", floats),
                         PatchOperation.Set("/embedded_at", now),
                         PatchOperation.Set("/embedding_dims", floats.Count),
                         PatchOperation.Set("/pipeline_id", pipeline.Id),
@@ -660,7 +669,7 @@ public class SourceWatcher : ISourceWatcher
 
         var ops = new List<PatchOperation>
         {
-            PatchOperation.Set("/embedding", floats),
+            PatchOperation.Set($"/{_vectorField}", floats),
             PatchOperation.Set("/embedded_at", DateTime.UtcNow.ToString("O")),
             PatchOperation.Set("/embedding_dims", floats.Count),
             PatchOperation.Set("/pipeline_id", pipeline.Id),

--- a/connectors/worker/dotnet/Destinations/CosmosDbDestinationWriter.cs
+++ b/connectors/worker/dotnet/Destinations/CosmosDbDestinationWriter.cs
@@ -29,6 +29,9 @@ public class CosmosDbDestinationWriter : IDestinationWriter
         var client = GetOrCreateClient(endpoint);
         var container = client.GetDatabase(database).GetContainer(containerName);
 
+        // Read vector path from destination config (set by API probe of container's vector policy)
+        var vectorField = config.ContainsKey("vector_field") ? config["vector_field"]?.ToString() ?? "embedding" : "embedding";
+
         // Resolve partition key path
         var cacheKey = $"{endpoint}/{database}/{containerName}";
         if (!_pkPathCache.TryGetValue(cacheKey, out var pkPath))
@@ -78,7 +81,7 @@ public class CosmosDbDestinationWriter : IDestinationWriter
                 {
                     var ops = new List<PatchOperation>
                     {
-                        PatchOperation.Set("/embedding", doc.Embedding.ToList()),
+                        PatchOperation.Set($"/{vectorField}", doc.Embedding.ToList()),
                         PatchOperation.Set("/embedded_at", now),
                         PatchOperation.Set("/embedding_dims", doc.Embedding.Length),
                         PatchOperation.Set("/pipeline_id", doc.PipelineId),
@@ -100,7 +103,7 @@ public class CosmosDbDestinationWriter : IDestinationWriter
                 if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
                 {
                     _logger.LogInformation("Patch NotFound pk={PK}, falling back to upsert", pkValue);
-                    await UpsertBatchWithRetryAsync(container, pk, docs, pkField, now, ct);
+                    await UpsertBatchWithRetryAsync(container, pk, docs, pkField, vectorField, now, ct);
                     return;
                 }
 
@@ -146,6 +149,7 @@ public class CosmosDbDestinationWriter : IDestinationWriter
         PartitionKey pk,
         List<EmbeddingResult> docs,
         string pkField,
+        string vectorField,
         string now,
         CancellationToken ct)
     {
@@ -160,7 +164,7 @@ public class CosmosDbDestinationWriter : IDestinationWriter
                     {
                         ["id"] = doc.DocId,
                         ["source_ref"] = doc.SourceRef,
-                        ["embedding"] = doc.Embedding.ToList(),
+                        [vectorField] = doc.Embedding.ToList(),
                         ["embedded_at"] = now,
                         ["embedding_dims"] = doc.Embedding.Length,
                         ["pipeline_id"] = doc.PipelineId,


### PR DESCRIPTION
No more hardcoded /embedding. .NET worker reads vector_field from destination config. SourceWatcher reads VectorEmbeddingPolicy from container at startup. Python side already did this.