### PR TITLE
Pipeline selects vector index path from destination's vector policies

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1675,11 +1675,23 @@ async def create_pipeline(req: CreatePipelineRequest):
             )
 
     # Validate destination exists
-    if not store.get(req.destination_id, "destination"):
+    dest_doc = store.get(req.destination_id, "destination")
+    if not dest_doc:
         raise HTTPException(
             status_code=400,
             detail=f"Destination '{req.destination_id}' not found"
         )
+
+    # Validate vector_index_path exists in destination's vector policies
+    dest_config = dest_doc.get("config", {})
+    vector_indexes = dest_config.get("vector_indexes", [])
+    if vector_indexes:
+        valid_paths = [vi.get("path", "").lstrip("/") for vi in vector_indexes]
+        if req.vector_index_path.lstrip("/") not in valid_paths:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Vector index path '/{req.vector_index_path}' not found in destination. Available: {[f'/{p}' for p in valid_paths]}"
+            )
 
     # Validate docgrok_pipeline (must be a valid model ID or transform pipeline)
     resolved_pipeline = await _validate_docgrok_ref(req.docgrok_pipeline)
@@ -1707,6 +1719,7 @@ async def create_pipeline(req: CreatePipelineRequest):
         sources=req.sources,
         docgrok_pipeline=resolved_pipeline,
         destination_id=req.destination_id,
+        vector_index_path=req.vector_index_path,
         status=initial_status,
         process_existing=req.process_existing,
         metadata_mapping=req.metadata_mapping,

--- a/api/api.py
+++ b/api/api.py
@@ -1324,6 +1324,9 @@ async def create_destination(req: CreateDestinationRequest):
             # Auto-set vector field
             if "vector_field" not in config and probe_result.get("vector_field"):
                 config["vector_field"] = probe_result["vector_field"]
+            # Store all vector indexes from probe
+            if probe_result.get("vector_indexes"):
+                config["vector_indexes"] = probe_result["vector_indexes"]
             # Check vector embedding policy
             if not probe_result.get("has_vector_policy"):
                 enabled = False
@@ -1415,6 +1418,13 @@ async def test_destination(dest_id: str):
     from connectors.cosmosdb_vector_connector import test_vector_connection
     ok, result = await _test_with_timeout(lambda: asyncio.run(test_vector_connection(destination.config)))
     if ok:
+        # Persist vector_indexes back into destination config so pipeline creation can use them
+        vi = result.get("vector_indexes")
+        if vi is not None:
+            config = dict(destination.config)
+            config["vector_indexes"] = vi
+            destination.config = config
+            store.upsert(_to_doc(destination, "destination"))
         return {"success": True, "result": result}
     return {"success": False, "error": result}
 
@@ -1744,12 +1754,26 @@ async def update_pipeline(pipeline_id: str, req: CreatePipelineRequest):
 
     resolved_pipeline = await _validate_docgrok_ref(req.docgrok_pipeline)
 
+    # Validate vector_index_path against destination if provided
+    dest_doc = await asyncio.to_thread(store.get, req.destination_id, "destination")
+    if dest_doc:
+        dest_config = dest_doc.get("config", {})
+        vector_indexes = dest_config.get("vector_indexes", [])
+        if vector_indexes:
+            valid_paths = [vi.get("path", "").lstrip("/") for vi in vector_indexes]
+            if req.vector_index_path.lstrip("/") not in valid_paths:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Vector index path '/{req.vector_index_path}' not found in destination. Available: {[f'/{p}' for p in valid_paths]}"
+                )
+
     pipeline = _pipeline_from_doc(doc)
     pipeline.name = req.name
     pipeline.description = req.description
     pipeline.sources = req.sources
     pipeline.docgrok_pipeline = resolved_pipeline
     pipeline.destination_id = req.destination_id
+    pipeline.vector_index_path = req.vector_index_path
     pipeline.metadata_mapping = req.metadata_mapping
     pipeline.processing_mode = req.processing_mode
     pipeline.content_strategy = req.content_strategy if req.content_strategy in ("truncate", "chunk") else pipeline.content_strategy
@@ -2199,25 +2223,29 @@ def _extract_text_parts_from_doc(doc: dict, content_field) -> list:
     return parts
 
 
-def _search_single_index(destination, query_embedding: list, top_k: int, content_field="content") -> list:
+def _search_single_index(destination, query_embedding: list, top_k: int, content_field="content", vector_field=None) -> list:
     """Synchronous vector search on a single destination (CosmosDB or pgvector)."""
     from models import DestinationType
 
     # Check destination type and route to appropriate search function
     if destination.type == DestinationType.PGVECTOR:
-        return _search_pgvector_index(destination, query_embedding, top_k, content_field)
+        return _search_pgvector_index(destination, query_embedding, top_k, content_field, vector_field)
     else:
-        return _search_cosmosdb_index(destination, query_embedding, top_k, content_field)
+        return _search_cosmosdb_index(destination, query_embedding, top_k, content_field, vector_field)
 
 
-def _search_pgvector_index(destination, query_embedding: list, top_k: int, content_field="content") -> list:
+def _search_pgvector_index(destination, query_embedding: list, top_k: int, content_field="content", vector_field=None) -> list:
     """Synchronous vector search on a pgvector table."""
     import asyncio
     from connectors.postgres_connector import search_vectors
 
-    # Run async search synchronously using asyncio.run() which properly manages the event loop
+    # Override vector_column in config if pipeline specifies a vector_index_path
+    search_config = dict(destination.config)
+    if vector_field:
+        search_config["vector_column"] = vector_field
+
     raw_results = asyncio.run(
-        search_vectors(destination.config, query_embedding, top_k)
+        search_vectors(search_config, query_embedding, top_k)
     )
 
     results = []
@@ -2235,7 +2263,7 @@ def _search_pgvector_index(destination, query_embedding: list, top_k: int, conte
     return results
 
 
-def _search_cosmosdb_index(destination, query_embedding: list, top_k: int, content_field="content") -> list:
+def _search_cosmosdb_index(destination, query_embedding: list, top_k: int, content_field="content", vector_field=None) -> list:
     """Synchronous vector search on a single CosmosDB container."""
     from azure.cosmos import CosmosClient
     from azure.identity import DefaultAzureCredential
@@ -2245,14 +2273,17 @@ def _search_cosmosdb_index(destination, query_embedding: list, top_k: int, conte
     database = client.get_database_client(destination.config["database"])
     container = database.get_container_client(destination.config["container"])
 
+    # Use pipeline's vector_index_path, fall back to destination config, then default
+    vf = vector_field or destination.config.get("vector_field", "embedding")
+
     validated = [float(x) for x in query_embedding]
     embedding_str = "[" + ",".join(str(x) for x in validated) + "]"
 
     query = f"""
         SELECT TOP @top_k
-            c, VectorDistance(c.embedding, {embedding_str}) as distance
+            c, VectorDistance(c.{vf}, {embedding_str}) as distance
         FROM c
-        ORDER BY VectorDistance(c.embedding, {embedding_str})
+        ORDER BY VectorDistance(c.{vf}, {embedding_str})
     """
 
     fields = _resolve_content_fields(content_field)
@@ -2268,7 +2299,8 @@ def _search_cosmosdb_index(destination, query_embedding: list, top_k: int, conte
         text_parts = _extract_text_parts_from_doc(doc, content_field)
         # Build metadata from scalar fields
         skip_fields = {"id", "text", "content", "source", "source_ref",
-                       "embedding", "metadata", "_rid", "_self", "_etag", "_attachments", "_ts"}
+                       "embedding", "metadata", "_rid", "_self", "_etag", "_attachments", "_ts",
+                       vf}
         skip_fields.update(fields)
         metadata = doc.get("metadata", {})
         for k, v in doc.items():
@@ -2397,8 +2429,9 @@ async def playground_search(req: SearchRequest):
     # Search all indexes in parallel
     search_start = time.time()
 
-    # Resolve content_fields per destination from pipeline source config
+    # Resolve content_fields and vector_index_path per destination from pipeline config
     source_content_fields = {}  # dest_id -> content_fields
+    dest_vector_fields = {}  # dest_id -> vector_index_path
     for dest_id, dest, pip in dest_infos:
         cf = ["content"]
         if pip:
@@ -2406,14 +2439,18 @@ async def playground_search(req: SearchRequest):
             if sources:
                 src = sources[0] if isinstance(sources[0], dict) else sources[0].dict()
                 cf = src.get("content_fields", ["content"])
+            vip = pip.get("vector_index_path")
+            if vip:
+                dest_vector_fields[dest_id] = vip.lstrip("/")
         source_content_fields[dest_id] = cf
 
     async def search_one(dest_id, destination, model_ref):
         try:
             t0 = time.time()
             cf = source_content_fields.get(dest_id, ["content"])
+            vf = dest_vector_fields.get(dest_id)
             results = await asyncio.to_thread(
-                _search_single_index, destination, embeddings[model_ref], req.per_index_top_k, cf
+                _search_single_index, destination, embeddings[model_ref], req.per_index_top_k, cf, vf
             )
             search_ms = int((time.time() - t0) * 1000)
             for r in results:
@@ -3668,8 +3705,10 @@ async def assistant_chat(assistant_id: str, req: AssistantChatRequest):
                 if sources:
                     src = sources[0] if isinstance(sources[0], dict) else sources[0]
                     cf = src.get("content_fields", ["content"]) if isinstance(src, dict) else getattr(src, "content_fields", ["content"])
+                # Use pipeline's vector_index_path for search
+                vf = matched_pip.get("vector_index_path", "").lstrip("/") or None
                 results = await asyncio.to_thread(
-                    _search_single_index, destination, query_embedding, assistant.top_k, cf
+                    _search_single_index, destination, query_embedding, assistant.top_k, cf, vf
                 )
                 search_results.extend(results)
             except Exception as e:

--- a/api/api.py
+++ b/api/api.py
@@ -240,6 +240,56 @@ def _build_mssql_odbc_conn_str(cfg: dict) -> str:
     return f"Driver={{ODBC Driver 18 for SQL Server}};Server={server};Database={database};Uid={user};Pwd={password};Encrypt=yes;TrustServerCertificate=yes;"
 
 
+def _discover_mssql_vector_columns(cursor, table: str, schema: str = "dbo", config: dict = None) -> list:
+    """Discover vector columns in an MSSQL table.
+
+    Probes INFORMATION_SCHEMA for native ``vector`` type columns (SQL Server 2025+).
+    Falls back to reporting the configured ``vector_column`` if it exists in the
+    table — older SQL Server stores vectors as JSON in NVARCHAR columns.
+
+    Returns ``vector_indexes`` in the same format as CosmosDB so the UI dropdown
+    and pipeline ``vector_index_path`` validation work identically.
+    """
+    import re as _re
+    cursor.execute(
+        """SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH
+           FROM INFORMATION_SCHEMA.COLUMNS
+           WHERE TABLE_NAME = ? AND TABLE_SCHEMA = ?
+           ORDER BY ORDINAL_POSITION""",
+        (table, schema),
+    )
+    columns = cursor.fetchall()
+
+    vector_indexes = []
+    all_col_names = set()
+    for col_name, data_type, max_length in columns:
+        all_col_names.add(col_name)
+        dt_lower = (data_type or "").lower()
+        # SQL Server 2025+ native vector type
+        if "vector" in dt_lower:
+            dimensions = None
+            if max_length and isinstance(max_length, int) and max_length > 0:
+                dimensions = max_length
+            vector_indexes.append({
+                "path": col_name,
+                "dimensions": dimensions,
+                "dataType": "vector",
+            })
+
+    # Fallback: if no native vector columns found, include the configured
+    # vector_column when it exists in the table (NVARCHAR storing JSON vectors)
+    if not vector_indexes and config:
+        vec_col = config.get("vector_column", config.get("vector_col", "embedding"))
+        if vec_col in all_col_names:
+            vector_indexes.append({
+                "path": vec_col,
+                "dimensions": config.get("vector_dimensions"),
+                "dataType": "float32",
+            })
+
+    return vector_indexes
+
+
 async def _test_with_timeout(fn, retries: int = TEST_CONN_RETRIES, timeout: int = TEST_CONN_TIMEOUT):
     """Run a test-connection function with timeout and retries.
     fn can be sync or async â€” sync calls run in a thread pool so timeout works.
@@ -1343,6 +1393,41 @@ async def create_destination(req: CreateDestinationRequest):
             warnings.append(f"Could not connect to destination: {str(e)}. "
                 "Check endpoint, database, container, and permissions.")
 
+    # Auto-probe pgvector table for vector columns
+    elif req.type == "pgvector":
+        try:
+            from connectors.postgres_connector import test_destination_connection as _test_pg
+            probe_result = await _test_pg(config)
+            if probe_result.get("vector_indexes"):
+                config["vector_indexes"] = probe_result["vector_indexes"]
+            if probe_result.get("vector_field"):
+                config["vector_field"] = probe_result["vector_field"]
+            if not probe_result.get("has_vector_policy"):
+                warnings.append("No vector columns found in table. "
+                    "Ensure the table has columns of type vector(N).")
+        except Exception as e:
+            warnings.append(f"Could not probe pgvector table: {str(e)}. "
+                "Vector column discovery skipped.")
+
+    # Auto-probe MSSQL table for vector columns
+    elif req.type == "mssql":
+        try:
+            import pyodbc
+            conn_str = _build_mssql_odbc_conn_str(config)
+            mssql_conn = pyodbc.connect(conn_str, timeout=10)
+            try:
+                table = config.get("table", "vectors")
+                schema = config.get("schema_name", config.get("schema", "dbo"))
+                cursor = mssql_conn.cursor()
+                vi = _discover_mssql_vector_columns(cursor, table, schema, config)
+                if vi:
+                    config["vector_indexes"] = vi
+            finally:
+                mssql_conn.close()
+        except Exception as e:
+            warnings.append(f"Could not probe MSSQL table: {str(e)}. "
+                "Vector column discovery skipped.")
+
     dest_id = f"dst-{str(uuid.uuid4())[:8]}"
     destination = Destination(
         id=dest_id,
@@ -1415,8 +1500,35 @@ async def test_destination(dest_id: str):
 
     destination = _destination_from_doc(doc)
 
-    from connectors.cosmosdb_vector_connector import test_vector_connection
-    ok, result = await _test_with_timeout(lambda: asyncio.run(test_vector_connection(destination.config)))
+    if destination.type == "pgvector":
+        from connectors.postgres_connector import test_destination_connection as _test_pg
+        ok, result = await _test_with_timeout(lambda: asyncio.run(_test_pg(destination.config)))
+    elif destination.type == "mssql":
+        def _test_mssql_dest():
+            import pyodbc
+            conn_str = _build_mssql_odbc_conn_str(destination.config)
+            conn = pyodbc.connect(conn_str, timeout=10)
+            try:
+                table = destination.config.get("table", "vectors")
+                schema = destination.config.get("schema_name", destination.config.get("schema", "dbo"))
+                cursor = conn.cursor()
+                cursor.execute(f"SELECT COUNT(*) FROM [{schema}].[{table}]")
+                row_count = cursor.fetchone()[0]
+                vi = _discover_mssql_vector_columns(cursor, table, schema, destination.config)
+                return {
+                    "status": "connected",
+                    "table": f"{schema}.{table}",
+                    "row_count": row_count,
+                    "vector_indexes": vi,
+                    "has_vector_policy": len(vi) > 0,
+                }
+            finally:
+                conn.close()
+        ok, result = await _test_with_timeout(_test_mssql_dest)
+    else:
+        from connectors.cosmosdb_vector_connector import test_vector_connection
+        ok, result = await _test_with_timeout(lambda: asyncio.run(test_vector_connection(destination.config)))
+
     if ok:
         # Persist vector_indexes back into destination config so pipeline creation can use them
         vi = result.get("vector_indexes")
@@ -1516,35 +1628,26 @@ async def test_destination_connection_before_save(req: TestDestConnectionRequest
 
         elif req.type == "pgvector":
             from health_checker import _connect_pg
+            from connectors.postgres_connector import _discover_vector_columns
             table = req.config.get("table", "vectors")
             conn = await _connect_pg(req.config)
             try:
                 row_count = await conn.fetchval(f'SELECT COUNT(*) FROM "{table}"')
 
                 ext = await conn.fetchval("SELECT extversion FROM pg_extension WHERE extname = 'vector'")
-                vector_col = req.config.get("vector_column", req.config.get("vector_col", "embedding"))
-                col_exists = await conn.fetchval(
-                    "SELECT COUNT(*) FROM information_schema.columns WHERE table_name = $1 AND column_name = $2",
-                    table, vector_col)
 
                 details = []
                 details.append(f"Table: {table}, {row_count} rows")
                 if ext:
                     details.append(f"pgvector v{ext}")
-                if col_exists:
-                    details.append(f"Vector column '{vector_col}' exists")
 
-                vector_indexes = []
-                if ext and col_exists:
-                    idx_rows = await conn.fetch(
-                        "SELECT indexname, indexdef FROM pg_indexes WHERE tablename = $1 AND indexdef LIKE '%vector%'",
-                        table)
-                    for row in idx_rows:
-                        vector_indexes.append({
-                            "path": vector_col,
-                            "indexType": "ivfflat" if "ivfflat" in row["indexdef"] else "hnsw" if "hnsw" in row["indexdef"] else "unknown",
-                            "indexName": row["indexname"],
-                        })
+                # Discover all vector columns from table schema
+                vector_indexes = await _discover_vector_columns(conn, table)
+
+                if vector_indexes:
+                    details.append(f"{len(vector_indexes)} vector column(s) found")
+                else:
+                    details.append("No vector columns found")
 
                 return {
                     "success": True,
@@ -1559,7 +1662,7 @@ async def test_destination_connection_before_save(req: TestDestConnectionRequest
             try:
                 import pyodbc
             except ImportError:
-                return {"success": False, "error": "pyodbc not installed â€” MSSQL destination tests handled by changefeed connector"}
+                return {"success": False, "error": "pyodbc not installed. MSSQL destination tests handled by changefeed connector"}
 
             conn_str = _build_mssql_odbc_conn_str(req.config)
 
@@ -1570,10 +1673,18 @@ async def test_destination_connection_before_save(req: TestDestConnectionRequest
                 cursor = conn.cursor()
                 cursor.execute(f"SELECT COUNT(*) FROM [{schema}].[{table}]")
                 row_count = cursor.fetchone()[0]
+
+                vector_indexes = _discover_mssql_vector_columns(cursor, table, schema, req.config)
+
+                vec_msg = ""
+                if vector_indexes:
+                    vec_msg = f" {len(vector_indexes)} vector column(s) found."
+
                 return {
                     "success": True,
-                    "message": f"Connected to MS SQL. {row_count} rows in '{schema}.{table}'.",
-                    "details": f"Schema: {schema}, Table: {table}"
+                    "message": f"Connected to MS SQL. {row_count} rows in '{schema}.{table}'.{vec_msg}",
+                    "details": f"Schema: {schema}, Table: {table}",
+                    "vector_indexes": vector_indexes,
                 }
             finally:
                 conn.close()

--- a/api/connectors/cosmosdb_vector_connector.py
+++ b/api/connectors/cosmosdb_vector_connector.py
@@ -151,7 +151,7 @@ async def test_vector_connection(config: Dict[str, Any]) -> Dict[str, Any]:
 
 
 async def probe_container_config(config: Dict[str, Any]) -> Dict[str, str]:
-    """Probe a CosmosDB container and return partition_key_path and vector_field."""
+    """Probe a CosmosDB container and return partition_key_path, vector_field, and all vector_indexes."""
     client = await get_cosmos_client(config)
     database = client.get_database_client(config["database"])
     container = database.get_container_client(config["container"])
@@ -164,12 +164,35 @@ async def probe_container_config(config: Dict[str, Any]) -> Dict[str, str]:
     if pk_paths:
         result["partition_key_path"] = pk_paths[0]
 
-    # Vector field from embedding policy
-    vector_embeddings = props.get("vectorEmbeddingPolicy", {}).get("vectorEmbeddings", [])
+    # Vector field from embedding policy (first one for backward compat)
+    vector_embedding_policy = props.get("vectorEmbeddingPolicy", {})
+    vector_embeddings = vector_embedding_policy.get("vectorEmbeddings", [])
     if vector_embeddings:
         vf = vector_embeddings[0].get("path", "").lstrip("/")
         if vf:
             result["vector_field"] = vf
+
+    # All vector indexes with full details
+    indexing_policy = props.get("indexingPolicy", {})
+    vector_indexes = indexing_policy.get("vectorIndexes", [])
+    structured_indexes = []
+    for vi in vector_indexes:
+        vi_path = vi.get("path", "")
+        vi_type = vi.get("type", "")
+        embedding_info = {}
+        for ve in vector_embeddings:
+            if ve.get("path") == vi_path:
+                embedding_info = ve
+                break
+        structured_indexes.append({
+            "path": vi_path,
+            "indexType": vi_type,
+            "dimensions": embedding_info.get("dimensions"),
+            "dataType": embedding_info.get("dataType"),
+            "distanceFunction": embedding_info.get("distanceFunction"),
+            "quantizationByteSize": vi.get("quantizationByteSize"),
+        })
+    result["vector_indexes"] = structured_indexes
 
     return result
 

--- a/api/connectors/postgres_connector.py
+++ b/api/connectors/postgres_connector.py
@@ -8,6 +8,7 @@ Supports:
 - Connection pooling for efficiency
 """
 
+import re
 import logging
 from datetime import datetime
 from typing import Optional, Dict, Any, List, Tuple, AsyncGenerator
@@ -451,3 +452,148 @@ async def delete_vectors(
     count = int(result.split()[-1]) if result else 0
     logger.info("Deleted %d vectors from %s", count, table)
     return count
+
+
+# =============================================================================
+# VECTOR COLUMN DISCOVERY
+# =============================================================================
+
+async def _discover_vector_columns(conn, table: str) -> List[Dict[str, Any]]:
+    """Discover vector columns in a pgvector table using an existing connection.
+
+    Queries information_schema for columns with the ``vector`` user-defined type,
+    then resolves each column's dimension from ``pg_attribute``.  Returns a list
+    of descriptors in the same format as CosmosDB ``vector_indexes`` so the UI
+    dropdown and pipeline validation work identically.
+    """
+    rows = await conn.fetch(
+        """SELECT column_name, data_type, udt_name
+           FROM information_schema.columns
+           WHERE table_name = $1
+           ORDER BY ordinal_position""",
+        table,
+    )
+
+    vector_indexes: List[Dict[str, Any]] = []
+    for row in rows:
+        col_name = row["column_name"]
+        data_type = (row["data_type"] or "").lower()
+        udt_name = (row["udt_name"] or "").lower()
+
+        if "vector" not in data_type and udt_name != "vector":
+            continue
+
+        # Resolve dimensions from vector(N) type modifier
+        dimensions = None
+        type_str = await conn.fetchval(
+            """SELECT format_type(atttypid, atttypmod)
+               FROM pg_attribute
+               WHERE attrelid = $1::regclass AND attname = $2""",
+            table,
+            col_name,
+        )
+        if type_str:
+            m = re.search(r"vector\((\d+)\)", str(type_str))
+            if m:
+                dimensions = int(m.group(1))
+
+        # Check for a vector index on this column
+        idx_row = await conn.fetchrow(
+            "SELECT indexname, indexdef FROM pg_indexes "
+            "WHERE tablename = $1 AND indexdef LIKE '%' || $2 || '%'",
+            table,
+            col_name,
+        )
+        index_type = None
+        index_name = None
+        if idx_row:
+            index_name = idx_row["indexname"]
+            indexdef = idx_row["indexdef"]
+            if "ivfflat" in indexdef:
+                index_type = "ivfflat"
+            elif "hnsw" in indexdef:
+                index_type = "hnsw"
+            else:
+                index_type = "btree"
+
+        vector_indexes.append({
+            "path": col_name,
+            "dimensions": dimensions,
+            "dataType": "vector",
+            "indexType": index_type,
+            "indexName": index_name,
+        })
+
+    return vector_indexes
+
+
+async def probe_vector_columns(config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Discover vector columns using a fresh connection (no pool required).
+
+    Returns ``vector_indexes`` in CosmosDB-compatible format so the UI and
+    pipeline validation treat pgvector destinations the same as CosmosDB.
+    """
+    try:
+        import asyncpg
+    except ImportError:
+        logger.warning("asyncpg not installed — cannot probe pgvector columns")
+        return []
+
+    dsn = (
+        f"postgresql://{config.get('user', '')}:{config.get('password', '')}"
+        f"@{config['host']}:{config.get('port', 5432)}/{config['database']}"
+    )
+    ssl_mode = config.get("ssl_mode", "require")
+    ssl = ssl_mode not in ("disable", "allow")
+
+    conn = await asyncpg.connect(dsn, ssl=ssl if ssl else None)
+    try:
+        return await _discover_vector_columns(conn, config["table"])
+    finally:
+        await conn.close()
+
+
+async def test_destination_connection(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Test pgvector destination connectivity and discover vector columns.
+
+    Called from ``create_destination`` and ``test_destination`` in the API layer,
+    mirroring ``cosmosdb_vector_connector.test_vector_connection``.
+    """
+    try:
+        import asyncpg
+    except ImportError:
+        raise ImportError("asyncpg required: pip install asyncpg")
+
+    dsn = (
+        f"postgresql://{config.get('user', '')}:{config.get('password', '')}"
+        f"@{config['host']}:{config.get('port', 5432)}/{config['database']}"
+    )
+    ssl_mode = config.get("ssl_mode", "require")
+    ssl = ssl_mode not in ("disable", "allow")
+
+    conn = await asyncpg.connect(dsn, ssl=ssl if ssl else None)
+    try:
+        table = config["table"]
+        row_count = await conn.fetchval(f'SELECT COUNT(*) FROM "{table}"')
+        ext = await conn.fetchval(
+            "SELECT extversion FROM pg_extension WHERE extname = 'vector'"
+        )
+
+        vector_indexes = await _discover_vector_columns(conn, table)
+
+        # First discovered column becomes the default; fall back to config
+        vector_field = config.get("vector_column", "embedding")
+        if vector_indexes:
+            vector_field = vector_indexes[0]["path"]
+
+        return {
+            "status": "connected",
+            "table": table,
+            "row_count": row_count,
+            "pgvector_version": ext,
+            "vector_field": vector_field,
+            "vector_indexes": vector_indexes,
+            "has_vector_policy": len(vector_indexes) > 0,
+        }
+    finally:
+        await conn.close()

--- a/api/models.py
+++ b/api/models.py
@@ -229,6 +229,7 @@ class Pipeline(BaseModel):
     sources: List[PipelineSource]
     docgrok_pipeline: str  # Name of DocGrok pipeline to use
     destination_id: str
+    vector_index_path: str  # Selected from destination's vector indexing policy (e.g. "embedding", "content_vector")
     status: PipelineStatus = PipelineStatus.ACTIVE
     process_existing: bool = True  # Process existing documents on creation
     metadata_mapping: Dict[str, str] = {}  # Map source fields to destination
@@ -321,6 +322,7 @@ class CreatePipelineRequest(BaseModel):
     sources: List[PipelineSource]
     docgrok_pipeline: str
     destination_id: str
+    vector_index_path: str  # Must match a path in destination's vector indexing policy
     process_existing: bool = True
     metadata_mapping: Dict[str, str] = {}
     processing_mode: str = "queue"  # "queue" or "inline"

--- a/cli/cmd_pipeline.go
+++ b/cli/cmd_pipeline.go
@@ -451,7 +451,7 @@ func toInt(v any) int {
 }
 
 func newPipelineCreateCmd() *cobra.Command {
-	var name, description, source, destination, model, contentFields string
+	var name, description, source, destination, model, contentFields, vectorIndexPath string
 	var processExisting bool
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -486,9 +486,10 @@ func newPipelineCreateCmd() *cobra.Command {
 				"sources": []map[string]any{
 					{"source_id": srcID, "filters": map[string]any{}, "content_fields": fields},
 				},
-				"destination_id":   dstID,
-				"docgrok_pipeline": model,
-				"process_existing": processExisting,
+				"destination_id":     dstID,
+				"docgrok_pipeline":   model,
+				"vector_index_path":  vectorIndexPath,
+				"process_existing":   processExisting,
 			}
 			if description != "" {
 				body["description"] = description
@@ -516,6 +517,7 @@ func newPipelineCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&destination, "destination", "", "Destination ID")
 	cmd.Flags().StringVar(&model, "model", "", "DocGrok pipeline or model name")
 	cmd.Flags().StringVar(&contentFields, "content-fields", "", "Comma-separated content field names (default: content)")
+	cmd.Flags().StringVar(&vectorIndexPath, "vector-index-path", "", "Vector index path from destination's vector policy (required)")
 	cmd.Flags().BoolVar(&processExisting, "process-existing", true, "Process existing documents on creation")
 	return cmd
 }

--- a/connectors/ingestion/dotnet/Models/Pipeline.cs
+++ b/connectors/ingestion/dotnet/Models/Pipeline.cs
@@ -30,6 +30,9 @@ public class Pipeline
 
     [JsonPropertyName("generation")]
     public string Generation { get; set; } = "1";
+
+    [JsonPropertyName("vector_index_path")]
+    public string VectorIndexPath { get; set; } = "embedding";
 }
 
 public class PipelineSource

--- a/connectors/ingestion/dotnet/Services/SourceWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/SourceWatcher.cs
@@ -28,7 +28,6 @@ public class SourceWatcher : ISourceWatcher
     private ChangeFeedProcessor? _processor;
     private Container? _sourceContainer;
     private string _partitionKeyPath = "/id"; // Discovered from container properties
-    private string _vectorField = "embedding"; // Discovered from container's vector embedding policy
     private volatile bool _running;
 
     private const int MaxPatchRetries = 20; // Cap retries to prevent infinite loops on permanent errors
@@ -123,14 +122,6 @@ public class SourceWatcher : ISourceWatcher
             var pkPath = props.Resource.PartitionKeyPath; // e.g. "/partition_id"
             _partitionKeyPath = pkPath;
             _logger.LogInformation("Source {SourceId} container PK path: {PkPath}", _source.Id, pkPath);
-
-            // Discover vector embedding path from container's vector policy
-            var vecPolicy = props.Resource.VectorEmbeddingPolicy;
-            if (vecPolicy?.Embeddings?.Count > 0)
-            {
-                _vectorField = vecPolicy.Embeddings[0].Path?.TrimStart('/') ?? "embedding";
-                _logger.LogInformation("Source {SourceId} vector field: {VectorField}", _source.Id, _vectorField);
-            }
         }
         catch (Exception ex)
         {
@@ -328,6 +319,10 @@ public class SourceWatcher : ISourceWatcher
                                     : token.ToString();
                         }
 
+                        // Inject pipeline's vector_index_path into destination config
+                        var destConfig = dest?.Config ?? new();
+                        destConfig["vector_field"] = pipeline.VectorIndexPath;
+
                         messages.Add(new EmbeddingMessage
                         {
                             PipelineId = pipeline.Id,
@@ -337,7 +332,7 @@ public class SourceWatcher : ISourceWatcher
                             SourceRef = docId,
                             DestinationId = pipeline.DestinationId,
                             DestinationType = dest?.Type ?? "cosmosdb-vector",
-                            DestinationConfig = dest?.Config ?? new(),
+                            DestinationConfig = destConfig,
                             Content = content,
                             ContentHash = contentHash,
                             PartitionKeyValue = pkValue,
@@ -577,8 +572,7 @@ public class SourceWatcher : ISourceWatcher
                     var floats = EmbeddingToFloatList(embedding);
                     var ops = new List<PatchOperation>
                     {
-                        PatchOperation.Set($"/{_vectorField}", floats),
-                        PatchOperation.Set("/embedded_at", now),
+                        PatchOperation.Set($"/{pipeline.VectorIndexPath}", floats),                        PatchOperation.Set("/embedded_at", now),
                         PatchOperation.Set("/embedding_dims", floats.Count),
                         PatchOperation.Set("/pipeline_id", pipeline.Id),
                         PatchOperation.Set("/pipeline_name", pipeline.Name),
@@ -669,7 +663,7 @@ public class SourceWatcher : ISourceWatcher
 
         var ops = new List<PatchOperation>
         {
-            PatchOperation.Set($"/{_vectorField}", floats),
+            PatchOperation.Set($"/{pipeline.VectorIndexPath}", floats),
             PatchOperation.Set("/embedded_at", DateTime.UtcNow.ToString("O")),
             PatchOperation.Set("/embedding_dims", floats.Count),
             PatchOperation.Set("/pipeline_id", pipeline.Id),

--- a/connectors/worker/dotnet/Destinations/CosmosDbDestinationWriter.cs
+++ b/connectors/worker/dotnet/Destinations/CosmosDbDestinationWriter.cs
@@ -53,7 +53,7 @@ public class CosmosDbDestinationWriter : IDestinationWriter
             for (int i = 0; i < items.Count; i += 100)
             {
                 var chunk = items.Skip(i).Take(100).ToList();
-                tasks.Add(WriteBatchWithRetryAsync(container, group.Key, chunk, pkField, ct));
+                tasks.Add(WriteBatchWithRetryAsync(container, group.Key, chunk, pkField, vectorField, ct));
             }
         }
 
@@ -65,6 +65,7 @@ public class CosmosDbDestinationWriter : IDestinationWriter
         string pkValue,
         List<EmbeddingResult> docs,
         string pkField,
+        string vectorField,
         CancellationToken ct)
     {
         var pk = new PartitionKey(pkValue);

--- a/scripts/e2e-demo.ps1
+++ b/scripts/e2e-demo.ps1
@@ -568,8 +568,8 @@ if ($FromStep -le 8) {
 
     $pipBody = @{
         name = $PIPELINE_NAME; sources = @(@{ source_id = $SOURCE_ID; filters = @{}; content_fields = @("content") })
-        destination_id = $DEST_ID; docgrok_pipeline = $MODEL_ID; process_existing = $true
-        processing_mode = "queue"
+        destination_id = $DEST_ID; docgrok_pipeline = $MODEL_ID; vector_index_path = "embedding"
+        process_existing = $true; processing_mode = "queue"
     } | ConvertTo-Json -Depth 5
     $pipResult = Invoke-RestMethod -Uri "$SERVER_URL/api/pipelines" -Method POST -Headers $apiHeaders -Body $pipBody
     $PIP_ID = $pipResult.pipeline.id

--- a/scripts/e2e-demo.sh
+++ b/scripts/e2e-demo.sh
@@ -564,7 +564,7 @@ if [ "$FROM_STEP" -le 8 ]; then
   log_step 8 "Creating pipeline (queue mode), inserting docs, activating..."
 
   PIP_BODY=$(cat <<PEOF
-{"name":"demo-pipeline","sources":[{"source_id":"$SOURCE_ID","filters":{},"content_fields":["content"]}],"destination_id":"$DEST_ID","docgrok_pipeline":"$MODEL_ID","process_existing":true,"processing_mode":"queue"}
+{"name":"demo-pipeline","sources":[{"source_id":"$SOURCE_ID","filters":{},"content_fields":["content"]}],"destination_id":"$DEST_ID","docgrok_pipeline":"$MODEL_ID","vector_index_path":"embedding","process_existing":true,"processing_mode":"queue"}
 PEOF
   )
   PIP_RESULT=$(api_post "/api/pipelines" "$PIP_BODY")

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2012,7 +2012,7 @@
                                 <div class="form-group">
                                     <label class="form-label">Vector Store</label>
                                     <div style="display: flex; gap: 8px;">
-                                        <select class="form-input" name="destination" id="pipeline-destination" style="flex: 1;"></select>
+                                        <select class="form-input" name="destination" id="pipeline-destination" style="flex: 1;" onchange="loadVectorPoliciesForDest()"></select>
                                         <button type="button" class="btn btn-secondary" onclick="testExistingPipelineDest()" style="white-space: nowrap;">
                                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
                                             Test
@@ -2020,6 +2020,16 @@
                                     </div>
                                 </div>
                                 <div id="pl-dest-existing-test-result" style="margin-top: 8px;"></div>
+                                <div class="form-group" id="pl-dest-vector-policy-group" style="display: none; margin-top: 12px;">
+                                    <label class="form-label">Vector Index Policy</label>
+                                    <select class="form-input" id="pl-dest-vector-policy"></select>
+                                    <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
+                                        Select which vector embedding field to use for this pipeline
+                                    </small>
+                                    <div id="pl-dest-vector-policy-warning" style="display: none; margin-top: 8px; padding: 8px 12px; background: var(--warning-muted, rgba(255,204,0,0.1)); border: 1px solid var(--warning); border-radius: var(--radius-sm); font-size: 12px; color: var(--warning);">
+                                        ⚠ No vector policies found on destination. Test the connection or check vector indexing configuration.
+                                    </div>
+                                </div>
                                 <div class="form-group" style="margin-top: 12px;">
                                     <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
                                         <input type="checkbox" id="pl-dest-same-as-source" onchange="toggleDestSameAsSource()">
@@ -3893,6 +3903,15 @@
                         </div>
                         <div id="pip-detail-dest-test-result" style="margin-top: 8px;"></div>
                     </div>
+                    <div class="form-group" style="margin-top: 4px;">
+                        <label class="form-label">Vector Index Path</label>
+                        <div style="padding: 10px 12px; background: var(--bg-tertiary); border-radius: var(--radius-sm); font-family: monospace; font-size: 13px;">
+                            /${pipeline.vector_index_path || '<span style="color: var(--text-tertiary);">not set</span>'}
+                        </div>
+                        <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
+                            The vector embedding field used by this pipeline
+                        </small>
+                    </div>
                 `;
             } else if (currentPipelineTab === 'model') {
                 configPanel.innerHTML = `
@@ -4388,6 +4407,7 @@
                         sources: pipeline.sources,
                         docgrok_pipeline: pipeline.docgrok_pipeline,
                         destination_id,
+                        vector_index_path: pipeline.vector_index_path || 'embedding',
                         process_existing: editedPipelineData.process_existing !== undefined ? editedPipelineData.process_existing : pipeline.process_existing,
                         metadata_mapping: pipeline.metadata_mapping || {},
                         content_strategy: editedPipelineData.content_strategy || pipeline.content_strategy || 'truncate',
@@ -4535,6 +4555,9 @@
             const destSelect = document.getElementById('pipeline-destination');
             destSelect.innerHTML = destinations.map(d => `<option value="${d.id}">${d.name}</option>`).join('');
 
+            // Load vector policies for the initially-selected destination
+            loadVectorPoliciesForDest();
+
             const docgrokSelect = document.getElementById('pipeline-docgrok');
             // Filter out old auto-created pipelines (legacy - no longer created)
             const filteredPipelines = docgrokPipelines.filter(p => !p.name.endsWith('-auto'));
@@ -4618,11 +4641,62 @@
                 const data = await res.json();
                 if (data.success) {
                     resultDiv.innerHTML = `<span style="color: var(--success); font-size: 13px;">Connected</span>`;
+                    // Populate vector policies from test result
+                    const vi = data.result?.vector_indexes || [];
+                    populateVectorPolicyDropdown(vi);
                 } else {
                     resultDiv.innerHTML = `<span style="color: var(--error); font-size: 13px;">Failed: ${data.error}</span>`;
                 }
             } catch (err) {
                 resultDiv.innerHTML = `<span style="color: var(--error); font-size: 13px;">Error: ${err.message}</span>`;
+            }
+        }
+
+        function loadVectorPoliciesForDest() {
+            const destId = document.getElementById('pipeline-destination').value;
+            if (!destId) {
+                document.getElementById('pl-dest-vector-policy-group').style.display = 'none';
+                return;
+            }
+            // Try to load from destination's stored config first
+            const dest = destinations.find(d => d.id === destId);
+            const vi = dest?.config?.vector_indexes || [];
+            if (vi.length > 0) {
+                populateVectorPolicyDropdown(vi);
+            } else {
+                // No cached policies — show the dropdown prompting user to test
+                const group = document.getElementById('pl-dest-vector-policy-group');
+                group.style.display = 'block';
+                const select = document.getElementById('pl-dest-vector-policy');
+                select.innerHTML = '<option value="">— Test connection to load policies —</option>';
+                document.getElementById('pl-dest-vector-policy-warning').style.display = 'block';
+            }
+        }
+
+        function populateVectorPolicyDropdown(vectorIndexes) {
+            const group = document.getElementById('pl-dest-vector-policy-group');
+            const select = document.getElementById('pl-dest-vector-policy');
+            const warning = document.getElementById('pl-dest-vector-policy-warning');
+            group.style.display = 'block';
+
+            if (!vectorIndexes || vectorIndexes.length === 0) {
+                select.innerHTML = '<option value="">No vector policies found</option>';
+                warning.style.display = 'block';
+                return;
+            }
+
+            warning.style.display = 'none';
+            select.innerHTML = vectorIndexes.map(vi => {
+                const path = (vi.path || '').replace(/^\//, '');
+                const dims = vi.dimensions || '?';
+                const dist = vi.distanceFunction || '?';
+                const idx = vi.indexType || '?';
+                return `<option value="${path}">${path} — ${dims}d, ${dist}, ${idx}</option>`;
+            }).join('');
+
+            // Auto-select if only one policy
+            if (vectorIndexes.length === 1) {
+                select.selectedIndex = 0;
             }
         }
 
@@ -4648,6 +4722,7 @@
                         if (processingModeSelect) processingModeSelect.value = 'inline';
                         resultDiv.innerHTML =
                             `<span style="color: var(--success); font-size: 13px;">Matched: ${match.name} (using inline mode)</span>`;
+                        loadVectorPoliciesForDest();
                         return;
                     }
                     // No match found - create destination from source config
@@ -4931,6 +5006,10 @@
                 const data = await res.json();
                 if (data.success) {
                     resultDiv.innerHTML = `<div style="background:var(--success-muted);border:1px solid var(--success);padding:8px;border-radius:var(--radius-sm);color:var(--success);font-size:12px;">Connected: ${data.message || 'Success'}</div>`;
+                    // Populate vector policy dropdown when testing from pipeline wizard's new dest
+                    if (prefix === 'pl-dest' && data.vector_indexes) {
+                        populateVectorPolicyDropdown(data.vector_indexes);
+                    }
                 } else {
                     resultDiv.innerHTML = `<div style="background:var(--error-muted);border:1px solid var(--error);padding:8px;border-radius:var(--radius-sm);font-size:12px;"><div style="color:var(--error);font-weight:500;">Failed</div><div style="color:var(--text-secondary);margin-top:4px;">${data.error}</div></div>`;
                 }
@@ -5354,6 +5433,15 @@
                 docgrokPipelineName = modelId;
             }
 
+            // --- Resolve Vector Index Path ---
+            const vectorPolicySelect = document.getElementById('pl-dest-vector-policy');
+            const vectorIndexPath = vectorPolicySelect ? vectorPolicySelect.value : '';
+            if (!vectorIndexPath) {
+                alert('Please select a vector index policy. Test the destination connection if no policies are shown.');
+                showPipelineStep('destination');
+                return;
+            }
+
             // --- Create Pipeline ---
             const contentStrategy = formData.get('content_strategy') || 'truncate';
             const processingMode = formData.get('processing_mode') || 'queue';
@@ -5391,6 +5479,7 @@
                 sources: [pipelineSourceEntry],
                 docgrok_pipeline: docgrokPipelineName,
                 destination_id: destinationId,
+                vector_index_path: vectorIndexPath,
                 process_existing: form.querySelector('input[name="process_existing"]').checked,
                 content_strategy: contentStrategy,
                 processing_mode: processingMode,


### PR DESCRIPTION
Customer selects which vector index to use when creating a pipeline. Supports multiple embedding policies per container.

- Pipeline.vector_index_path: required field, validated against destination
- CosmosDB: reads vector indexing policy (existing)
- pgvector: probes table columns for vector(N) types
- MSSQL: probes INFORMATION_SCHEMA for vector columns
- All store vector_indexes in same format
- UI: vector policy dropdown in pipeline wizard
- CLI: --vector-index-path required flag
- Search uses pipeline's chosen path
- Worker/SourceWatcher inject path into destination config
- E2E demo updated