### PR TITLE
Pipeline wizard: 'Same as source' destination shortcut

### DIFF
--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2071,7 +2071,13 @@
                                 <div id="pl-dest-existing-test-result" style="margin-top: 8px;"></div>
                                 <div class="form-group" id="pl-dest-vector-policy-group" style="display: none; margin-top: 12px;">
                                     <label class="form-label">Vector Embedding Policy</label>
-                                    <select class="form-input" id="pl-dest-vector-policy"></select>
+                                    <div style="display: flex; gap: 8px;">
+                                        <select class="form-input" id="pl-dest-vector-policy" style="flex: 1;"></select>
+                                        <button type="button" class="btn btn-secondary" onclick="loadVectorPoliciesForDest()" style="white-space: nowrap;" title="Refresh embedding policies">
+                                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><path d="M21 2v6h-6"/><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M3 22v-6h6"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/></svg>
+                                            Refresh
+                                        </button>
+                                    </div>
                                     <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
                                         Select which vector embedding field to use for this pipeline
                                     </small>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -4652,6 +4652,14 @@
             if (plDestName) plDestName.value = '';
             const sameAsSource = document.getElementById('pl-dest-same-as-source');
             if (sameAsSource) sameAsSource.checked = false;
+            // Reset same-as-source visual state
+            const sameLabel = document.getElementById('pl-dest-same-as-source-label');
+            if (sameLabel) { sameLabel.style.borderColor = 'transparent'; sameLabel.style.background = 'var(--bg-tertiary)'; }
+            const sameInfo = document.getElementById('pl-dest-same-as-source-info');
+            if (sameInfo) sameInfo.style.display = 'none';
+            // Restore destination dropdown visibility
+            const destDropdownGroup = document.getElementById('pipeline-destination')?.closest('.form-group');
+            if (destDropdownGroup) destDropdownGroup.style.display = '';
         }
 
         // ── Inline Source/Destination Creation in Pipeline Modal ──
@@ -4711,7 +4719,12 @@
                 if (data.success) {
                     resultDiv.innerHTML = `<span style="color: var(--success); font-size: 13px;">Connected</span>`;
                     // Populate vector policies from test result
-                    const vi = data.result?.vector_indexes || [];
+                    const vi = data.vector_indexes || data.result?.vector_indexes || [];
+                    if (vi.length > 0) {
+                        // Update cached policies on the destination object
+                        const dest = destinations.find(d => d.id === destId);
+                        if (dest && dest.config) dest.config.vector_indexes = vi;
+                    }
                     populateVectorPolicyDropdown(vi);
                 } else {
                     resultDiv.innerHTML = `<span style="color: var(--error); font-size: 13px;">Failed: ${data.error}</span>`;
@@ -4721,22 +4734,39 @@
             }
         }
 
-        function loadVectorPoliciesForDest() {
+        async function loadVectorPoliciesForDest() {
             const destId = document.getElementById('pipeline-destination').value;
             if (!destId) {
                 document.getElementById('pl-dest-vector-policy-group').style.display = 'none';
                 return;
             }
-            // Try to load from destination's stored config first
+            // Try cached policies first
             const dest = destinations.find(d => d.id === destId);
             const vi = dest?.config?.vector_indexes || [];
             if (vi.length > 0) {
                 populateVectorPolicyDropdown(vi);
             } else {
-                // No cached policies — show the dropdown prompting user to test
+                // No cached policies — try live fetch via test-connection
                 const group = document.getElementById('pl-dest-vector-policy-group');
                 group.style.display = 'block';
                 const select = document.getElementById('pl-dest-vector-policy');
+                select.innerHTML = '<option value="">Loading policies...</option>';
+
+                try {
+                    const res = await apiFetch(`/api/destinations/${destId}/test`, { method: 'POST' });
+                    if (res.ok) {
+                        const data = await res.json();
+                        const policies = data.vector_indexes || data.result?.vector_indexes || [];
+                        if (policies.length > 0) {
+                            // Cache them back
+                            if (dest && dest.config) dest.config.vector_indexes = policies;
+                            populateVectorPolicyDropdown(policies);
+                            return;
+                        }
+                    }
+                } catch (_) {}
+
+                // Fallback: prompt user to test
                 select.innerHTML = '<option value="">— Test connection to load policies —</option>';
                 document.getElementById('pl-dest-vector-policy-warning').style.display = 'block';
             }

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2046,6 +2046,18 @@
 
                             <!-- Mode: Select Existing -->
                             <div id="pl-dest-existing-section">
+                                <div class="form-group" style="margin-bottom: 12px;">
+                                    <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; padding: 12px; background: var(--bg-tertiary); border-radius: var(--radius-md); border: 2px solid transparent;" id="pl-dest-same-as-source-label">
+                                        <input type="checkbox" id="pl-dest-same-as-source" onchange="toggleDestSameAsSource()" style="width: 18px; height: 18px;">
+                                        <div>
+                                            <div style="font-weight: 500; font-size: 13px;">Write vectors back to source container</div>
+                                            <div style="font-size: 12px; color: var(--text-tertiary);">Embeds vectors directly into source documents (inline mode). No separate destination needed.</div>
+                                        </div>
+                                    </label>
+                                </div>
+                                <div id="pl-dest-same-as-source-info" style="display: none; margin-bottom: 12px; padding: 10px 14px; background: var(--info-muted); border: 1px solid var(--info); border-radius: var(--radius-sm); font-size: 12px; color: var(--text-secondary);">
+                                    <strong>Note:</strong> The managed identity needs <strong>Cosmos DB Built-in Data Contributor</strong> role (read + write) on the source container.
+                                </div>
                                 <div class="form-group">
                                     <label class="form-label">Vector Store</label>
                                     <div style="display: flex; gap: 8px;">
@@ -2066,18 +2078,6 @@
                                     <div id="pl-dest-vector-policy-warning" style="display: none; margin-top: 8px; padding: 8px 12px; background: var(--warning-muted, rgba(255,204,0,0.1)); border: 1px solid var(--warning); border-radius: var(--radius-sm); font-size: 12px; color: var(--warning);">
                                         ⚠ No vector policies found on destination. Test the connection or check vector indexing configuration.
                                     </div>
-                                </div>
-                                <div class="form-group" style="margin-top: 12px; margin-bottom: 12px;">
-                                    <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; padding: 12px; background: var(--bg-tertiary); border-radius: var(--radius-md); border: 2px solid transparent;" id="pl-dest-same-as-source-label">
-                                        <input type="checkbox" id="pl-dest-same-as-source" onchange="toggleDestSameAsSource()" style="width: 18px; height: 18px;">
-                                        <div>
-                                            <div style="font-weight: 500; font-size: 13px;">Write vectors back to source container</div>
-                                            <div style="font-size: 12px; color: var(--text-tertiary);">Embeds vectors directly into source documents (inline mode). No separate destination needed.</div>
-                                        </div>
-                                    </label>
-                                </div>
-                                <div id="pl-dest-same-as-source-info" style="display: none; margin-bottom: 12px; padding: 10px 14px; background: var(--info-muted); border: 1px solid var(--info); border-radius: var(--radius-sm); font-size: 12px; color: var(--text-secondary);">
-                                    <strong>Note:</strong> The managed identity needs <strong>Cosmos DB Built-in Data Contributor</strong> role (read + write) on the source container.
                                 </div>
                                 <div id="pl-dest-same-container-indicator" style="display: none; margin-top: 12px; padding: 10px 14px; background: rgba(34,197,94,0.08); border: 1px solid var(--success); border-radius: var(--radius-sm); font-size: 13px; color: var(--success);">
                                     ✓ Source and destination are the same container (inline mode recommended)
@@ -4740,33 +4740,36 @@
                 document.getElementById('pl-dest-vector-policy-group').style.display = 'none';
                 return;
             }
-            // Try cached policies first
+
             const dest = destinations.find(d => d.id === destId);
-            const vi = dest?.config?.vector_indexes || [];
-            if (vi.length > 0) {
-                populateVectorPolicyDropdown(vi);
+            const cachedVi = dest?.config?.vector_indexes || [];
+            const group = document.getElementById('pl-dest-vector-policy-group');
+            const select = document.getElementById('pl-dest-vector-policy');
+            group.style.display = 'block';
+
+            // Show cached while fetching live
+            if (cachedVi.length > 0) {
+                populateVectorPolicyDropdown(cachedVi);
             } else {
-                // No cached policies — try live fetch via test-connection
-                const group = document.getElementById('pl-dest-vector-policy-group');
-                group.style.display = 'block';
-                const select = document.getElementById('pl-dest-vector-policy');
-                select.innerHTML = '<option value="">Loading policies...</option>';
+                select.innerHTML = '<option value="">Loading embedding policies...</option>';
+            }
 
-                try {
-                    const res = await apiFetch(`/api/destinations/${destId}/test`, { method: 'POST' });
-                    if (res.ok) {
-                        const data = await res.json();
-                        const policies = data.vector_indexes || data.result?.vector_indexes || [];
-                        if (policies.length > 0) {
-                            // Cache them back
-                            if (dest && dest.config) dest.config.vector_indexes = policies;
-                            populateVectorPolicyDropdown(policies);
-                            return;
-                        }
+            // Always fetch live to get latest policies
+            try {
+                const res = await apiFetch(`/api/destinations/${destId}/test`, { method: 'POST' });
+                if (res.ok) {
+                    const data = await res.json();
+                    const policies = data.vector_indexes || data.result?.vector_indexes || [];
+                    if (policies.length > 0) {
+                        if (dest && dest.config) dest.config.vector_indexes = policies;
+                        populateVectorPolicyDropdown(policies);
+                        return;
                     }
-                } catch (_) {}
+                }
+            } catch (_) {}
 
-                // Fallback: prompt user to test
+            // If live fetch failed and no cache, show warning
+            if (cachedVi.length === 0) {
                 select.innerHTML = '<option value="">— Test connection to load policies —</option>';
                 document.getElementById('pl-dest-vector-policy-warning').style.display = 'block';
             }

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2067,11 +2067,17 @@
                                         ⚠ No vector policies found on destination. Test the connection or check vector indexing configuration.
                                     </div>
                                 </div>
-                                <div class="form-group" style="margin-top: 12px;">
-                                    <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
-                                        <input type="checkbox" id="pl-dest-same-as-source" onchange="toggleDestSameAsSource()">
-                                        <span style="font-size: 13px; color: var(--text-secondary);">Same as source (write vectors to the source container)</span>
+                                <div class="form-group" style="margin-top: 12px; margin-bottom: 12px;">
+                                    <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; padding: 12px; background: var(--bg-tertiary); border-radius: var(--radius-md); border: 2px solid transparent;" id="pl-dest-same-as-source-label">
+                                        <input type="checkbox" id="pl-dest-same-as-source" onchange="toggleDestSameAsSource()" style="width: 18px; height: 18px;">
+                                        <div>
+                                            <div style="font-weight: 500; font-size: 13px;">Write vectors back to source container</div>
+                                            <div style="font-size: 12px; color: var(--text-tertiary);">Embeds vectors directly into source documents (inline mode). No separate destination needed.</div>
+                                        </div>
                                     </label>
+                                </div>
+                                <div id="pl-dest-same-as-source-info" style="display: none; margin-bottom: 12px; padding: 10px 14px; background: var(--info-muted); border: 1px solid var(--info); border-radius: var(--radius-sm); font-size: 12px; color: var(--text-secondary);">
+                                    <strong>Note:</strong> The managed identity needs <strong>Cosmos DB Built-in Data Contributor</strong> role (read + write) on the source container.
                                 </div>
                                 <div id="pl-dest-same-container-indicator" style="display: none; margin-top: 12px; padding: 10px 14px; background: rgba(34,197,94,0.08); border: 1px solid var(--success); border-radius: var(--radius-sm); font-size: 13px; color: var(--success);">
                                     ✓ Source and destination are the same container (inline mode recommended)
@@ -4768,70 +4774,122 @@
             const destSelect = document.getElementById('pipeline-destination');
             const processingModeSelect = document.getElementById('pipeline-processing-mode');
             const resultDiv = document.getElementById('pl-dest-existing-test-result');
+            const infoDiv = document.getElementById('pl-dest-same-as-source-info');
+            const label = document.getElementById('pl-dest-same-as-source-label');
+
+            // Hide/show destination selection when same-as-source is checked
+            const destDropdownGroup = destSelect?.closest('.form-group');
+            const testBtn = destDropdownGroup?.querySelector('.btn-secondary');
+
             if (checked) {
-                // Find destination matching the selected source's config
+                label.style.borderColor = 'var(--accent-primary)';
+                label.style.background = 'var(--accent-muted)';
+
+                // Validate source is selected and not blob
                 const sourceId = document.getElementById('pipeline-source-select').value;
                 const source = sources.find(s => s.id === sourceId);
-                if (source && source.config) {
-                    // Find a destination with matching endpoint/database/container
-                    const match = destinations.find(d =>
-                        d.config?.endpoint === source.config.endpoint &&
-                        d.config?.database === source.config.database &&
-                        d.config?.container === source.config.container
-                    );
-                    if (match) {
-                        destSelect.value = match.id;
-                        // Auto-select inline mode when source = destination
+                if (!source) {
+                    resultDiv.innerHTML = '<span style="color: var(--error); font-size: 13px;">Please select a source first.</span>';
+                    document.getElementById('pl-dest-same-as-source').checked = false;
+                    label.style.borderColor = 'transparent';
+                    label.style.background = 'var(--bg-tertiary)';
+                    return;
+                }
+                if (source.type === 'azure-blob') {
+                    resultDiv.innerHTML = '<span style="color: var(--error); font-size: 13px;">Blob sources cannot be used as destinations. Select a different destination.</span>';
+                    document.getElementById('pl-dest-same-as-source').checked = false;
+                    label.style.borderColor = 'transparent';
+                    label.style.background = 'var(--bg-tertiary)';
+                    return;
+                }
+
+                // Hide destination dropdown (auto-fill from source)
+                if (destDropdownGroup) destDropdownGroup.style.display = 'none';
+                infoDiv.style.display = 'block';
+
+                // Determine destination type from source type
+                const destTypeMap = { 'cosmosdb': 'cosmosdb-vector', 'postgresql': 'pgvector', 'mssql': 'mssql' };
+                const destType = destTypeMap[source.type] || 'cosmosdb-vector';
+
+                // Find existing destination matching source config
+                const match = destinations.find(d => {
+                    if (source.type === 'cosmosdb') {
+                        return d.type === 'cosmosdb-vector' &&
+                            d.config?.endpoint === source.config.endpoint &&
+                            d.config?.database === source.config.database &&
+                            d.config?.container === source.config.container;
+                    } else {
+                        return d.type === destType &&
+                            d.config?.host === source.config.host &&
+                            d.config?.database === source.config.database &&
+                            d.config?.table === source.config.table;
+                    }
+                });
+
+                if (match) {
+                    destSelect.value = match.id;
+                    if (processingModeSelect) processingModeSelect.value = 'inline';
+                    resultDiv.innerHTML =
+                        `<span style="color: var(--success); font-size: 13px;">✓ Using: ${match.name} (inline mode)</span>`;
+                    loadVectorPoliciesForDest();
+                    updateSameContainerIndicator();
+                    return;
+                }
+
+                // No match — auto-create destination from source config
+                resultDiv.innerHTML = '<span style="color: var(--text-secondary); font-size: 13px;">Creating destination from source config...</span>';
+                try {
+                    const destConfig = { auth_type: source.config.auth_type || 'managed-identity' };
+                    if (source.type === 'cosmosdb') {
+                        destConfig.endpoint = source.config.endpoint;
+                        destConfig.database = source.config.database;
+                        destConfig.container = source.config.container;
+                        if (source.config.client_id) destConfig.client_id = source.config.client_id;
+                    } else {
+                        destConfig.host = source.config.host;
+                        destConfig.port = source.config.port;
+                        destConfig.database = source.config.database;
+                        destConfig.table = source.config.table;
+                        if (source.config.user) destConfig.user = source.config.user;
+                        if (source.config.password) destConfig.password = source.config.password;
+                        if (source.config.ssl_mode) destConfig.ssl_mode = source.config.ssl_mode;
+                    }
+
+                    const destData = { name: source.name + ' (vectors)', type: destType, config: destConfig };
+                    const res = await apiFetch('/api/destinations', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(destData)
+                    });
+                    if (res.ok) {
+                        const newDest = await res.json();
+                        destinations.push(newDest.destination || newDest);
+                        const dest = newDest.destination || newDest;
+                        const option = document.createElement('option');
+                        option.value = dest.id;
+                        option.textContent = dest.name;
+                        destSelect.appendChild(option);
+                        destSelect.value = dest.id;
                         if (processingModeSelect) processingModeSelect.value = 'inline';
                         resultDiv.innerHTML =
-                            `<span style="color: var(--success); font-size: 13px;">Matched: ${match.name} (using inline mode)</span>`;
+                            `<span style="color: var(--success); font-size: 13px;">✓ Created: ${dest.name} (inline mode)</span>`;
                         loadVectorPoliciesForDest();
                         updateSameContainerIndicator();
-                        return;
-                    }
-                    // No match found - create destination from source config
-                    resultDiv.innerHTML = '<span style="color: var(--text-secondary); font-size: 13px;">Creating destination from source...</span>';
-                    try {
-                        const destData = {
-                            name: source.name + ' (vector)',
-                            type: 'cosmosdb-vector',
-                            config: {
-                                endpoint: source.config.endpoint,
-                                database: source.config.database,
-                                container: source.config.container,
-                                auth_type: source.config.auth_type || 'managed-identity',
-                            }
-                        };
-                        const res = await apiFetch('/api/destinations', {
-                            method: 'POST',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify(destData)
-                        });
-                        if (res.ok) {
-                            const newDest = await res.json();
-                            // Add to destinations array and refresh dropdown
-                            destinations.push(newDest.destination);
-                            const option = document.createElement('option');
-                            option.value = newDest.destination.id;
-                            option.textContent = newDest.destination.name;
-                            destSelect.appendChild(option);
-                            destSelect.value = newDest.destination.id;
-                            // Auto-select inline mode
-                            if (processingModeSelect) processingModeSelect.value = 'inline';
-                            resultDiv.innerHTML =
-                                `<span style="color: var(--success); font-size: 13px;">Created: ${newDest.destination.name} (using inline mode)</span>`;
-                            updateSameContainerIndicator();
-                        } else {
-                            const err = await res.json();
-                            resultDiv.innerHTML =
-                                `<span style="color: var(--error); font-size: 13px;">Failed to create destination: ${err.detail || 'Unknown error'}</span>`;
-                        }
-                    } catch (err) {
+                    } else {
+                        const err = await res.json();
                         resultDiv.innerHTML =
-                            `<span style="color: var(--error); font-size: 13px;">Error: ${err.message}</span>`;
+                            `<span style="color: var(--error); font-size: 13px;">Failed: ${err.detail || 'Unknown error'}</span>`;
                     }
+                } catch (err) {
+                    resultDiv.innerHTML =
+                        `<span style="color: var(--error); font-size: 13px;">Error: ${err.message}</span>`;
                 }
             } else {
+                // Unchecked — show normal destination form
+                label.style.borderColor = 'transparent';
+                label.style.background = 'var(--bg-tertiary)';
+                if (destDropdownGroup) destDropdownGroup.style.display = '';
+                infoDiv.style.display = 'none';
                 resultDiv.innerHTML = '';
                 updateSameContainerIndicator();
             }
@@ -5275,6 +5333,19 @@
             `;
 
             configDiv.innerHTML = sourceSpecificHtml + contentFieldsHtml;
+
+            // Show/hide "same as source" checkbox based on source type
+            const sameAsSourceLabel = document.getElementById('pl-dest-same-as-source-label');
+            if (sameAsSourceLabel) {
+                // Hide for blob sources — they can't be destinations
+                sameAsSourceLabel.style.display = source.type === 'azure-blob' ? 'none' : 'flex';
+                // Uncheck if source changed
+                const cb = document.getElementById('pl-dest-same-as-source');
+                if (cb && cb.checked) {
+                    cb.checked = false;
+                    toggleDestSameAsSource();
+                }
+            }
         }
 
         // API calls


### PR DESCRIPTION
When user checks 'Write vectors back to source container':

- Destination dropdown hides (auto-creates from source config)
- Embedding policy picker still shown (user selects which vector field)
- Processing mode auto-set to inline
- RBAC note: managed identity needs Data Contributor (read + write)
- Works for CosmosDB, PostgreSQL, MSSQL (hidden for blob)
- Unchecking restores normal destination form

This eliminates the most common friction point: creating a duplicate destination when source and destination are the same container.