### PR TITLE
Remove non-Azure destinations, fix eval helm, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Sources                  Processing              Destinations
 Azure Blob Storage ─┐                         ┌→ CosmosDB Vector
 CosmosDB           ─┼─→ DocGrok Pipelines ───┤→ pgvector
 PostgreSQL         ─┤   (embed, OCR, chunk)   └→ MSSQL
-S3 / HTTP          ─┘
+MSSQL              ─┘
 ```
 
 This guide walks you through deploying OmniVec and running your first end-to-end pipeline.
@@ -292,8 +292,6 @@ This removes the resource group, all Azure services, and local environment confi
 | `cosmosdb` | endpoint, database, container |
 | `azure-blob` | account_url, container, prefix |
 | `postgresql` | host, port, database, table |
-| `s3` | bucket, prefix, region |
-| `http` | url, method, headers, auth_type |
 | `mssql` | host, port, database, table |
 
 **Destinations** are where vectors are stored. When you test a destination, OmniVec probes its vector indexing policy and returns available vector paths. You pick one when creating a pipeline.

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -104,8 +104,7 @@ omnivec source delete <id> -y
 | `azure-blob` | `account_url`, `container` | `prefix` |
 | `cosmosdb` | `endpoint`, `database`, `container` | `query` |
 | `postgresql` | `host`, `database`, `table` | `port`, `user`, `password`, `ssl_mode` |
-| `s3` | `bucket` | `prefix`, `region` |
-| `http` | `url` | `method`, `headers`, `auth_type` |
+| `mssql` | `host`, `database`, `table` | `port`, `user`, `password` |
 
 > **Note:** Content extraction config (`content_fields`, `content_mode`, `file_types`) is configured per-pipeline on the pipeline source entry, not on the source itself.
 
@@ -158,10 +157,13 @@ omnivec pipeline create \
   --destination <dst-id> \
   --model text-azure \
   --content-fields content \
+  --content-strategy truncate \
   --vector-index-path /embedding \
   --process-existing
 
-# Update a pipeline
+# Update a pipeline (content config, strategy, chunking)
+omnivec pipeline update <id> --content-strategy chunk --chunk-size 1000 --chunk-overlap 200
+omnivec pipeline update <id> --content-fields "title,content" --doc-id-pattern "{source}-chunk-{chunk}"
 omnivec pipeline update <id> --name "Renamed" --description "Updated"
 
 # Pause / Resume / Run / Reset / Delete
@@ -181,6 +183,12 @@ omnivec pipeline delete <id> -y
 | `--destination` | Yes | — | Destination ID |
 | `--model` | Yes | — | DocGrok pipeline name (e.g., `text-azure`, `pdf-vision`) |
 | `--content-fields` | No | `content` | Comma-separated field names to embed |
+| `--content-mode` | No | `field` | Content extraction mode: `field`, `blob_url`, `http_url`, `s3_url` |
+| `--file-types` | No | — | Comma-separated file type filters (e.g., `txt,pdf,md`) |
+| `--content-strategy` | No | `truncate` | Content strategy: `truncate` or `chunk` |
+| `--chunk-size` | No | `1000` | Chunk size in characters (used with `--content-strategy=chunk`) |
+| `--chunk-overlap` | No | `200` | Chunk overlap in characters |
+| `--doc-id-pattern` | No | `{source}` | Document ID pattern (e.g., `{source}-chunk-{chunk}`) |
 | `--vector-index-path` | No | — | Vector index path from destination's vector policy (e.g., `/embedding`) |
 | `--description` | No | — | Pipeline description |
 | `--process-existing` | No | true | Process existing documents on creation |
@@ -244,6 +252,12 @@ Manage embedding models in DocGrok.
 ```bash
 # List models
 omnivec model list
+
+# Show model details
+omnivec model show <name>
+
+# Test model connectivity
+omnivec model test <name>
 
 # Add an Azure OpenAI model
 omnivec model add \

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -32,11 +32,12 @@ A source is a connection to a data store. Sources store **connection info only**
 ### Creating a Source
 
 1. Navigate to **Sources** and click **+ New Source**.
-2. Enter a **name** and select the **source type** (Azure Blob, CosmosDB, PostgreSQL, S3, HTTP).
+2. Enter a **name** and select the **source type** (Azure Blob, CosmosDB, PostgreSQL, MSSQL).
 3. Fill in the connection config:
    - **Azure Blob:** `account_url`, `container`, optional `prefix`
    - **CosmosDB:** `endpoint`, `database`, `container`
    - **PostgreSQL:** `host`, `port`, `database`, `table`
+   - **MSSQL:** `host`, `port`, `database`, `table`
 4. Click **Test Connection** to verify connectivity before saving.
 5. Click **Create**.
 
@@ -61,6 +62,8 @@ A destination is where vector embeddings are stored.
 2. Enter a **name** and select the type (CosmosDB Vector, pgvector, MSSQL).
 3. Fill in connection config:
    - **CosmosDB Vector:** `endpoint`, `database`, `container`
+   - **pgvector:** `host`, `port`, `database`, `table`, `vector_column`, `dimensions`
+   - **MSSQL:** `host`, `port`, `database`, `table`
 4. Click **Test Connection** — this probes the container and returns the **vector indexing policy** (available embedding paths with dimensions, distance function, and index type).
 5. Click **Create**.
 

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -488,44 +488,85 @@ fi
 
 IMAGE_TAG="latest"
 
-# Build helm command (POSIX-compatible — no bash arrays)
-HELM_CMD="helm upgrade --install omnivec ${ROOT_DIR}/helm/omnivec \
-  --kube-context ${KUBE_CONTEXT} \
-  --namespace omnivec \
-  --set global.imageRegistry=${ACR_LOGIN_SERVER} \
-  --set azure.workloadIdentity.clientId=${IDENTITY_CLIENT_ID} \
-  --set azure.cosmos.endpoint=${COSMOS_ENDPOINT} \
-  --set api.image.tag=${IMAGE_TAG} \
-  --set controller.image.tag=${IMAGE_TAG} \
-  --set web.image.tag=${IMAGE_TAG} \
-  --set changefeed.image.tag=${IMAGE_TAG} \
-  --set docgrok.global.imageRegistry=${ACR_LOGIN_SERVER} \
-  --set docgrok.azure.workloadIdentity.clientId=${IDENTITY_CLIENT_ID} \
-  --set docgrok.azure.cosmos.endpoint=${COSMOS_ENDPOINT} \
-  --set docgrok.azure.cosmos.database=omnivec \
-  --set docgrok.azure.cosmos.container=metadata \
-  --set docgrok.docgrok.image.tag=${IMAGE_TAG} \
-  --set api.adminToken=${ADMIN_TOKEN} \
-  --set dotnetWorker.enabled=true \
-  --set web.service.dnsLabel=${INSTANCE_ID}"
+# Write helm values to a temp file (avoids fragile eval + string concatenation)
+HELM_VALUES_FILE=$(mktemp /tmp/omnivec-helm-values.XXXXXX.yaml)
+cat > "$HELM_VALUES_FILE" <<EOF
+global:
+  imageRegistry: "${ACR_LOGIN_SERVER}"
+azure:
+  workloadIdentity:
+    clientId: "${IDENTITY_CLIENT_ID}"
+  cosmos:
+    endpoint: "${COSMOS_ENDPOINT}"
+api:
+  image:
+    tag: "${IMAGE_TAG}"
+  adminToken: "${ADMIN_TOKEN}"
+controller:
+  image:
+    tag: "${IMAGE_TAG}"
+web:
+  image:
+    tag: "${IMAGE_TAG}"
+  service:
+    dnsLabel: "${INSTANCE_ID}"
+changefeed:
+  image:
+    tag: "${IMAGE_TAG}"
+dotnetWorker:
+  enabled: true
+docgrok:
+  global:
+    imageRegistry: "${ACR_LOGIN_SERVER}"
+  azure:
+    workloadIdentity:
+      clientId: "${IDENTITY_CLIENT_ID}"
+    cosmos:
+      endpoint: "${COSMOS_ENDPOINT}"
+      database: "omnivec"
+      container: "metadata"
+  docgrok:
+    image:
+      tag: "${IMAGE_TAG}"
+EOF
 
 if [ -n "$KEYVAULT_URI" ]; then
-  HELM_CMD="$HELM_CMD \
-  --set azure.keyVault.uri=${KEYVAULT_URI}"
+  cat >> "$HELM_VALUES_FILE" <<EOF
+  keyVault:
+    uri: "${KEYVAULT_URI}"
+EOF
 fi
 
+# Add optional values via yq-style append (plain echo since YAML is simple)
 if [ -n "$SB_ENDPOINT" ]; then
-  HELM_CMD="$HELM_CMD \
-  --set azure.serviceBus.namespace=${SB_ENDPOINT}"
+  # Append under azure: (already exists in the file, so use separate --set for these)
+  :
 fi
 
-if [ "$ENABLE_BLOB_SOURCE" = "true" ]; then
-  HELM_CMD="$HELM_CMD \
-  --set azure.storage.accountName=${STORAGE_ACCOUNT} \
-  --set azure.storage.blobEndpoint=${STORAGE_BLOB_ENDPOINT}"
-fi
+# Build helm command as a proper argument list using a function
+run_helm_deploy() {
+  set -- helm upgrade --install omnivec "${ROOT_DIR}/helm/omnivec" \
+    --kube-context "$KUBE_CONTEXT" \
+    --namespace omnivec \
+    --values "$HELM_VALUES_FILE"
 
-HELM_CMD="$HELM_CMD --wait --timeout 10m --atomic"
+  if [ -n "$KEYVAULT_URI" ]; then
+    set -- "$@" --set "azure.keyVault.uri=${KEYVAULT_URI}"
+  fi
+
+  if [ -n "$SB_ENDPOINT" ]; then
+    set -- "$@" --set "azure.serviceBus.namespace=${SB_ENDPOINT}"
+  fi
+
+  if [ "$ENABLE_BLOB_SOURCE" = "true" ]; then
+    set -- "$@" --set "azure.storage.accountName=${STORAGE_ACCOUNT}" \
+                --set "azure.storage.blobEndpoint=${STORAGE_BLOB_ENDPOINT}"
+  fi
+
+  set -- "$@" --wait --timeout 10m --atomic
+
+  "$@"
+}
 
 # Detect stuck Helm release (pending-install / pending-upgrade from interrupted deploy)
 set +e
@@ -547,9 +588,12 @@ fi
 
 # Execute
 set +e
-eval $HELM_CMD
+run_helm_deploy
 helm_rc=$?
 set -e
+
+# Clean up temp values file
+rm -f "$HELM_VALUES_FILE"
 
 if [ "$helm_rc" -ne 0 ]; then
   printf "${RED}Helm deploy failed. Collecting pod diagnostics...${NC}\n"

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -3135,7 +3135,7 @@
                         ${dh && dh.status !== 'healthy' ? `<div style="font-size: 11px; color: ${dh.status === 'warning' ? 'var(--warning)' : 'var(--error)'}; padding-left: 16px;">${dh.checks?.find(c => c.status === 'fail' || c.status === 'warn')?.detail?.substring(0, 80) || dh.status}</div>` : ''}
                         ${pkPath ? `<div style="font-size: 11px; color: var(--text-tertiary); padding-left: 16px;">PK: ${pkPath}${vecField ? ' | Vector: /' + vecField : ''}</div>` : ''}
                     </td>
-                    <td><span class="badge badge-success">${d.type === 'cosmosdb-vector' ? 'CosmosDB Vector' : d.type === 'pgvector' ? 'pgvector' : d.type === 'pinecone' ? 'Pinecone' : d.type === 'milvus' ? 'Milvus' : d.type === 'qdrant' ? 'Qdrant' : d.type}</span></td>
+                    <td><span class="badge badge-success">${d.type === 'cosmosdb-vector' ? 'CosmosDB Vector' : d.type === 'pgvector' ? 'pgvector' : d.type === 'mssql' ? 'MSSQL' : d.type}</span></td>
                     <td class="mono">${d.config?.endpoint || '-'}</td>
                     <td>${statusBadge}</td>
                     <td>${healthBadge}</td>
@@ -3179,9 +3179,8 @@
             const config = dest.config || {};
 
             const destTypeDisplay = dest.type === 'cosmosdb-vector' ? 'CosmosDB Vector' :
-                                    dest.type === 'pinecone' ? 'Pinecone' :
-                                    dest.type === 'milvus' ? 'Milvus' :
-                                    dest.type === 'qdrant' ? 'Qdrant' : dest.type;
+                                    dest.type === 'pgvector' ? 'pgvector' :
+                                    dest.type === 'mssql' ? 'MSSQL' : dest.type;
 
             const destIcon = dest.type === 'cosmosdb-vector'
                 ? '<svg viewBox="0 0 24 24" fill="none" stroke="var(--accent-primary)" stroke-width="1.5" width="32" height="32"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>'
@@ -3262,17 +3261,6 @@
                             <input type="text" class="form-input" id="dest-detail-container" value="${config.container || ''}" oninput="markDestDetailDirty()">
                         </div>
                     `;
-                } else if (dest.type === 'pinecone') {
-                    configFields = `
-                        <div class="form-group">
-                            <label class="form-label">Index Name</label>
-                            <input type="text" class="form-input" id="dest-detail-index" value="${config.index || ''}">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">Environment</label>
-                            <input type="text" class="form-input" id="dest-detail-environment" value="${config.environment || ''}">
-                        </div>
-                    `;
                 } else if (dest.type === 'pgvector') {
                     configFields = `
                         <div class="form-group">
@@ -3302,17 +3290,6 @@
                         <div class="form-group">
                             <label class="form-label">Vector Dimensions</label>
                             <input type="number" class="form-input" id="dest-detail-pg-dimensions" value="${config.vector_dimensions || 1536}" oninput="markDestDetailDirty()">
-                        </div>
-                    `;
-                } else {
-                    configFields = `
-                        <div class="form-group">
-                            <label class="form-label">Host</label>
-                            <input type="text" class="form-input" id="dest-detail-host" value="${config.host || ''}" placeholder="localhost:19530">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">Collection</label>
-                            <input type="text" class="form-input" id="dest-detail-collection" value="${config.collection || ''}">
                         </div>
                     `;
                 }
@@ -3468,11 +3445,6 @@
                 if (vecColEl) editedDestData.vector_column = vecColEl.value;
                 if (contentColEl) editedDestData.content_column = contentColEl.value;
                 if (dimsEl) editedDestData.vector_dimensions = parseInt(dimsEl.value) || 1536;
-            } else {
-                const hostEl = document.getElementById('dest-detail-host');
-                const collEl = document.getElementById('dest-detail-collection');
-                if (hostEl) editedDestData.host = hostEl.value;
-                if (collEl) editedDestData.collection = collEl.value;
             }
         }
 
@@ -4998,12 +4970,6 @@
                         <input type="text" class="form-input" id="${prefix}-database" placeholder="vectors"></div>
                     <div class="form-group"><label class="form-label">Container</label>
                         <input type="text" class="form-input" id="${prefix}-container" placeholder="embeddings"></div>`;
-            } else if (type === 'pinecone') {
-                container.innerHTML = `
-                    <div class="form-group"><label class="form-label">Index</label>
-                        <input type="text" class="form-input" id="${prefix}-index" placeholder="my-index"></div>
-                    <div class="form-group"><label class="form-label">Namespace (optional)</label>
-                        <input type="text" class="form-input" id="${prefix}-namespace" placeholder="default"></div>`;
             } else if (type === 'pgvector') {
                 container.innerHTML = `
                     <div class="form-group"><label class="form-label">Host</label>
@@ -5022,12 +4988,6 @@
                         <select class="form-input" id="${prefix}-index-type">
                             <option value="ivfflat">IVFFlat</option><option value="hnsw">HNSW</option>
                         </select></div>`;
-            } else if (type === 'milvus' || type === 'qdrant') {
-                container.innerHTML = `
-                    <div class="form-group"><label class="form-label">Endpoint</label>
-                        <input type="text" class="form-input" id="${prefix}-endpoint" placeholder="https://${type}-host:${type === 'milvus' ? '19530' : '6333'}"></div>
-                    <div class="form-group"><label class="form-label">Collection</label>
-                        <input type="text" class="form-input" id="${prefix}-collection" placeholder="embeddings"></div>`;
             }
             document.getElementById(`${prefix}-test-result`).innerHTML = '';
         }
@@ -5152,10 +5112,6 @@
                     database: document.getElementById(`${prefix}-database`)?.value || '',
                     container: document.getElementById(`${prefix}-container`)?.value || ''
                 };
-            } else if (destType === 'pinecone') {
-                config = { index: document.getElementById(`${prefix}-index`)?.value || '', namespace: document.getElementById(`${prefix}-namespace`)?.value || '' };
-            } else if (destType === 'milvus' || destType === 'qdrant') {
-                config = { endpoint: document.getElementById(`${prefix}-endpoint`)?.value || '', collection: document.getElementById(`${prefix}-collection`)?.value || '' };
             }
             return { name: document.getElementById(`${prefix}-name`)?.value || '', type: destType, config };
         }


### PR DESCRIPTION
## Changes

### Web UI
- Remove Pinecone/Milvus/Qdrant from all destination code paths (display, detail, config capture, form collection)
- Only Azure-supported destinations remain: CosmosDB Vector, pgvector, MSSQL

### Hooks
- Replace fragile \val \\ with temp YAML values file + POSIX \set --\ argument list
- Eliminates shell metacharacter risks

### Docs
- **cli-guide.md**: Add 6 new pipeline create flags, pipeline update with content config, model show/test commands, remove S3/HTTP
- **user-guide.md**: Remove S3/HTTP sources, add pgvector/MSSQL dest config details
- **README.md**: Update diagram and source table (replace S3/HTTP with MSSQL)

### Images
All 6 core images rebuilt and pushed to omnivecregistry.
