### PR TITLE
Fix diagnose.sh resource parsing on Linux

### DIFF
--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -140,8 +140,17 @@ if [ -n "$ENV_NAME" ]; then
     [ -n "$IDENTITY_NAME" ] && pass "Managed Identity: $IDENTITY_NAME" || warn "No Managed Identity found"
 
     if [ -n "$AKS_NAME" ]; then
-      az aks get-credentials --resource-group "$RG" --name "$AKS_NAME" --overwrite-existing 2>/dev/null
+      # Get credentials — show error if it fails (common: kubelogin not installed)
+      if az aks get-credentials --resource-group "$RG" --name "$AKS_NAME" --overwrite-existing 2>&1 | grep -qi "error\|fail"; then
+        # Retry without admin (default uses kubelogin)
+        az aks get-credentials --resource-group "$RG" --name "$AKS_NAME" --overwrite-existing --admin 2>/dev/null || true
+      fi
       KUBE_CONTEXT="$AKS_NAME"
+      # Verify kubectl works
+      if ! kubectl --context "$KUBE_CONTEXT" cluster-info >/dev/null 2>&1; then
+        warn "kubectl cannot connect to AKS (credentials may need kubelogin)" "az aks install-cli && az aks get-credentials --resource-group $RG --name $AKS_NAME --overwrite-existing"
+        KUBE_CONTEXT=""
+      fi
     fi
   else
     fail "Resource group $RG does not exist" "azd up"
@@ -302,17 +311,17 @@ fi
 
 # CosmosDB RBAC
 if [ -n "$IDENTITY_NAME" ] && [ -n "$COSMOS_NAME" ] && [ -n "$RG" ]; then
-  _principal=$(az identity show --name "$IDENTITY_NAME" --resource-group "$RG" --query "principalId" -o tsv 2>/dev/null)
-  _cosmos_id=$(az cosmosdb show --name "$COSMOS_NAME" --resource-group "$RG" --query "id" -o tsv 2>/dev/null)
+  _principal=$(az identity show --name "$IDENTITY_NAME" --resource-group "$RG" --query "principalId" -o tsv 2>/dev/null | tr -d '\r\n')
+  _cosmos_id=$(az cosmosdb show --name "$COSMOS_NAME" --resource-group "$RG" --query "id" -o tsv 2>/dev/null | tr -d '\r\n')
   if [ -n "$_principal" ] && [ -n "$_cosmos_id" ]; then
-    _arm_roles=$(az role assignment list --assignee "$_principal" --scope "$_cosmos_id" --query "[].roleDefinitionName" -o tsv 2>/dev/null)
+    _arm_roles=$(az role assignment list --assignee "$_principal" --scope "$_cosmos_id" --query "[].roleDefinitionName" -o tsv 2>/dev/null | tr -d '\r')
     if echo "$_arm_roles" | grep -qi "reader"; then
       pass "CosmosDB ARM RBAC — Account Reader assigned"
     else
       fail "CosmosDB ARM RBAC — missing Account Reader" "az role assignment create --assignee $_principal --role 'Cosmos DB Account Reader Role' --scope $_cosmos_id"
     fi
 
-    _sql_roles=$(az cosmosdb sql role assignment list --account-name "$COSMOS_NAME" --resource-group "$RG" --query "[?principalId=='$_principal'].roleDefinitionId" -o tsv 2>/dev/null)
+    _sql_roles=$(az cosmosdb sql role assignment list --account-name "$COSMOS_NAME" --resource-group "$RG" --query "[?principalId=='$_principal'].roleDefinitionId" -o tsv 2>/dev/null | tr -d '\r')
     if [ -n "$_sql_roles" ]; then
       pass "CosmosDB SQL RBAC — Data role assigned"
     else
@@ -328,7 +337,12 @@ fi
 header "6. Container Images"
 
 if [ -n "$ACR_NAME" ]; then
-  _repos=$(az acr repository list --name "$ACR_NAME" -o tsv 2>/dev/null)
+  _repos=$(az acr repository list --name "$ACR_NAME" -o tsv 2>/dev/null | tr -d '\r')
+  if [ -z "$_repos" ]; then
+    # May need login first
+    az acr login --name "$ACR_NAME" --expose-token >/dev/null 2>&1 || true
+    _repos=$(az acr repository list --name "$ACR_NAME" -o tsv 2>/dev/null | tr -d '\r')
+  fi
   for _img in omnivec-api omnivec-web omnivec-changefeed omnivec-dotnet-worker docgrok-router docgrok-pipeline-worker; do
     if echo "$_repos" | grep -qx "$_img"; then
       pass "$_img — present"
@@ -463,9 +477,12 @@ fi
 header "10. Service Bus"
 
 if [ -n "$_SB_NAME" ] && [ -n "$RG" ]; then
-  _queues=$(az servicebus queue list --namespace-name "$_SB_NAME" --resource-group "$RG" --query "[].{name:name,messageCount:messageCount}" -o tsv 2>/dev/null)
+  _queues=$(az servicebus queue list --namespace-name "$_SB_NAME" --resource-group "$RG" --query "[].{name:name,messageCount:messageCount}" -o tsv 2>/dev/null | tr -d '\r')
   if [ -n "$_queues" ]; then
-    echo "$_queues" | while IFS=$'\t' read -r _qn _qc; do
+    echo "$_queues" | while read -r _line; do
+      _qn=$(echo "$_line" | awk '{print $1}' | tr -d '\r')
+      _qc=$(echo "$_line" | awk '{print $2}' | tr -d '\r')
+      _qc=${_qc:-0}
       if [ "$_qc" -gt 1000 ] 2>/dev/null; then
         warn "Queue '$_qn' — $_qc messages backed up" "Scale workers: kubectl scale deployment omnivec-dotnet-worker -n omnivec --replicas=3"
       else

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -123,15 +123,15 @@ if [ -n "$ENV_NAME" ]; then
   if [ "$_rg_exists" = "true" ]; then
     pass "Resource group $RG exists"
 
-    _resources=$(az resource list --resource-group "$RG" --query "[].{type:type,name:name}" -o tsv 2>/dev/null)
+    _resources=$(az resource list --resource-group "$RG" --query "[].{type:type,name:name}" -o json 2>/dev/null)
 
-    AKS_NAME=$(echo "$_resources" | grep "containerService/managedClusters" | head -1 | awk '{print $2}')
-    COSMOS_NAME=$(echo "$_resources" | grep "documentDB/databaseAccounts" | head -1 | awk '{print $2}')
-    ACR_NAME=$(echo "$_resources" | grep "containerRegistry" | head -1 | awk '{print $2}')
-    _KV_NAME=$(echo "$_resources" | grep "vaults" | head -1 | awk '{print $2}')
-    _STOR_NAME=$(echo "$_resources" | grep "storageAccounts" | head -1 | awk '{print $2}')
-    _SB_NAME=$(echo "$_resources" | grep "servicebus" | head -1 | awk '{print $2}')
-    IDENTITY_NAME=$(echo "$_resources" | grep "userAssignedIdentities" | head -1 | awk '{print $2}')
+    AKS_NAME=$(echo "$_resources" | grep -i "containerService/managedClusters" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
+    COSMOS_NAME=$(echo "$_resources" | grep -i "documentDB/databaseAccounts" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
+    ACR_NAME=$(echo "$_resources" | grep -i "containerRegistry/registries" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
+    _KV_NAME=$(echo "$_resources" | grep -i "keyVault/vaults" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
+    _STOR_NAME=$(echo "$_resources" | grep -i "storage/storageAccounts" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
+    _SB_NAME=$(echo "$_resources" | grep -i "serviceBus/namespaces" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
+    IDENTITY_NAME=$(echo "$_resources" | grep -i "managedIdentity/userAssignedIdentities" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
 
     [ -n "$AKS_NAME" ]    && pass "AKS: $AKS_NAME"           || fail "No AKS cluster found" "azd up"
     [ -n "$COSMOS_NAME" ]  && pass "CosmosDB: $COSMOS_NAME"    || fail "No CosmosDB account found"

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -123,15 +123,13 @@ if [ -n "$ENV_NAME" ]; then
   if [ "$_rg_exists" = "true" ]; then
     pass "Resource group $RG exists"
 
-    _resources=$(az resource list --resource-group "$RG" --query "[].{type:type,name:name}" -o json 2>/dev/null)
-
-    AKS_NAME=$(echo "$_resources" | grep -i "containerService/managedClusters" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
-    COSMOS_NAME=$(echo "$_resources" | grep -i "documentDB/databaseAccounts" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
-    ACR_NAME=$(echo "$_resources" | grep -i "containerRegistry/registries" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
-    _KV_NAME=$(echo "$_resources" | grep -i "keyVault/vaults" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
-    _STOR_NAME=$(echo "$_resources" | grep -i "storage/storageAccounts" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
-    _SB_NAME=$(echo "$_resources" | grep -i "serviceBus/namespaces" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
-    IDENTITY_NAME=$(echo "$_resources" | grep -i "managedIdentity/userAssignedIdentities" | grep -o '"name":"[^"]*"' | head -1 | sed 's/"name":"//;s/"//')
+    AKS_NAME=$(az resource list --resource-group "$RG" --resource-type "Microsoft.ContainerService/managedClusters" --query "[0].name" -o tsv 2>/dev/null | tr -d '\r\n')
+    COSMOS_NAME=$(az resource list --resource-group "$RG" --resource-type "Microsoft.DocumentDB/databaseAccounts" --query "[0].name" -o tsv 2>/dev/null | tr -d '\r\n')
+    ACR_NAME=$(az resource list --resource-group "$RG" --resource-type "Microsoft.ContainerRegistry/registries" --query "[0].name" -o tsv 2>/dev/null | tr -d '\r\n')
+    _KV_NAME=$(az resource list --resource-group "$RG" --resource-type "Microsoft.KeyVault/vaults" --query "[0].name" -o tsv 2>/dev/null | tr -d '\r\n')
+    _STOR_NAME=$(az resource list --resource-group "$RG" --resource-type "Microsoft.Storage/storageAccounts" --query "[0].name" -o tsv 2>/dev/null | tr -d '\r\n')
+    _SB_NAME=$(az resource list --resource-group "$RG" --resource-type "Microsoft.ServiceBus/namespaces" --query "[0].name" -o tsv 2>/dev/null | tr -d '\r\n')
+    IDENTITY_NAME=$(az resource list --resource-group "$RG" --resource-type "Microsoft.ManagedIdentity/userAssignedIdentities" --query "[0].name" -o tsv 2>/dev/null | tr -d '\r\n')
 
     [ -n "$AKS_NAME" ]    && pass "AKS: $AKS_NAME"           || fail "No AKS cluster found" "azd up"
     [ -n "$COSMOS_NAME" ]  && pass "CosmosDB: $COSMOS_NAME"    || fail "No CosmosDB account found"

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -140,16 +140,35 @@ if [ -n "$ENV_NAME" ]; then
     [ -n "$IDENTITY_NAME" ] && pass "Managed Identity: $IDENTITY_NAME" || warn "No Managed Identity found"
 
     if [ -n "$AKS_NAME" ]; then
-      # Get credentials — show error if it fails (common: kubelogin not installed)
-      if az aks get-credentials --resource-group "$RG" --name "$AKS_NAME" --overwrite-existing 2>&1 | grep -qi "error\|fail"; then
-        # Retry without admin (default uses kubelogin)
-        az aks get-credentials --resource-group "$RG" --name "$AKS_NAME" --overwrite-existing --admin 2>/dev/null || true
+      # Ensure kubectl and kubelogin are installed
+      if ! command -v kubectl >/dev/null 2>&1; then
+        printf "  ${YELLOW}kubectl not found — installing...${NC}\n"
+        mkdir -p "$HOME/.azure-kubectl"
+        az aks install-cli --install-location "$HOME/.azure-kubectl/kubectl" --kubelogin-install-location "$HOME/.azure-kubectl/kubelogin" 2>/dev/null || true
+        chmod +x "$HOME/.azure-kubectl/kubectl" "$HOME/.azure-kubectl/kubelogin" 2>/dev/null || true
+        export PATH="$HOME/.azure-kubectl:$PATH"
       fi
+      if ! command -v kubelogin >/dev/null 2>&1; then
+        printf "  ${YELLOW}kubelogin not found — installing...${NC}\n"
+        mkdir -p "$HOME/.azure-kubectl"
+        az aks install-cli --install-location "$HOME/.azure-kubectl/kubectl" --kubelogin-install-location "$HOME/.azure-kubectl/kubelogin" 2>/dev/null || true
+        chmod +x "$HOME/.azure-kubectl/kubectl" "$HOME/.azure-kubectl/kubelogin" 2>/dev/null || true
+        export PATH="$HOME/.azure-kubectl:$PATH"
+      fi
+
+      # Get credentials — try normal first, fall back to --admin
+      az aks get-credentials --resource-group "$RG" --name "$AKS_NAME" --overwrite-existing 2>/dev/null || \
+        az aks get-credentials --resource-group "$RG" --name "$AKS_NAME" --overwrite-existing --admin 2>/dev/null || true
+
       KUBE_CONTEXT="$AKS_NAME"
       # Verify kubectl works
       if ! kubectl --context "$KUBE_CONTEXT" cluster-info >/dev/null 2>&1; then
-        warn "kubectl cannot connect to AKS (credentials may need kubelogin)" "az aks install-cli && az aks get-credentials --resource-group $RG --name $AKS_NAME --overwrite-existing"
-        KUBE_CONTEXT=""
+        # One more try: convert kubelogin
+        kubelogin convert-kubeconfig -l azurecli 2>/dev/null || true
+        if ! kubectl --context "$KUBE_CONTEXT" cluster-info >/dev/null 2>&1; then
+          warn "kubectl cannot connect to AKS" "Check az login and network connectivity"
+          KUBE_CONTEXT=""
+        fi
       fi
     fi
   else


### PR DESCRIPTION
Resource type matching was case-sensitive and tsv parsing with awk was unreliable. Switched to JSON output with case-insensitive grep. Fixes AKS/CosmosDB/ACR not being detected on Linux.