### PR TITLE
Fix postprovision.sh: token prompt crashes in no-TTY context

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,33 +140,64 @@ This walkthrough uses the UI. For CLI equivalents, see [docs/cli-guide.md](docs/
 
 ### 3b. Create a source
 
-A source is a connection to data you want to embed. For this first run, use **Azure Blob Storage** — `azd up` already provisioned a storage account in your resource group (`rg-omnivec-<your-env-name>`).
+A source is a connection to data you want to embed. For this first run, use **CosmosDB** — create a new CosmosDB account for your data (separate from the OmniVec metadata account).
 
-1. Find your storage account: Azure Portal → resource group `rg-omnivec-<your-env-name>` → the Storage account resource → **Properties** → copy the **Primary blob service endpoint** URL.
-2. In that storage account, create a container named `docs` (Azure Portal → Storage account → **Containers** → **+ Container**).
-3. Upload a sample file. Create a file called `hello.txt` with this content:
+1. Create a new CosmosDB account in the Azure Portal:
+   - Azure Portal → **Create a resource** → **Azure Cosmos DB** → **NoSQL**
+   - **Account name**: e.g., `my-omnivec-data`
+   - **Capacity mode**: Serverless
+   - Enable **Vector Search** under Features
+   - Click **Create** (takes ~3–5 minutes)
+2. Create a database and source container:
+   - Go to your new Cosmos DB account → **Data Explorer** → **New Container**
+   - **Database id**: `demo` (create new)
+   - **Container id**: `documents`
+   - **Partition key**: `/id`
+   - Click **OK**
+3. Insert a few sample documents via Data Explorer → `documents` container → **New Item**:
+   ```json
+   { "id": "doc-001", "content": "OmniVec is a universal vector ingestion platform that processes documents from Azure CosmosDB into vector embeddings for semantic search.", "title": "About OmniVec" }
    ```
-   OmniVec is a universal vector ingestion platform that processes documents
-   from Azure Blob Storage, CosmosDB, and PostgreSQL into vector embeddings
-   for semantic search.
+   ```json
+   { "id": "doc-002", "content": "Azure Kubernetes Service simplifies deploying managed Kubernetes clusters in Azure by offloading operational overhead.", "title": "About AKS" }
    ```
-   Upload it to the `docs` container (drag-and-drop in the Azure Portal works).
-4. In OmniVec, go to **Sources** → **New Source**.
-5. Choose **Azure Blob Storage**.
-6. Fill in:
+4. Grant the OmniVec managed identity access to this account:
+
+   **Bash / Linux:**
+   ```bash
+   az cosmosdb sql role assignment create \
+     --account-name "my-omnivec-data" \
+     --resource-group "<your-rg>" \
+     --role-definition-id "00000000-0000-0000-0000-000000000002" \
+     --principal-id "<omnivec-identity-principal-id>" \
+     --scope "/dbs"
+   ```
+   **PowerShell / Windows:**
+   ```powershell
+   az cosmosdb sql role assignment create `
+     --account-name "my-omnivec-data" `
+     --resource-group "<your-rg>" `
+     --role-definition-id "00000000-0000-0000-0000-000000000002" `
+     --principal-id "<omnivec-identity-principal-id>" `
+     --scope "/dbs"
+   ```
+   Also grant **Cosmos DB Account Reader Role** via Access Control (IAM).
+
+5. In OmniVec, go to **Sources** → **New Source**.
+6. Choose **CosmosDB**.
+7. Fill in:
    - **Name**: `My First Source`
-   - **Account URL**: the blob endpoint URL you copied
-   - **Container**: `docs`
-7. Click **Save**, then **Test Connection** to verify access.
+   - **Endpoint**: your new Cosmos DB account URI
+   - **Database**: `demo`
+   - **Container**: `documents`
+8. Click **Save**, then **Test Connection** to verify access.
 
 ### 3c. Create a destination
 
-A destination is where vectors are stored. Use **CosmosDB Vector** — `azd up` already created a CosmosDB account in your resource group (`rg-omnivec-<your-env-name>`).
+A destination is where vectors are stored. Use the **same CosmosDB account** with a separate container that has a vector embedding policy.
 
-1. Find your CosmosDB account: Azure Portal → resource group `rg-omnivec-<your-env-name>` → the Cosmos DB account → **Overview** → copy the **URI**.
-2. Create a database and container for vectors:
-   - Azure Portal → Cosmos DB account → **Data Explorer** → **New Container**
-   - **Database id**: `omnivec-vectors` (create new)
+1. In your Cosmos DB account → **Data Explorer** → **New Container**:
+   - **Database id**: `demo` (use existing)
    - **Container id**: `vectors`
    - **Partition key**: `/id`
    - Under **Container Vector Policy**, add a vector embedding:
@@ -175,17 +206,17 @@ A destination is where vectors are stored. Use **CosmosDB Vector** — `azd up` 
      - **Dimensions**: `1536` (matches `text-embedding-3-small`)
      - **Distance function**: `cosine`
    - Click **OK** to create
-3. In OmniVec, go to **Destinations** → **New Destination**.
-4. Choose **CosmosDB Vector**.
-5. Fill in:
+2. In OmniVec, go to **Destinations** → **New Destination**.
+3. Choose **CosmosDB Vector**.
+4. Fill in:
    - **Name**: `My First Destination`
-   - **Endpoint**: the URI you copied
-   - **Database**: `omnivec-vectors`
+   - **Endpoint**: same Cosmos DB account URI
+   - **Database**: `demo`
    - **Container**: `vectors`
-6. Click **Save**, then **Test Connection**.
-7. Click **Fetch Vector Index Details** — you should see `/embedding` with dimensions `1536` and distance function `cosine`.
+5. Click **Save**, then **Test Connection**.
+6. Click **Fetch Embedding Policies** — you should see `/embedding` with dimensions `1536` and distance function `cosine`.
 
-> **If Fetch Vector Index Details returns nothing:** your container doesn't have a vector indexing policy configured. Go back to Data Explorer and verify the container's vector policy includes a `/embedding` path. See the [Cosmos DB vector search docs](https://learn.microsoft.com/azure/cosmos-db/nosql/vector-search) for details.
+> **If Fetch Embedding Policies returns nothing:** your container doesn't have a vector embedding policy configured. Go back to Data Explorer and verify the container's vector policy includes a `/embedding` path. See the [Cosmos DB vector search docs](https://learn.microsoft.com/azure/cosmos-db/nosql/vector-search) for details.
 
 ### 3d. Create a pipeline
 
@@ -194,12 +225,11 @@ A pipeline ties source → model → destination together.
 1. Go to **Pipelines** → **New Pipeline**.
 2. Fill in:
    - **Name**: `My First Pipeline`
-   - **Source**: select your blob source
+   - **Source**: select your CosmosDB source
    - **Destination**: select your CosmosDB vector destination
    - **Model**: select the Azure OpenAI model you registered
-   - **Vector Index Path**: select the path shown from your destination (e.g., `/embedding`)
+   - **Embedding Policy Path**: select the path from your destination (e.g., `/embedding`)
    - **Content Strategy**: `Truncate` (embeds full document text as a single vector — simplest for first run)
-   - **Processing Mode**: `Queue`
    - **Process Existing**: ✅ enable this (so documents already in the source get processed)
 3. Click **Create**.
 
@@ -210,17 +240,17 @@ The pipeline starts processing immediately. You can watch progress on the pipeli
 Within a few minutes, check these signals:
 
 - [ ] **Pipeline health** shows green on the Pipelines page
-- [ ] **Jobs** tab shows completed jobs (one per document)
-- [ ] **Job count** increases from 0
+- [ ] **Embedded count** increases to match your source document count
+- [ ] **Completion** reaches 100%
 
 Then test vector search:
 
 1. Go to **Vector Search** in the sidebar.
 2. Select your destination index.
 3. Type: `vector ingestion platform`
-4. Click **Search** — you should see your `hello.txt` document returned as the top result.
+4. Click **Search** — you should see your documents returned with similarity scores.
 
-> **Expected result:** Since your sample document contains "universal vector ingestion platform," a search for "vector ingestion platform" should match it as the first or second result.
+> **Expected result:** Your sample document about OmniVec should appear as the top result for "vector ingestion platform."
 
 **Congratulations — you've deployed OmniVec and run a full vector ingestion pipeline.** 🎉
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ This guide walks you through deploying OmniVec and running your first end-to-end
 
 ---
 
-## Prerequisites
+## Part 1 — Deploy OmniVec
+
+### Prerequisites
 
 Install these before you begin:
 
@@ -31,21 +33,12 @@ Install these before you begin:
 You also need:
 
 - An **Azure subscription** with permission to create resource groups, AKS clusters, and CosmosDB accounts.
-- An **Azure OpenAI resource** with an embedding model deployment. If you don't have one yet:
-  1. [Create an Azure OpenAI resource](https://learn.microsoft.com/azure/ai-services/openai/how-to/create-resource)
-  2. [Deploy an embedding model](https://learn.microsoft.com/azure/ai-services/openai/how-to/create-resource?pivots=web-portal#deploy-a-model) — choose `text-embedding-3-small` for a first run
-  3. Note these three values (you'll need them in Step 3a):
-     - **Endpoint URL** — Azure Portal → your OpenAI resource → Overview
-     - **API Key** — Azure Portal → Keys and Endpoint
-     - **Deployment Name** — Azure Portal → Deployments → the exact name you gave the deployment (this is **not** the model name)
 
 > `kubectl` and `helm` are installed automatically by the deployment hooks if not already present.
 
 > **Cost estimate:** The default configuration (2× Standard_B4ms nodes, no GPU, CosmosDB serverless) costs roughly **$5–10/day**. Run `azd down --purge --force` when you're done to stop all charges.
 
----
-
-## Step 1 — Deploy OmniVec
+### Deploy
 
 > **Windows users:** Run these commands in PowerShell 7 (`pwsh`), not Command Prompt.
 
@@ -105,7 +98,7 @@ azd env list
 
 ---
 
-## Step 2 — Open the UI
+### Open the UI
 
 Open the **OmniVec URL** in your browser. You should see the OmniVec dashboard.
 
@@ -115,13 +108,24 @@ If the page doesn't load, wait 1–2 minutes for the load balancer to assign an 
 kubectl get svc omnivec-web -n omnivec
 ```
 
+**Deployment is complete.** OmniVec is running. The next part walks through creating your first pipeline.
+
 ---
 
-## Step 3 — Your first pipeline
+## Part 2 — Your first pipeline
+
+This section requires an **Azure OpenAI resource** with an embedding model deployed. If you don't have one yet:
+
+1. [Create an Azure OpenAI resource](https://learn.microsoft.com/azure/ai-services/openai/how-to/create-resource)
+2. [Deploy an embedding model](https://learn.microsoft.com/azure/ai-services/openai/how-to/create-resource?pivots=web-portal#deploy-a-model) — choose `text-embedding-3-small` for a first run
+3. Note these three values:
+   - **Endpoint URL** — Azure Portal → your OpenAI resource → Overview
+   - **API Key** — Azure Portal → Keys and Endpoint
+   - **Deployment Name** — Azure Portal → Deployments → the exact name you gave the deployment (this is **not** the model name)
 
 This walkthrough uses the UI. For CLI equivalents, see [docs/cli-guide.md](docs/cli-guide.md).
 
-### 3a. Register an embedding model
+### Register an embedding model
 
 1. Go to **Models** in the sidebar.
 2. Click **Add Model**.
@@ -138,7 +142,7 @@ This walkthrough uses the UI. For CLI equivalents, see [docs/cli-guide.md](docs/
 
 > **Common mistake:** The deployment name must match exactly what's shown in the Azure Portal under "Deployments." If you named your deployment `my-embeddings`, use `my-embeddings` — not `text-embedding-3-small`.
 
-### 3b. Create a source
+### Create a source
 
 A source is a connection to data you want to embed. For this first run, use **CosmosDB** — create a new CosmosDB account for your data (separate from the OmniVec metadata account).
 
@@ -192,7 +196,7 @@ A source is a connection to data you want to embed. For this first run, use **Co
    - **Container**: `documents`
 8. Click **Save**, then **Test Connection** to verify access.
 
-### 3c. Create a destination
+### Create a destination
 
 A destination is where vectors are stored. Use the **same CosmosDB account** with a separate container that has a vector embedding policy.
 
@@ -218,7 +222,7 @@ A destination is where vectors are stored. Use the **same CosmosDB account** wit
 
 > **If Fetch Embedding Policies returns nothing:** your container doesn't have a vector embedding policy configured. Go back to Data Explorer and verify the container's vector policy includes a `/embedding` path. See the [Cosmos DB vector search docs](https://learn.microsoft.com/azure/cosmos-db/nosql/vector-search) for details.
 
-### 3d. Create a pipeline
+### Create a pipeline
 
 A pipeline ties source → model → destination together.
 
@@ -235,7 +239,7 @@ A pipeline ties source → model → destination together.
 
 The pipeline starts processing immediately. You can watch progress on the pipeline detail page.
 
-### 3e. Verify it worked
+### Verify it worked
 
 Within a few minutes, check these signals:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -113,6 +113,27 @@ ACTIVE  ──pause──→  PAUSED  ──resume──→  ACTIVE
 Any     ──reset──→  Reprocess all documents from the beginning
 ```
 
+### Important: One pipeline per source + destination + embedding path
+
+If you create two pipelines with the **same source, same destination, and same embedding path**, the second pipeline may not process documents. This is because the changefeed processor uses lease-based ownership — only one pipeline's changefeed can process a given source container at a time.
+
+**If you need multiple embedding models on the same data:**
+- Use different **embedding policy paths** in the destination (e.g., `/embedding_small` and `/embedding_large`)
+- Each pipeline selects a different embedding path, so they write to different vector fields
+- Both pipelines can share the same source and destination containers
+
+**If you need the same model but different content strategies:**
+- Create separate destination containers (one per strategy)
+- Each pipeline targets a different destination
+
+### Locked settings after creation
+
+Once a pipeline is created, the following settings become **read-only**:
+- **Source** and **Destination** — cannot be changed
+- **Content Strategy** (truncate/chunk) — changing would invalidate existing vectors
+- **Chunk Configuration** (size, overlap, doc ID pattern) — must be consistent with existing chunks
+- **Processing Mode** (inline/queue) — tied to changefeed lease setup
+
 ---
 
 ## 4. Jobs

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -382,7 +382,12 @@ if ($missingImages.Count -gt 0) {
 
 Write-Host "`n`e[33mPhase 2: Getting AKS credentials...`e[0m"
 $KUBE_CONTEXT = $AKS_CLUSTER
-az aks get-credentials --resource-group $RESOURCE_GROUP --name $AKS_CLUSTER --context $KUBE_CONTEXT --overwrite-existing
+
+# Use a separate kubeconfig to avoid overwriting user's default context
+$OMNIVEC_KUBECONFIG = Join-Path $HOME ".kube" "omnivec-$env:AZURE_ENV_NAME"
+$env:KUBECONFIG = $OMNIVEC_KUBECONFIG
+
+az aks get-credentials --resource-group $RESOURCE_GROUP --name $AKS_CLUSTER --file $OMNIVEC_KUBECONFIG --overwrite-existing
 Write-Host "`e[32mConnected to AKS cluster: $AKS_CLUSTER`e[0m"
 
 # =============================================================================

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -241,8 +241,8 @@ if [ "$OMNIVEC_BUILD" != "true" ]; then
   printf "  ${CYAN}Source: $SHARED_REGISTRY${NC}\n"
 
   # Try anonymous pull first
-  printf "  ${CYAN}Testing anonymous pull...${NC}"
-  if az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:latest" --image "${FIRST_IMAGE}:latest" --force >/dev/null 2>&1; then
+  printf "  ${CYAN}Testing anonymous pull (this may take 30-60s)...${NC}"
+  if timeout 90 az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:latest" --image "${FIRST_IMAGE}:latest" --force >/dev/null 2>&1; then
     printf " ${GREEN}✓ anonymous pull works${NC}\n"
     ANON_OK=true
   else

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -405,10 +405,15 @@ fi
 
 printf "\n${YELLOW}Phase 2: Getting AKS credentials...${NC}\n"
 KUBE_CONTEXT="${AKS_CLUSTER}"
+
+# Use a separate kubeconfig to avoid overwriting user's default context
+OMNIVEC_KUBECONFIG="$HOME/.kube/omnivec-${AZURE_ENV_NAME:-omnivec}"
+export KUBECONFIG="$OMNIVEC_KUBECONFIG"
+
 az aks get-credentials \
   --resource-group "$RESOURCE_GROUP" \
   --name "$AKS_CLUSTER" \
-  --context "$KUBE_CONTEXT" \
+  --file "$OMNIVEC_KUBECONFIG" \
   --overwrite-existing >/dev/null
 
 # WSL: az writes kubeconfig to Windows home — symlink to Linux home for helm/kubectl

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -19,12 +19,17 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Helper: read user input (handles non-TTY contexts)
 read_input() {
   prompt="$1"
+  _ri_val=""
   if [ -t 0 ]; then
     printf "%s" "$prompt"
-    read -r _ri_val
-  else
+    read -r _ri_val || true
+  elif [ -e /dev/tty ]; then
     printf "%s" "$prompt" > /dev/tty
-    read -r _ri_val < /dev/tty
+    read -r _ri_val < /dev/tty || true
+  else
+    # No TTY available (non-interactive hook context) — return empty
+    printf "%s" "$prompt"
+    printf " ${YELLOW}(no interactive input available — skipping)${NC}\n"
   fi
   echo "$_ri_val"
 }

--- a/scripts/test-hooks.ps1
+++ b/scripts/test-hooks.ps1
@@ -378,13 +378,8 @@ function Test-Scenario1 {
     Write-MockScript -Dir $mockBin -Name "git"     -Body (Get-NoopMockBody)
 
     $hookPath = Join-Path $testDir "hooks" "preprovision.ps1"
-    # Provide stdin answers for every Read-Host prompt:
-    #   Metadata: 1 (cosmosdb-serverless)
-    #   Blob: 1 (yes)
-    #   System SKU: 1
-    #   System count: 2
-    #   GPU count: 0
-    $stdin = "1`n1`n1`n2`n0`n"
+    # Provide stdin: "1" for quick start mode
+    $stdin = "1`n"
 
     $r = Invoke-HookTest -HookPath $hookPath -MockBinDir $mockBin -WorkDir $testDir -StdinText $stdin -EnvVars @{
         AZURE_ENV_NAME  = $envName
@@ -392,9 +387,9 @@ function Test-Scenario1 {
         HOME            = $HOME
     }
 
-    $showsPrompts = ($r.Output -match "Select metadata storage backend" -or $r.Output -match "metadata storage")
-    Assert-Test "Scenario 1: Fresh deploy — shows config prompts" $showsPrompts `
-        "Expected prompt text in output. Exit=$($r.ExitCode). Output tail: $($r.Output.Substring([Math]::Max(0,$r.Output.Length-300)))"
+    $showsPrompts = ($r.Output -match "Quick start" -or $r.Output -match "recommended defaults" -or $r.Output -match "Choose setup mode")
+    Assert-Test "Scenario 1: Fresh deploy — quick start applies defaults" $showsPrompts `
+        "Expected quick start text in output. Exit=$($r.ExitCode). Output tail: $($r.Output.Substring([Math]::Max(0,$r.Output.Length-300)))"
 
     Remove-TestDir $testDir
 }

--- a/scripts/test-hooks.sh
+++ b/scripts/test-hooks.sh
@@ -1,0 +1,491 @@
+#!/bin/sh
+# OmniVec — Hook Test Harness (Bash)
+# Tests preprovision.sh and postprovision.sh by mocking external commands.
+# Usage: ./scripts/test-hooks.sh
+#
+# Mirrors the PowerShell test-hooks.ps1 scenarios for Linux/macOS.
+
+set +e  # Don't exit on test failures
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PREPROVISION="$REPO_ROOT/hooks/preprovision.sh"
+POSTPROVISION="$REPO_ROOT/hooks/postprovision.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); printf "  ${GREEN}✓ PASS${NC}  %s\n" "$1"; }
+fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); printf "  ${RED}✗ FAIL${NC}  %s\n" "$1"; [ -n "$2" ] && printf "          %s\n" "$2"; }
+
+# ─── Test directory setup ────────────────────────────────────────────────────
+
+new_test_dir() {
+  _td=$(mktemp -d /tmp/omnivec-test.XXXXXXXX)
+  echo "$_td"
+}
+
+cleanup_test_dir() {
+  [ -n "$1" ] && rm -rf "$1" 2>/dev/null
+}
+
+# ─── Mock script creation ────────────────────────────────────────────────────
+
+write_mock() {
+  # $1 = dir, $2 = name, $3 = script body
+  _mock="$1/$2"
+  cat > "$_mock" <<ENDMOCK
+#!/bin/sh
+$3
+ENDMOCK
+  chmod +x "$_mock"
+}
+
+# ─── Hook runner ─────────────────────────────────────────────────────────────
+
+run_hook() {
+  # $1 = hook path, $2 = mock bin dir, $3 = test dir, $4 = stdin text, $5+ = env vars
+  _hook="$1"; _mockbin="$2"; _workdir="$3"; _stdin="$4"
+  shift 4
+
+  # Copy hook to test dir
+  mkdir -p "$_workdir/hooks"
+  cp "$_hook" "$_workdir/hooks/"
+
+  # Set env and run
+  _output=$(cd "$_workdir" && \
+    PATH="$_mockbin:$PATH" \
+    HOME="$_workdir" \
+    PSScriptRoot="$_workdir/hooks" \
+    "$@" \
+    sh "$_workdir/hooks/$(basename "$_hook")" <<EOF 2>&1
+$_stdin
+EOF
+  )
+  _exit=$?
+  echo "$_output"
+  return $_exit
+}
+
+# ─── Standard mock helpers ───────────────────────────────────────────────────
+
+setup_preprovision_stubs() {
+  _dir="$1"
+  mkdir -p "$_dir/docgrok"
+  touch "$_dir/docgrok/Dockerfile"
+  mkdir -p "$_dir/.azure/$2"
+  touch "$_dir/.azure/$2/.env"
+  mkdir -p "$_dir/.omnivec/locks"
+}
+
+setup_postprovision_stubs() {
+  _dir="$1"; _envname="$2"
+  mkdir -p "$_dir/docgrok" "$_dir/helm/omnivec" "$_dir/.azure/$_envname" "$_dir/.omnivec/locks" "$_dir/.kube"
+  touch "$_dir/docgrok/Dockerfile" "$_dir/.azure/$_envname/.env"
+  # Create minimal Chart.yaml and Chart.lock
+  echo "name: omnivec" > "$_dir/helm/omnivec/Chart.yaml"
+  echo "dependencies: []" > "$_dir/helm/omnivec/Chart.lock"
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# SCENARIOS
+# ═════════════════════════════════════════════════════════════════════════════
+
+printf "\n${CYAN}OmniVec Hook Test Harness (Bash)${NC}\n\n"
+
+# ─── Preprovision Scenarios ──────────────────────────────────────────────────
+printf "${YELLOW}--- Preprovision Scenarios ---${NC}\n"
+
+# Scenario 1: Fresh deploy — quick start defaults
+test_scenario_1() {
+  _td=$(new_test_dir)
+  _mb="$_td/mockbin"; mkdir -p "$_mb"
+  _env="test-env"
+  setup_preprovision_stubs "$_td" "$_env"
+
+  write_mock "$_mb" "az" '
+case "$*" in
+  *"group exists"*) echo "false"; exit 0 ;;
+  *"account show"*) echo "{\"name\":\"TestSub\",\"id\":\"00000000\"}"; exit 0 ;;
+  *"vm list-skus"*) echo "Standard_B4ms"; exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "azd" '
+case "$*" in
+  *"env get-value"*) echo "ERROR: key not found" >&2; exit 1 ;;
+  *"env set"*) exit 0 ;;
+  *"env select"*) exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "kubectl" 'exit 0'
+  write_mock "$_mb" "helm" 'exit 0'
+  write_mock "$_mb" "git" 'exit 0'
+
+  # Stdin: choose "1" for quick start
+  _output=$(run_hook "$PREPROVISION" "$_mb" "$_td" "1" \
+    AZURE_ENV_NAME="$_env" AZURE_LOCATION="eastus2")
+  _rc=$?
+
+  if echo "$_output" | grep -q "Quick start\|recommended defaults\|Applying recommended"; then
+    pass "Scenario 1: Fresh deploy — quick start applies defaults"
+  else
+    fail "Scenario 1: Fresh deploy — quick start" "Expected quick start text. exit=$_rc"
+  fi
+
+  cleanup_test_dir "$_td"
+}
+test_scenario_1
+
+# Scenario 2: Existing RG with tags — imports config
+test_scenario_2() {
+  _td=$(new_test_dir)
+  _mb="$_td/mockbin"; mkdir -p "$_mb"
+  _env="test-env"
+  setup_preprovision_stubs "$_td" "$_env"
+
+  write_mock "$_mb" "az" '
+case "$*" in
+  *"group exists"*) echo "true"; exit 0 ;;
+  *"account show"*) echo "{\"name\":\"TestSub\",\"id\":\"00000000\"}"; exit 0 ;;
+  *"group show"*query*) echo "Standard_B4ms"; exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "azd" '
+case "$*" in
+  *"env set"*) exit 0 ;;
+  *"env select"*) exit 0 ;;
+  *"env get-value"*) echo "ERROR" >&2; exit 1 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "kubectl" 'exit 0'
+  write_mock "$_mb" "helm" 'exit 0'
+  write_mock "$_mb" "git" 'exit 0'
+
+  _output=$(run_hook "$PREPROVISION" "$_mb" "$_td" "" \
+    AZURE_ENV_NAME="$_env" AZURE_LOCATION="eastus2")
+  _rc=$?
+
+  if echo "$_output" | grep -q "Existing deployment detected\|Importing config"; then
+    pass "Scenario 2: Existing RG with tags — imports config"
+  else
+    fail "Scenario 2: Existing RG" "Expected import text. exit=$_rc"
+  fi
+
+  cleanup_test_dir "$_td"
+}
+test_scenario_2
+
+# Scenario 3: Config pre-set — skips prompts
+test_scenario_3() {
+  _td=$(new_test_dir)
+  _mb="$_td/mockbin"; mkdir -p "$_mb"
+  _env="test-env"
+  setup_preprovision_stubs "$_td" "$_env"
+
+  write_mock "$_mb" "az" '
+case "$*" in
+  *"group exists"*) echo "false"; exit 0 ;;
+  *"account show"*) echo "{\"name\":\"TestSub\",\"id\":\"00000000\"}"; exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "azd" '
+case "$*" in
+  *"env get-value"*OMNIVEC_SYSTEM_NODE_VM_SIZE*) echo "Standard_B4ms"; exit 0 ;;
+  *"env get-value"*) echo "some-value"; exit 0 ;;
+  *"env set"*) exit 0 ;;
+  *"env select"*) exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "kubectl" 'exit 0'
+  write_mock "$_mb" "helm" 'exit 0'
+  write_mock "$_mb" "git" 'exit 0'
+
+  _output=$(run_hook "$PREPROVISION" "$_mb" "$_td" "" \
+    AZURE_ENV_NAME="$_env" AZURE_LOCATION="eastus2")
+  _rc=$?
+
+  if echo "$_output" | grep -q "Config already set\|Skipping prompts"; then
+    pass "Scenario 3: Config pre-set — skips prompts"
+  else
+    fail "Scenario 3: Config pre-set" "Expected skip text. exit=$_rc"
+  fi
+
+  cleanup_test_dir "$_td"
+}
+test_scenario_3
+
+# ─── Postprovision Scenarios ────────────────────────────────────────────────
+printf "\n${YELLOW}--- Postprovision Scenarios ---${NC}\n"
+
+# Common postprovision env vars
+postprov_env() {
+  echo "AZURE_ENV_NAME=$1"
+  echo "AZURE_AKS_CLUSTER_NAME=omnivec-aks-test"
+  echo "AZURE_ACR_LOGIN_SERVER=testacr.azurecr.io"
+  echo "AZURE_ACR_NAME=testacr"
+  echo "AZURE_COSMOS_ENDPOINT=https://test.documents.azure.com:443/"
+  echo "AZURE_RESOURCE_GROUP=rg-omnivec-$1"
+  echo "AZURE_IDENTITY_CLIENT_ID=test-identity-id"
+  echo "INSTANCE_ID=test-instance"
+  echo "ENABLE_BLOB_SOURCE=false"
+  echo "BUILD_MODE=import"
+}
+
+# Scenario 5: Anonymous pull works
+test_scenario_5() {
+  _td=$(new_test_dir)
+  _mb="$_td/mockbin"; mkdir -p "$_mb"
+  _env="test-env"
+  setup_postprovision_stubs "$_td" "$_env"
+
+  write_mock "$_mb" "az" '
+case "$*" in
+  *"acr import"*) exit 0 ;;
+  *"acr repository"*) echo "latest"; exit 0 ;;
+  *"acr manifest"*) echo "sha256:abc123"; exit 0 ;;
+  *"aks get-credentials"*) exit 0 ;;
+  *"tag update"*) exit 0 ;;
+  *"account show"*) echo "{\"name\":\"TestSub\"}"; exit 0 ;;
+  *"env get-value"*) echo "test-value"; exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "azd" '
+case "$*" in
+  *"env get-value"*ADMIN_TOKEN*) echo "test-token"; exit 0 ;;
+  *"env get-value"*) echo "test-value"; exit 0 ;;
+  *"env set"*) exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "kubectl" '
+case "$*" in
+  *"get nodes"*) echo "node1 Ready"; exit 0 ;;
+  *"create namespace"*) exit 0 ;;
+  *"label"*) exit 0 ;;
+  *"annotate"*) exit 0 ;;
+  *"get pods"*) echo "omnivec-api-xxx Running 0 1m"; exit 0 ;;
+  *"get svc"*) echo "1.2.3.4"; exit 0 ;;
+  *"rollout"*) exit 0 ;;
+  *"cluster-info"*) echo "running"; exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "helm" '
+case "$*" in
+  *"dependency"*) exit 0 ;;
+  *"upgrade"*) echo "deployed"; exit 0 ;;
+  *"status"*) echo "{\"info\":{\"status\":\"deployed\"},\"version\":1}"; exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "git" 'exit 0'
+  write_mock "$_mb" "timeout" 'shift; exec "$@"'  # pass-through
+
+  _output=$(eval $(postprov_env "$_env") run_hook "$POSTPROVISION" "$_mb" "$_td" "" \
+    $(postprov_env "$_env"))
+  _rc=$?
+
+  if echo "$_output" | grep -q "anonymous pull works"; then
+    pass "Scenario 5: Anonymous pull works — no token prompt"
+  else
+    fail "Scenario 5: Anonymous pull" "Expected 'anonymous pull works'. exit=$_rc"
+  fi
+
+  cleanup_test_dir "$_td"
+}
+test_scenario_5
+
+# Scenario 7: Anonymous fails, no token — prompts user
+test_scenario_7() {
+  _td=$(new_test_dir)
+  _mb="$_td/mockbin"; mkdir -p "$_mb"
+  _env="test-env"
+  setup_postprovision_stubs "$_td" "$_env"
+
+  write_mock "$_mb" "az" '
+case "$*" in
+  *"acr import"*user-provided-token*) exit 0 ;;
+  *"acr import"*) echo "401 Unauthorized" >&2; exit 1 ;;
+  *"acr repository"*) echo "latest"; exit 0 ;;
+  *"acr manifest"*) echo "sha256:abc123"; exit 0 ;;
+  *"aks get-credentials"*) exit 0 ;;
+  *"tag update"*) exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "azd" '
+case "$*" in
+  *"env get-value"*SHARED_REGISTRY_TOKEN*) echo ""; exit 1 ;;
+  *"env get-value"*ADMIN_TOKEN*) echo "test-token"; exit 0 ;;
+  *"env get-value"*) echo "test-value"; exit 0 ;;
+  *"env set"*) exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "kubectl" '
+case "$*" in
+  *"get nodes"*) echo "node1 Ready"; exit 0 ;;
+  *"create namespace"*) exit 0 ;;
+  *"label"*) exit 0 ;;
+  *"annotate"*) exit 0 ;;
+  *"get pods"*) echo "omnivec-api-xxx Running 0 1m"; exit 0 ;;
+  *"get svc"*) echo "1.2.3.4"; exit 0 ;;
+  *"rollout"*) exit 0 ;;
+  *"cluster-info"*) echo "running"; exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "helm" '
+case "$*" in
+  *"dependency"*) exit 0 ;;
+  *"upgrade"*) echo "deployed"; exit 0 ;;
+  *"status"*) echo "{\"info\":{\"status\":\"deployed\"},\"version\":1}"; exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "git" 'exit 0'
+  write_mock "$_mb" "timeout" 'shift; exec "$@"'
+
+  # Provide token via stdin
+  _output=$(eval $(postprov_env "$_env") run_hook "$POSTPROVISION" "$_mb" "$_td" \
+    "user-provided-token" \
+    $(postprov_env "$_env"))
+  _rc=$?
+
+  if echo "$_output" | grep -q "token required\|Enter token"; then
+    pass "Scenario 7: Anonymous fails, no token — shows token prompt"
+  else
+    fail "Scenario 7: Token prompt" "Expected prompt text. exit=$_rc"
+  fi
+
+  cleanup_test_dir "$_td"
+}
+test_scenario_7
+
+# Scenario 9: All auth fails — falls back to build
+test_scenario_9() {
+  _td=$(new_test_dir)
+  _mb="$_td/mockbin"; mkdir -p "$_mb"
+  _env="test-env"
+  setup_postprovision_stubs "$_td" "$_env"
+
+  write_mock "$_mb" "az" '
+case "$*" in
+  *"acr import"*) echo "401 Unauthorized" >&2; exit 1 ;;
+  *"acr build"*) exit 0 ;;
+  *"acr repository"*) echo "latest"; exit 0 ;;
+  *"acr manifest"*) echo "sha256:abc123"; exit 0 ;;
+  *"aks get-credentials"*) exit 0 ;;
+  *"tag update"*) exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "azd" '
+case "$*" in
+  *"env get-value"*SHARED_REGISTRY_TOKEN*) echo ""; exit 1 ;;
+  *"env get-value"*ADMIN_TOKEN*) echo "test-token"; exit 0 ;;
+  *"env get-value"*BUILD_MODE*) echo "acr"; exit 0 ;;
+  *"env get-value"*) echo "test-value"; exit 0 ;;
+  *"env set"*) exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "kubectl" '
+case "$*" in
+  *"get nodes"*) echo "node1 Ready"; exit 0 ;;
+  *"create namespace"*) exit 0 ;;
+  *"label"*) exit 0 ;;
+  *"annotate"*) exit 0 ;;
+  *"get pods"*) echo "omnivec-api-xxx Running 0 1m"; exit 0 ;;
+  *"get svc"*) echo "1.2.3.4"; exit 0 ;;
+  *"rollout"*) exit 0 ;;
+  *"cluster-info"*) echo "running"; exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "helm" '
+case "$*" in
+  *"dependency"*) exit 0 ;;
+  *"upgrade"*) echo "deployed"; exit 0 ;;
+  *"status"*) echo "{\"info\":{\"status\":\"deployed\"},\"version\":1}"; exit 0 ;;
+  *) exit 0 ;;
+esac'
+
+  write_mock "$_mb" "git" 'exit 0'
+  write_mock "$_mb" "docker" 'exit 0'
+  write_mock "$_mb" "timeout" 'shift; exec "$@"'
+
+  # Stdin: press Enter (empty) to skip token → build
+  _output=$(eval $(postprov_env "$_env") run_hook "$POSTPROVISION" "$_mb" "$_td" \
+    "" \
+    $(postprov_env "$_env"))
+  _rc=$?
+
+  if echo "$_output" | grep -qi "build from source\|Building\|acr build\|no interactive input"; then
+    pass "Scenario 9: All auth fails — falls back to build"
+  else
+    fail "Scenario 9: Build fallback" "Expected build text. exit=$_rc"
+  fi
+
+  cleanup_test_dir "$_td"
+}
+test_scenario_9
+
+# Scenario: read_input doesn't crash under set -eu
+test_read_input() {
+  # Extract read_input function and test it directly
+  _src=$(sed -n '/^read_input()/,/^}/p' "$POSTPROVISION")
+  if [ -z "$_src" ]; then
+    fail "read_input: Could not extract function"
+    return
+  fi
+
+  # Test with stdin input
+  _result=$(echo "test-val" | sh -c "set -eu; YELLOW='' NC=''; $_src; read_input 'prompt: '" 2>&1)
+  _rc=$?
+  if [ "$_rc" -eq 0 ] && echo "$_result" | grep -q "test-val"; then
+    pass "read_input: stdin pipe works under set -eu"
+  else
+    fail "read_input: stdin pipe failed (exit=$_rc)"
+  fi
+
+  # Test with empty stdin
+  _result=$(echo "" | sh -c "set -eu; YELLOW='' NC=''; $_src; read_input 'prompt: '" 2>&1)
+  _rc=$?
+  if [ "$_rc" -eq 0 ]; then
+    pass "read_input: empty stdin — no crash under set -eu"
+  else
+    fail "read_input: empty stdin crashed (exit=$_rc)"
+  fi
+
+  # Test with /dev/null (no TTY)
+  _result=$(sh -c "set -eu; YELLOW='' NC=''; $_src; read_input 'prompt: '" </dev/null 2>&1)
+  _rc=$?
+  if [ "$_rc" -eq 0 ]; then
+    pass "read_input: /dev/null stdin — no crash under set -eu"
+  else
+    fail "read_input: /dev/null stdin crashed (exit=$_rc)"
+  fi
+}
+test_read_input
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Summary
+# ═════════════════════════════════════════════════════════════════════════════
+
+echo ""
+printf "${CYAN}============================================${NC}\n"
+printf "${CYAN}  Results: %d passed, %d failed${NC}\n" "$PASS_COUNT" "$FAIL_COUNT"
+printf "${CYAN}============================================${NC}\n"
+echo ""
+
+exit "$FAIL_COUNT"

--- a/scripts/test-read-input.sh
+++ b/scripts/test-read-input.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+# Quick smoke test for postprovision.sh read_input function
+# Verifies it doesn't crash under set -eu with various input scenarios
+#
+# Usage: ./scripts/test-read-input.sh
+
+set -eu
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); printf "  \033[32m✓ PASS\033[0m  %s\n" "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf "  \033[31m✗ FAIL\033[0m  %s\n" "$1"; }
+
+echo ""
+echo "Testing postprovision.sh read_input function"
+echo ""
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Extract the read_input function from postprovision.sh
+_read_input_src=$(sed -n '/^read_input()/,/^}/p' "$SCRIPT_DIR/../hooks/postprovision.sh")
+
+if [ -z "$_read_input_src" ]; then
+  fail "Could not extract read_input function from postprovision.sh"
+  exit 1
+fi
+
+# Test 1: read_input with stdin input (simulates interactive)
+_result=$(echo "test-token-123" | sh -c "
+set -eu
+YELLOW='' NC=''
+$_read_input_src
+read_input 'Enter token: '
+")
+if echo "$_result" | grep -q "test-token-123"; then
+  pass "read_input with stdin pipe returns input value"
+else
+  fail "read_input with stdin pipe — expected 'test-token-123', got '$_result'"
+fi
+
+# Test 2: read_input with empty stdin (simulates Enter key)
+_result=$(echo "" | sh -c "
+set -eu
+YELLOW='' NC=''
+$_read_input_src
+read_input 'Enter token: '
+" 2>&1)
+_exit=$?
+if [ "$_exit" -eq 0 ]; then
+  pass "read_input with empty stdin — no crash (exit 0)"
+else
+  fail "read_input with empty stdin — crashed with exit $_exit"
+fi
+
+# Test 3: read_input with closed stdin (simulates no-TTY, no pipe)
+_result=$(sh -c "
+set -eu
+YELLOW='' NC=''
+$_read_input_src
+read_input 'Enter token: '
+" </dev/null 2>&1)
+_exit=$?
+if [ "$_exit" -eq 0 ]; then
+  pass "read_input with /dev/null stdin — no crash (exit 0)"
+else
+  fail "read_input with /dev/null stdin — crashed with exit $_exit"
+fi
+
+# Test 4: Verify token prompt text appears in output
+_output=$(echo "my-token" | sh -c "
+set -eu
+YELLOW='' NC=''
+$_read_input_src
+read_input 'Enter token for registry: '
+" 2>&1)
+if echo "$_output" | grep -q "Enter token for registry"; then
+  pass "read_input shows prompt text"
+else
+  fail "read_input did not show prompt text"
+fi
+
+# Test 5: Simulate the full auth flow — anonymous fail → token prompt → fallback
+_output=$(echo "" | sh -c "
+set -eu
+YELLOW='\033[1;33m' NC='\033[0m' GREEN='\033[0;32m' RED='\033[0;31m'
+$_read_input_src
+
+ANON_OK=false
+TOKEN_OK=false
+
+# Simulate anonymous pull failure
+printf '  Testing anonymous pull...'
+ANON_OK=false
+printf ' requires auth\n'
+
+# No stored token
+# Prompt for token
+if [ \"\$TOKEN_OK\" = 'false' ]; then
+  printf '  Registry token required for import.\n'
+  _new_token=\$(read_input '  Enter token (or Enter to build from source): ')
+  if [ -z \"\$_new_token\" ]; then
+    printf '  No token — will build from source.\n'
+  fi
+fi
+" 2>&1)
+_exit=$?
+if [ "$_exit" -eq 0 ] && echo "$_output" | grep -q "token required"; then
+  pass "Full auth flow: anon fail → prompt → empty input → build fallback (no crash)"
+else
+  fail "Full auth flow crashed (exit $_exit) or missing prompt. Output: $_output"
+fi
+
+echo ""
+echo "============================================"
+printf "  Results: %d passed, %d failed\n" "$PASS" "$FAIL"
+echo "============================================"
+echo ""
+
+exit "$FAIL"

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1338,7 +1338,7 @@
                                     <input type="text" class="form-input" id="playground-query" placeholder="Enter your search query..." style="font-size: 16px; padding: 14px 16px;">
                                 </div>
                                 <div class="form-group" style="margin-bottom: 0; position: relative;">
-                                    <label class="form-label">Vector Indexes</label>
+                                    <label class="form-label">Vector Embedding Policies</label>
                                     <div id="playground-destination-container" class="form-input" style="padding: 14px 16px; cursor: pointer; display: flex; align-items: center; justify-content: space-between;" onclick="toggleIndexDropdown()">
                                         <span id="playground-dest-summary" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">Select indexes...</span>
                                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14" style="flex-shrink: 0; margin-left: 8px;"><path d="m6 9 6 6 6-6"/></svg>
@@ -1894,8 +1894,8 @@
                             <div class="form-group" style="margin-top: 16px;">
                                 <label class="form-label">Processing Mode</label>
                                 <select class="form-input" name="processing_mode" id="pipeline-processing-mode">
+                                    <option value="inline">Inline (changefeed embeds directly — recommended)</option>
                                     <option value="queue">Queue (jobs created, worker processes)</option>
-                                    <option value="inline">Inline (changefeed patches directly)</option>
                                 </select>
                                 <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
                                     Queue mode: Change feed creates jobs, pipeline worker processes them. Inline mode: Change feed patches documents directly (faster for same source/destination).
@@ -2058,7 +2058,7 @@
                                 </div>
                                 <div id="pl-dest-existing-test-result" style="margin-top: 8px;"></div>
                                 <div class="form-group" id="pl-dest-vector-policy-group" style="display: none; margin-top: 12px;">
-                                    <label class="form-label">Vector Index Policy</label>
+                                    <label class="form-label">Vector Embedding Policy</label>
                                     <select class="form-input" id="pl-dest-vector-policy"></select>
                                     <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
                                         Select which vector embedding field to use for this pipeline
@@ -3389,7 +3389,7 @@
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18">
                             <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/>
                         </svg>
-                        Fetch Vector Index Details
+                        Fetch Embedding Policies
                     </button>
                     <div id="dest-detail-vector-result" style="margin-top: 16px;"></div>
                 `;
@@ -3956,7 +3956,7 @@
                     </div>
 
                     <div class="form-group" style="margin-top: 16px;">
-                        <label class="form-label">Vector Index Path</label>
+                        <label class="form-label">Embedding Policy Path</label>
                         <div style="padding: 10px 12px; background: var(--bg-tertiary); border-radius: var(--radius-sm); font-family: monospace; font-size: 13px;">
                             /${pipeline.vector_index_path || '<span style="color: var(--text-tertiary);">not set</span>'}
                         </div>
@@ -4052,29 +4052,30 @@
                 configPanel.innerHTML = `
                     <h4 style="margin: 0 0 20px 0; font-size: 16px;">Content Strategy</h4>
                     <div class="form-group">
-                        <select class="form-input" id="pip-detail-content-strategy" onchange="markPipelineDetailDirty(); renderPipelineDetailTab(pipelines.find(p=>p.id===currentPipelineId));">
-                            <option value="truncate" ${cs === 'truncate' ? 'selected' : ''}>Truncate — embed full text as single vector (default)</option>
+                        <select class="form-input" id="pip-detail-content-strategy" disabled style="opacity: 0.7; cursor: not-allowed;">
+                            <option value="truncate" ${cs === 'truncate' ? 'selected' : ''}>Truncate — embed full text as single vector</option>
                             <option value="chunk" ${cs === 'chunk' ? 'selected' : ''}>Chunk — split text into overlapping chunks, embed each</option>
                         </select>
+                        <small style="color: var(--text-tertiary); font-size: 11px; margin-top: 4px; display: block;">🔒 Cannot be changed after creation — would invalidate existing vectors</small>
                     </div>
                     ${isChunk ? `
                     <div style="padding: 20px; background: var(--bg-tertiary); border-radius: 8px; margin-top: 16px;">
-                        <div style="font-size: 11px; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 16px; font-weight: 600; letter-spacing: 0.5px;">Chunk Configuration</div>
+                        <div style="font-size: 11px; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 16px; font-weight: 600; letter-spacing: 0.5px;">Chunk Configuration (read-only)</div>
                         <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
                             <div class="form-group" style="margin-bottom: 0;">
                                 <label class="form-label">Chunk Size (characters)</label>
-                                <input type="number" class="form-input" id="pip-detail-chunk-size" value="${cc.chunk_size || 1000}" min="100" max="10000" oninput="markPipelineDetailDirty()">
+                                <input type="number" class="form-input" id="pip-detail-chunk-size" value="${cc.chunk_size || 1000}" disabled style="opacity: 0.7; cursor: not-allowed;">
                                 <small style="color: var(--text-tertiary); font-size: 11px; margin-top: 4px; display: block;">Max characters per chunk</small>
                             </div>
                             <div class="form-group" style="margin-bottom: 0;">
                                 <label class="form-label">Chunk Overlap (characters)</label>
-                                <input type="number" class="form-input" id="pip-detail-chunk-overlap" value="${cc.chunk_overlap || 200}" min="0" max="2000" oninput="markPipelineDetailDirty()">
+                                <input type="number" class="form-input" id="pip-detail-chunk-overlap" value="${cc.chunk_overlap || 200}" disabled style="opacity: 0.7; cursor: not-allowed;">
                                 <small style="color: var(--text-tertiary); font-size: 11px; margin-top: 4px; display: block;">Overlapping characters between adjacent chunks</small>
                             </div>
                         </div>
                         <div class="form-group" style="margin-top: 16px; margin-bottom: 0;">
                             <label style="display: flex; align-items: center; gap: 12px; cursor: pointer; padding: 12px; background: var(--bg-secondary); border-radius: 8px;">
-                                <input type="checkbox" id="pip-detail-store-text" ${cc.store_text ? 'checked' : ''} style="width: 18px; height: 18px;" onchange="markPipelineDetailDirty()">
+                                <input type="checkbox" id="pip-detail-store-text" ${cc.store_text ? 'checked' : ''} style="width: 18px; height: 18px;" disabled>
                                 <div>
                                     <div style="font-weight: 500; font-size: 14px;">Store Extracted Text</div>
                                     <div style="font-size: 12px; color: var(--text-tertiary);">Each chunk includes the text alongside the embedding vector</div>
@@ -4083,7 +4084,7 @@
                         </div>
                         <div class="form-group" style="margin-top: 16px; margin-bottom: 0;">
                             <label class="form-label">Chunk Doc ID Pattern</label>
-                            <input type="text" class="form-input" id="pip-detail-chunk-doc-id-pattern" value="${cc.doc_id_pattern || '{source}-chunk-{chunk}'}" placeholder="{source}-chunk-{chunk}" oninput="markPipelineDetailDirty()">
+                            <input type="text" class="form-input" id="pip-detail-chunk-doc-id-pattern" value="${cc.doc_id_pattern || '{source}-chunk-{chunk}'}" disabled style="opacity: 0.7; cursor: not-allowed;">
                             <small style="color: var(--text-tertiary); font-size: 11px; margin-top: 4px; display: block;">
                                 Variables: <code>{source}</code> (filename), <code>{chunk}</code> (index), <code>{source_hash}</code>, <code>{pipeline}</code>
                             </small>
@@ -4105,7 +4106,7 @@
                     ` : ''}
                 `;
             } else if (currentPipelineTab === 'processing') {
-                const pm = pipeline.processing_mode || 'queue';
+                const pm = pipeline.processing_mode || 'inline';
                 configPanel.innerHTML = `
                     <h4 style="margin: 0 0 20px 0; font-size: 16px;">Processing Mode</h4>
                     <p style="color: var(--text-tertiary); font-size: 13px; margin-bottom: 20px;">
@@ -4113,10 +4114,11 @@
                     </p>
                     <div class="form-group">
                         <label class="form-label">Mode</label>
-                        <select class="form-input" id="pip-detail-processing-mode" onchange="markPipelineDetailDirty()">
+                        <select class="form-input" id="pip-detail-processing-mode" disabled style="opacity: 0.7; cursor: not-allowed;">
                             <option value="queue" ${pm === 'queue' ? 'selected' : ''}>Queue — Jobs created, worker processes them</option>
-                            <option value="inline" ${pm === 'inline' ? 'selected' : ''}>Inline — Change feed patches documents directly</option>
+                            <option value="inline" ${pm === 'inline' ? 'selected' : ''}>Inline — Change feed embeds directly</option>
                         </select>
+                        <small style="color: var(--text-tertiary); font-size: 11px; margin-top: 4px; display: block;">🔒 Cannot be changed after creation</small>
                     </div>
                     <div style="margin-top: 20px; padding: 16px; background: var(--bg-tertiary); border-radius: 8px;">
                         <div style="font-size: 11px; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 12px; font-weight: 600;">How It Works</div>
@@ -4472,7 +4474,7 @@
                         metadata_mapping: pipeline.metadata_mapping || {},
                         content_strategy: editedPipelineData.content_strategy || pipeline.content_strategy || 'truncate',
                         chunk_config: editedPipelineData.chunk_config || pipeline.chunk_config || null,
-                        processing_mode: editedPipelineData.processing_mode || pipeline.processing_mode || 'queue',
+                        processing_mode: editedPipelineData.processing_mode || pipeline.processing_mode || 'inline',
                     })
                 });
 
@@ -5488,7 +5490,7 @@
 
             // --- Create Pipeline ---
             const contentStrategy = formData.get('content_strategy') || 'truncate';
-            const processingMode = formData.get('processing_mode') || 'queue';
+            const processingMode = formData.get('processing_mode') || 'inline';
 
             // Collect content_fields from pipeline source config
             const pipelineContentTags = document.getElementById('pipeline-content-field-tags');

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2866,10 +2866,16 @@
                             <ol style="margin: 0; padding-left: 20px; color: var(--text-secondary); line-height: 2;">
                                 <li>Verify the service account has correct identity annotations</li>
                                 <li>Check storage account firewall allows AKS subnet</li>
-                                <li style="margin-top: 8px;">Assign RBAC role via CLI:
-                                    <div style="background: var(--bg-secondary); padding: 12px; border-radius: 6px; margin: 8px 0; font-family: 'JetBrains Mono', monospace; font-size: 11px; overflow-x: auto; white-space: pre-wrap;">az role assignment create \\
+                                <li style="margin-top: 8px;">Assign RBAC role:
+                                    <div style="font-size: 11px; color: var(--text-tertiary); margin-bottom: 4px;">Bash / Linux:</div>
+                                    <div style="background: var(--bg-secondary); padding: 12px; border-radius: 6px; margin: 4px 0 8px 0; font-family: var(--font-mono), monospace; font-size: 11px; overflow-x: auto; white-space: pre-wrap;">az role assignment create \\
   --assignee &lt;managed-identity-client-id&gt; \\
   --role "Storage Blob Data Reader" \\
+  --scope /subscriptions/.../storageAccounts/&lt;name&gt;</div>
+                                    <div style="font-size: 11px; color: var(--text-tertiary); margin-bottom: 4px;">PowerShell / Windows:</div>
+                                    <div style="background: var(--bg-secondary); padding: 12px; border-radius: 6px; margin: 4px 0; font-family: var(--font-mono), monospace; font-size: 11px; overflow-x: auto; white-space: pre-wrap;">az role assignment create \`
+  --assignee &lt;managed-identity-client-id&gt; \`
+  --role "Storage Blob Data Reader" \`
   --scope /subscriptions/.../storageAccounts/&lt;name&gt;</div>
                                 </li>
                                 <li style="margin-top: 8px;"><strong>Azure Portal:</strong> Storage Account → Access Control (IAM) → Add role assignment → Select "Storage Blob Data Reader" → Assign to your managed identity</li>
@@ -3346,8 +3352,16 @@
                                 <li style="margin-top: 8px;">Find resource group:
                                     <div style="background: var(--bg-secondary); padding: 8px; border-radius: 6px; margin: 6px 0; font-family: 'JetBrains Mono', monospace; font-size: 11px;">az cosmosdb list --query "[?name=='ACCOUNT'].resourceGroup" -o tsv</div>
                                 </li>
-                                <li style="margin-top: 8px;">Assign RBAC role (PowerShell):
-                                    <div style="background: var(--bg-secondary); padding: 12px; border-radius: 6px; margin: 8px 0; font-family: 'JetBrains Mono', monospace; font-size: 11px; overflow-x: auto; white-space: pre-wrap;">az cosmosdb sql role assignment create \`
+                                <li style="margin-top: 8px;">Assign RBAC role:
+                                    <div style="font-size: 11px; color: var(--text-tertiary); margin-bottom: 4px;">Bash / Linux:</div>
+                                    <div style="background: var(--bg-secondary); padding: 12px; border-radius: 6px; margin: 4px 0 8px 0; font-family: var(--font-mono), monospace; font-size: 11px; overflow-x: auto; white-space: pre-wrap;">az cosmosdb sql role assignment create \\
+  --account-name "ACCOUNT" \\
+  --resource-group "RG_NAME" \\
+  --role-definition-id "00000000-0000-0000-0000-000000000002" \\
+  --principal-id "PRINCIPAL_ID" \\
+  --scope "/dbs"</div>
+                                    <div style="font-size: 11px; color: var(--text-tertiary); margin-bottom: 4px;">PowerShell / Windows:</div>
+                                    <div style="background: var(--bg-secondary); padding: 12px; border-radius: 6px; margin: 4px 0; font-family: var(--font-mono), monospace; font-size: 11px; overflow-x: auto; white-space: pre-wrap;">az cosmosdb sql role assignment create \`
   --account-name "ACCOUNT" \`
   --resource-group "RG_NAME" \`
   --role-definition-id "00000000-0000-0000-0000-000000000002" \`
@@ -5931,10 +5945,17 @@
                 const accountName = accountMatch ? accountMatch[1] : (config.endpoint ? config.endpoint.replace('https://', '').split('.')[0] : 'ACCOUNT_NAME');
                 return `
                     <div style="background: var(--bg-tertiary); padding: 12px; border-radius: var(--radius-md); margin-top: 8px;">
-                        <div style="font-weight: 500; margin-bottom: 8px; color: var(--text-primary);">Grant Access via PowerShell:</div>
+                        <div style="font-weight: 500; margin-bottom: 8px; color: var(--text-primary);">Grant Access — Bash / Linux:</div>
                         <div style="font-size: 11px; color: var(--text-tertiary); margin-bottom: 6px;">First, find the resource group:</div>
                         <pre style="background: #0d1117; padding: 8px; border-radius: 6px; font-size: 11px; overflow-x: auto; margin-bottom: 8px;"><code>az cosmosdb list --query "[?name=='${accountName}'].resourceGroup" -o tsv</code></pre>
                         <div style="font-size: 11px; color: var(--text-tertiary); margin-bottom: 6px;">Then run (replace RG_NAME with result above):</div>
+                        <pre style="background: #0d1117; padding: 10px; border-radius: 6px; font-size: 11px; overflow-x: auto; margin-bottom: 8px;"><code>az cosmosdb sql role assignment create \\
+  --account-name "${accountName}" \\
+  --resource-group "RG_NAME" \\
+  --role-definition-id "00000000-0000-0000-0000-000000000002" \\
+  --principal-id "${identityId}" \\
+  --scope "/dbs"</code></pre>
+                        <div style="font-weight: 500; margin-bottom: 8px; color: var(--text-primary);">PowerShell / Windows:</div>
                         <pre style="background: #0d1117; padding: 10px; border-radius: 6px; font-size: 11px; overflow-x: auto; margin-bottom: 8px;"><code>az cosmosdb sql role assignment create \`
   --account-name "${accountName}" \`
   --resource-group "RG_NAME" \`
@@ -5970,9 +5991,13 @@
                             <details style="font-size: 12px;">
                                 <summary style="cursor: pointer; color: var(--accent-primary); margin-bottom: 8px;">How to grant access to another identity</summary>
                                 <div style="margin-top: 8px;">
-                                    <div style="font-weight: 500; margin-bottom: 6px; color: var(--text-primary);">Azure CLI:</div>
+                                    <div style="font-weight: 500; margin-bottom: 6px; color: var(--text-primary);">Bash / Linux:</div>
                                     <pre style="background: #0d1117; padding: 10px; border-radius: 6px; font-size: 11px; overflow-x: auto; margin-bottom: 8px;"><code>az role assignment create --role "Storage Blob Data Reader" \\
   --assignee-object-id "YOUR_IDENTITY_ID" \\
+  --scope "/subscriptions/SUB_ID/resourceGroups/RG/providers/Microsoft.Storage/storageAccounts/${accountName}"</code></pre>
+                                    <div style="font-weight: 500; margin-bottom: 6px; color: var(--text-primary);">PowerShell / Windows:</div>
+                                    <pre style="background: #0d1117; padding: 10px; border-radius: 6px; font-size: 11px; overflow-x: auto; margin-bottom: 8px;"><code>az role assignment create --role "Storage Blob Data Reader" \`
+  --assignee-object-id "YOUR_IDENTITY_ID" \`
   --scope "/subscriptions/SUB_ID/resourceGroups/RG/providers/Microsoft.Storage/storageAccounts/${accountName}"</code></pre>
                                     <div style="font-weight: 500; margin-bottom: 6px; color: var(--text-primary);">Azure Portal:</div>
                                     <ol style="padding-left: 16px; color: var(--text-secondary); margin: 0;">
@@ -5998,10 +6023,15 @@
                             <details style="font-size: 12px;">
                                 <summary style="cursor: pointer; color: var(--accent-primary); margin-bottom: 8px;">How to grant access to another identity</summary>
                                 <div style="margin-top: 8px;">
-                                    <div style="font-weight: 500; margin-bottom: 6px; color: var(--text-primary);">Azure CLI:</div>
+                                    <div style="font-weight: 500; margin-bottom: 6px; color: var(--text-primary);">Bash / Linux:</div>
                                     <pre style="background: #0d1117; padding: 10px; border-radius: 6px; font-size: 11px; overflow-x: auto; margin-bottom: 8px;"><code>az cosmosdb sql role assignment create \\
   --account-name ${accountName} --resource-group RG \\
   --role-definition-id "00000000-0000-0000-0000-000000000002" \\
+  --principal-id "YOUR_IDENTITY_ID" --scope "/"</code></pre>
+                                    <div style="font-weight: 500; margin-bottom: 6px; color: var(--text-primary);">PowerShell / Windows:</div>
+                                    <pre style="background: #0d1117; padding: 10px; border-radius: 6px; font-size: 11px; overflow-x: auto; margin-bottom: 8px;"><code>az cosmosdb sql role assignment create \`
+  --account-name ${accountName} --resource-group RG \`
+  --role-definition-id "00000000-0000-0000-0000-000000000002" \`
   --principal-id "YOUR_IDENTITY_ID" --scope "/"</code></pre>
                                     <div style="font-weight: 500; margin-bottom: 6px; color: var(--text-primary);">Azure Portal:</div>
                                     <ol style="padding-left: 16px; color: var(--text-secondary); margin: 0;">
@@ -6255,8 +6285,16 @@
                 const accountName = config.endpoint ? config.endpoint.replace('https://', '').split('.')[0] : 'ACCOUNT_NAME';
                 return `
                     <div style="background: var(--bg-secondary); padding: 12px; border-radius: var(--radius-md); margin-top: 8px; font-size: 12px;">
-                        <div style="font-weight: 500; margin-bottom: 8px; color: var(--text-primary);">Grant Access (PowerShell):</div>
+                        <div style="font-weight: 500; margin-bottom: 8px; color: var(--text-primary);">Grant Access:</div>
                         <div style="font-size: 10px; color: var(--text-tertiary); margin-bottom: 4px;">Find RG: <code style="background:#0d1117;padding:2px 6px;border-radius:3px;">az cosmosdb list --query "[?name=='${accountName}'].resourceGroup" -o tsv</code></div>
+                        <div style="font-size: 10px; color: var(--text-tertiary); margin-bottom: 2px;">Bash / Linux:</div>
+                        <pre style="background: #0d1117; padding: 10px; border-radius: 6px; font-size: 11px; overflow-x: auto; margin: 0 0 8px 0;"><code>az cosmosdb sql role assignment create \\
+  --account-name "${accountName}" \\
+  --resource-group "RG_NAME" \\
+  --role-definition-id "00000000-0000-0000-0000-000000000002" \\
+  --principal-id "${identityId}" \\
+  --scope "/dbs"</code></pre>
+                        <div style="font-size: 10px; color: var(--text-tertiary); margin-bottom: 2px;">PowerShell / Windows:</div>
                         <pre style="background: #0d1117; padding: 10px; border-radius: 6px; font-size: 11px; overflow-x: auto; margin: 0;"><code>az cosmosdb sql role assignment create \`
   --account-name "${accountName}" \`
   --resource-group "RG_NAME" \`

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1929,7 +1929,7 @@
                                 <div class="form-group">
                                     <label class="form-label">Source</label>
                                     <div style="display: flex; gap: 8px;">
-                                        <select class="form-input" name="source_id" id="pipeline-source-select" onchange="updatePipelineSourceConfig()" style="flex: 1;">
+                                        <select class="form-input" name="source_id" id="pipeline-source-select" onchange="updatePipelineSourceConfig(); updateSameContainerIndicator()" style="flex: 1;">
                                             <option value="">Select a source...</option>
                                         </select>
                                         <button type="button" class="btn btn-secondary" onclick="testExistingPipelineSource()" style="white-space: nowrap;">
@@ -4848,7 +4848,10 @@
             const destId = document.getElementById('pipeline-destination')?.value;
             const destObj = destinations.find(d => d.id === destId);
 
-            const sameContainer = srcObj && destObj &&
+            // Both must be selected to evaluate
+            const bothSelected = srcObj && destObj;
+
+            const sameContainer = bothSelected &&
                 srcObj.type === 'cosmosdb' && destObj.type === 'cosmosdb-vector' &&
                 srcObj.config?.endpoint === destObj.config?.endpoint &&
                 srcObj.config?.database === destObj.config?.database &&
@@ -4856,10 +4859,14 @@
 
             indicator.style.display = sameContainer ? 'block' : 'none';
 
-            // Show doc-id-pattern only when source and destination are different (queue mode)
+            // Show doc-id-pattern only when both are selected AND they are different
             const docIdGroup = document.getElementById('doc-id-pattern-group');
             if (docIdGroup) {
-                docIdGroup.style.display = sameContainer ? 'none' : 'block';
+                if (!bothSelected) {
+                    docIdGroup.style.display = 'none';  // Hide until both selected
+                } else {
+                    docIdGroup.style.display = sameContainer ? 'none' : 'block';
+                }
             }
         }
 

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5964,8 +5964,8 @@
   --scope "/dbs"</code></pre>
                         <div style="font-weight: 500; margin-bottom: 8px; color: var(--text-primary);">Or via Azure Portal:</div>
                         <ol style="font-size: 12px; padding-left: 20px; color: var(--text-secondary);">
-                            <li>Go to CosmosDB Account <strong>${accountName}</strong> → Settings → Keys</li>
-                            <li>Click "Role assignments" tab</li>
+                            <li>Go to CosmosDB Account <strong>${accountName}</strong> → Access Control (IAM)</li>
+                            <li>Click "Add role assignment"</li>
                             <li>Add: <strong>Cosmos DB Built-in Data Contributor</strong></li>
                             <li>Assign to managed identity with principal ID: <strong>${identityId}</strong></li>
                         </ol>
@@ -6035,7 +6035,7 @@
   --principal-id "YOUR_IDENTITY_ID" --scope "/"</code></pre>
                                     <div style="font-weight: 500; margin-bottom: 6px; color: var(--text-primary);">Azure Portal:</div>
                                     <ol style="padding-left: 16px; color: var(--text-secondary); margin: 0;">
-                                        <li>CosmosDB → Settings → Keys → Role assignments</li>
+                                        <li>CosmosDB → Access Control (IAM) → Add role assignment</li>
                                         <li>Add Cosmos DB Built-in Data Contributor</li>
                                         <li>Select your Managed Identity</li>
                                     </ol>


### PR DESCRIPTION
When anonymous pull fails on Linux, the script should prompt for a token or fall back to building from source. Instead it crashed silently because \ead -r\ failed under \set -eu\ with no TTY.

Fix: \|| true\ on read, check \-e /dev/tty\, graceful skip message.