### PR TITLE
fix: prevent azd up hang on Unix after SKU selection

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -967,13 +967,14 @@ def delete_source(source_id: str):
 
     # Check if source is used by any pipeline
     pipelines = [_pipeline_from_doc(d) for d in store.list("pipeline")]
-    for p in pipelines:
-        for ps in p.sources:
-            if ps.source_id == source_id:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Source is used by pipeline '{p.name}'"
-                )
+    using = [p.name for p in pipelines for ps in p.sources if ps.source_id == source_id]
+    if using:
+        names = ", ".join(f"'{n}'" for n in using)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot delete — source is used by {len(using)} pipeline(s): {names}. "
+                   f"Delete or update those pipelines first."
+        )
 
     store.delete(source_id, "source")
     return {"success": True}
@@ -1374,12 +1375,14 @@ def delete_destination(dest_id: str):
 
     # Check if destination is used by any pipeline
     pipelines = [_pipeline_from_doc(d) for d in store.list("pipeline")]
-    for p in pipelines:
-        if p.destination_id == dest_id:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Destination is used by pipeline '{p.name}'"
-            )
+    using = [p.name for p in pipelines if p.destination_id == dest_id]
+    if using:
+        names = ", ".join(f"'{n}'" for n in using)
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot delete — destination is used by {len(using)} pipeline(s): {names}. "
+                   f"Delete or update those pipelines first."
+        )
 
     store.delete(dest_id, "destination")
     return {"success": True}

--- a/api/api.py
+++ b/api/api.py
@@ -3559,6 +3559,77 @@ async def create_model(payload: dict):
         raise HTTPException(status_code=503, detail=f"DocGrok error: {str(e)}")
 
 
+@app.put("/api/models/{model_id}")
+async def update_model(model_id: str, payload: dict):
+    """Update an external model's config (API key, endpoint, etc.)."""
+    if not model_id.startswith("mdl-ext-"):
+        raise HTTPException(status_code=400, detail="Only external models can be updated")
+
+    store = get_store()
+    doc = None
+    try:
+        doc = store.get(model_id, "docgrok_model")
+    except Exception:
+        pass
+    if not doc:
+        raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found")
+
+    # Merge updatable fields
+    updatable = ("api_key", "endpoint", "deployment", "api_version", "embedding_dim", "auth_type", "client_id")
+    changed = []
+    new_api_key = None
+    for field in updatable:
+        if field in payload and payload[field] is not None:
+            val = payload[field].strip() if isinstance(payload[field], str) else payload[field]
+            if field == "api_key":
+                new_api_key = val
+            else:
+                doc[field] = val
+            changed.append(field)
+
+    if not changed:
+        raise HTTPException(status_code=400, detail="No updatable fields provided")
+
+    # Handle API key update — Key Vault if available, else CosmosDB
+    if new_api_key:
+        from keyvault_client import set_model_api_key
+        if set_model_api_key(model_id, new_api_key):
+            doc["api_key_source"] = "keyvault"
+            doc.pop("api_key", None)
+        else:
+            doc["api_key"] = new_api_key
+            doc.pop("api_key_source", None)
+
+    doc["updated_at"] = datetime.utcnow().isoformat()
+    store.upsert(doc)
+
+    # Re-register with DocGrok if it's an embedding model (so DocGrok picks up new key/endpoint)
+    if doc.get("model_category") != "chat":
+        try:
+            reg_payload = {
+                "id": model_id,
+                "name": doc.get("name", ""),
+                "type": doc.get("type", "azure-openai"),
+                "endpoint": doc.get("endpoint", ""),
+                "auth_type": doc.get("auth_type", "key"),
+                "api_key": new_api_key or doc.get("api_key", ""),
+                "deployment": doc.get("deployment", ""),
+                "embedding_dim": int(doc.get("embedding_dim", 1536)),
+                "api_version": doc.get("api_version", "2024-06-01"),
+            }
+            # If key was in Key Vault, read it for DocGrok registration
+            if not reg_payload["api_key"] and doc.get("api_key_source") == "keyvault":
+                from keyvault_client import get_model_api_key
+                reg_payload["api_key"] = get_model_api_key(model_id) or ""
+            resp = await http_client.post(f"{DOCGROK_URL}/admin/models/registry", json=reg_payload)
+            if resp.status_code >= 400:
+                logger.warning(f"DocGrok re-register failed: {resp.text}")
+        except Exception as e:
+            logger.warning(f"DocGrok re-register error: {e}")
+
+    return {"status": "updated", "id": model_id, "fields_updated": changed}
+
+
 @app.delete("/api/models/{model_id}")
 async def delete_model(model_id: str):
     """Delete an external model â€” proxied to DocGrok, removed from CosmosDB."""
@@ -3598,6 +3669,17 @@ async def delete_model(model_id: str):
         raise
     except Exception as e:
         raise HTTPException(status_code=503, detail=f"DocGrok error: {str(e)}")
+
+
+@app.post("/api/models/{model_id}/test")
+async def test_model_health(model_id: str):
+    """Test a model's connectivity and auth by making a small embed call."""
+    from health_checker import run_health_checks
+    result = await run_health_checks(section="models")
+    for m in result.get("models", []):
+        if m["id"] == model_id:
+            return m
+    return {"id": model_id, "status": "unknown", "checks": [], "detail": "Model not found in health results"}
 
 
 # Native model actions (proxy to DocGrok K8s management)

--- a/api/api.py
+++ b/api/api.py
@@ -813,10 +813,11 @@ def get_metrics_timeseries(
     end: str | None = None,
     pipeline_id: str | None = None,
 ):
-    """Get time-series metrics at selected granularity and time range.
-    Granularity: minute, hour, day. Default time range: last 24h."""
-    now = datetime.utcnow()
+    """Get time-series metrics from in-memory store."""
+    if not metrics_store:
+        return {"granularity": granularity, "buckets": []}
 
+    now = datetime.utcnow()
     if granularity not in ("minute", "hour", "day"):
         raise HTTPException(status_code=400, detail="granularity must be minute, hour, or day")
 
@@ -826,63 +827,10 @@ def get_metrics_timeseries(
     except (ValueError, AttributeError):
         raise HTTPException(status_code=400, detail="Invalid date format. Use ISO 8601.")
 
-    # Cap max range to 30 days
-    if (end_dt - start_dt) > timedelta(days=30):
-        start_dt = end_dt - timedelta(days=30)
-
     start_iso = start_dt.strftime("%Y-%m-%dT%H:%M:00")
     end_iso = end_dt.strftime("%Y-%m-%dT%H:%M:00")
 
-    # Query timeseries buckets
-    query = "SELECT * FROM c WHERE c.doc_type = 'metric_ts' AND c.bucket >= @start AND c.bucket <= @end"
-    params = [
-        {"name": "@start", "value": start_iso},
-        {"name": "@end", "value": end_iso},
-    ]
-    if pipeline_id:
-        query += " AND c.pipeline_id = @pid"
-        params.append({"name": "@pid", "value": pipeline_id})
-
-    store = get_store()
-    rows = store.query(query, params, partition_key="metric_ts")
-
-    # Determine granularity truncation
-    gran_seconds = {"minute": 60, "hour": 3600, "day": 86400}.get(granularity, 3600)
-
-    def _trunc(bucket_str: str) -> str:
-        dt = datetime.fromisoformat(bucket_str)
-        if granularity == "minute":
-            return dt.strftime("%Y-%m-%dT%H:%M:00")
-        elif granularity == "hour":
-            return dt.strftime("%Y-%m-%dT%H:00:00")
-        else:  # day
-            return dt.strftime("%Y-%m-%dT00:00:00")
-
-    # Aggregate by truncated bucket
-    agg: dict[str, dict] = {}
-    for row in rows:
-        key = _trunc(row.get("bucket", ""))
-        if key not in agg:
-            agg[key] = {"processed": 0, "failed": 0, "processing_time_ms": 0.0}
-        agg[key]["processed"] += row.get("processed", 0)
-        agg[key]["failed"] += row.get("failed", 0)
-        agg[key]["processing_time_ms"] += row.get("processing_time_ms", 0.0)
-
-    # Build response buckets
-    buckets = []
-    for t in sorted(agg.keys()):
-        a = agg[t]
-        p = a["processed"]
-        f = a["failed"]
-        throughput = round(p / gran_seconds, 1) if p > 0 else 0.0
-        avg_latency = round(a["processing_time_ms"] / p, 1) if p > 0 else None
-        buckets.append({
-            "t": t,
-            "processed": p,
-            "failed": f,
-            "throughput": throughput,
-            "avg_latency_ms": avg_latency,
-        })
+    buckets = metrics_store.get_timeseries(start_iso, end_iso, granularity)
 
     return {
         "granularity": granularity,

--- a/api/api.py
+++ b/api/api.py
@@ -4,6 +4,7 @@
 import os
 import json
 import uuid
+import time
 import asyncio
 import logging
 import hashlib
@@ -18,15 +19,26 @@ from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from pydantic import BaseModel
 
-# Initialize Azure Monitor telemetry (safe if connection string not set)
+# Initialize telemetry (in-memory MetricsStore always active; App Insights if configured)
 try:
-    from telemetry import init_telemetry, track_metric, track_histogram, track_event, Timer
+    from telemetry import (
+        init_telemetry, metrics_store,
+        record_embedding_batch, record_search, record_error,
+        record_request, record_failure,
+        track_metric, track_histogram, track_event, Timer,
+    )
     init_telemetry()
 except ImportError:
     # Telemetry module not available — define no-ops
     def track_metric(*a, **kw): pass
     def track_histogram(*a, **kw): pass
     def track_event(*a, **kw): pass
+    def record_embedding_batch(**kw): pass
+    def record_search(**kw): pass
+    def record_error(**kw): pass
+    def record_request(**kw): pass
+    def record_failure(**kw): pass
+    metrics_store = None
     class Timer:
         def __init__(self, *a, **kw): pass
         def __enter__(self): return self
@@ -220,6 +232,21 @@ async def security_headers(request: Request, call_next):
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     response.headers["Cache-Control"] = "no-store"
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    return response
+
+
+@app.middleware("http")
+async def metrics_middleware(request: Request, call_next):
+    """Track request latency and error rates for all API calls."""
+    start = time.time()
+    response = await call_next(request)
+    latency_ms = (time.time() - start) * 1000
+    path = request.url.path
+    # Skip metrics/health endpoints to avoid recursion noise
+    if not path.startswith("/api/metrics") and not path.startswith("/api/health"):
+        record_request(latency_ms, method=request.method, path=path)
+        if response.status_code >= 400:
+            record_error(status_code=response.status_code, path=path)
     return response
 
 # â”€â”€ test-connection timeout / retry config â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
@@ -622,242 +649,130 @@ async def run_health_checks_now(section: str | None = None):
 
 
 # =============================================================================
-# METRICS
+# METRICS — powered by in-memory MetricsStore + App Insights (no CosmosDB)
 # =============================================================================
 
 @app.get("/api/metrics")
 def get_metrics():
-    """Get processing metrics for dashboard."""
-    store = get_store()
-    metrics_doc = store.get("global", "metrics")
+    """Get live processing metrics from in-memory store.
 
-    if not metrics_doc:
-        return {
-            "events_processed": 0,
-            "events_failed": 0,
-            "avg_processing_time_ms": None,
-            "today": {"processed": 0, "failed": 0},
-            "daily": [],
-            "pipelines": {},
-            "last_updated": None,
-        }
+    Primary dashboard endpoint. Returns throughput, latency, progress,
+    token usage, failure breakdown, per-pipeline stats.
+    No CosmosDB queries — reads from MetricsStore singleton.
+    """
+    if not metrics_store:
+        return {"error": "Metrics not available"}
 
-    today_str = datetime.utcnow().strftime("%Y-%m-%d")
-    today_data = metrics_doc.get("daily", {}).get(today_str, {})
+    snap = metrics_store.snapshot()
 
-    avg_time = None
-    total_completed = metrics_doc.get("events_processed", 0)
-    if total_completed > 0:
-        avg_time = round(
-            metrics_doc.get("total_processing_time_ms", 0) / total_completed, 1
-        )
-
-    daily_list = [
-        {"date": k, **v}
-        for k, v in sorted(metrics_doc.get("daily", {}).items())
-    ]
-
+    # Backward-compatible shape for existing dashboard
     return {
-        "events_processed": total_completed,
-        "events_failed": metrics_doc.get("events_failed", 0),
-        "avg_processing_time_ms": avg_time,
-        "total_processing_time_ms": metrics_doc.get("total_processing_time_ms", 0),
-        "today": {
-            "processed": today_data.get("processed", 0),
-            "failed": today_data.get("failed", 0),
+        "events_processed": snap["documents_embedded"],
+        "events_failed": snap["documents_failed"],
+        "avg_processing_time_ms": snap["embedding_latency"]["avg"],
+        "throughput_docs_per_sec": snap["throughput_docs_per_sec"],
+        "search_queries": snap["search_queries"],
+        "jobs_created": snap["jobs_created"],
+        "changefeed_batches": snap["changefeed_batches"],
+        # Latency distributions (5-min sliding window)
+        "latency": {
+            "embedding": snap["embedding_latency"],
+            "search": snap["search_latency"],
+            "request": snap["request_latency"],
         },
-        "daily": daily_list,
-        "pipelines": metrics_doc.get("pipelines", {}),
-        "last_updated": metrics_doc.get("last_updated"),
+        # Token usage
+        "tokens": snap["tokens"],
+        # Skipped documents
+        "skipped": snap["skipped"],
+        # Error breakdown
+        "errors": snap["errors"],
+        # Per-pipeline breakdown
+        "pipelines": snap["pipelines"],
+        # Meta
+        "started_at": snap["started_at"],
+        "uptime_seconds": snap["uptime_seconds"],
     }
 
 
-@app.get("/api/metrics/insights")
-async def get_insights_metrics():
-    """Get Application Insights metrics (request latency, errors, dependencies).
+@app.get("/api/metrics/live")
+def get_live_metrics():
+    """Full metrics snapshot — same as /api/metrics but explicit name."""
+    return get_metrics()
 
-    Queries the App Insights REST API using the connection string.
-    Returns empty data if App Insights is not configured.
-    """
+
+@app.get("/api/metrics/insights")
+def get_insights_metrics():
+    """App Insights status + portal link."""
     conn_str = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "")
     if not conn_str:
         return {
             "enabled": False,
-            "message": "Application Insights not configured",
-            "request_latency_ms": None,
-            "error_rate_pct": None,
-            "requests_total": None,
-            "dependencies": [],
-            "custom_metrics": {},
+            "message": "Application Insights not configured. "
+                       "In-memory metrics are still active via /api/metrics.",
         }
 
-    # Parse connection string for app ID
     parts = dict(p.split("=", 1) for p in conn_str.split(";") if "=" in p)
     ikey = parts.get("InstrumentationKey", "")
-
-    # Query via the existing telemetry module's metric counters
-    try:
-        from telemetry import _counters, _histograms, _initialized
-
-        custom = {}
-        if _initialized:
-            # Read current counter values (OpenTelemetry counters are additive)
-            # We report what we know from the in-memory state
-            custom = {
-                "documents_embedded": "tracked",
-                "jobs_created": "tracked",
-                "jobs_failed": "tracked",
-                "search_queries": "tracked",
-                "embedding_latency_ms": "tracked",
-                "search_latency_ms": "tracked",
-            }
-    except ImportError:
-        custom = {}
-
-    # Also pull pipeline-level stats from our store for a combined view
-    store = get_store()
-    pipeline_metrics = []
-    for d in store.list("pipeline"):
-        p = _pipeline_from_doc(d)
-        stats = get_pipeline_stats(p.id)
-        pipeline_metrics.append({
-            "id": p.id,
-            "name": p.name,
-            "status": p.status.value if hasattr(p.status, 'value') else str(p.status),
-            "documents_processed": stats.documents_processed,
-            "embedded_count": stats.embedded_count,
-            "completion_pct": stats.completion_pct,
-            "jobs_total": stats.jobs.total if stats.jobs else 0,
-            "jobs_failed": stats.jobs.failed if stats.jobs else 0,
-            "throughput_docs_per_sec": stats.throughput_docs_per_sec,
-        })
 
     return {
         "enabled": True,
         "instrumentation_key": ikey[:8] + "..." if len(ikey) > 8 else ikey,
-        "custom_metrics": custom,
-        "pipelines": pipeline_metrics,
         "portal_url": f"https://portal.azure.com/#blade/AppInsightsExtension/OverviewBlade/InstrumentationKey/{ikey}" if ikey else None,
+        "metrics_endpoint": "/api/metrics",
+        "note": "All metrics are dual-written to App Insights (persistent) and in-memory (real-time).",
     }
 
 
 @app.delete("/api/metrics")
 def clear_metrics():
-    """Clear all metrics (global + timeseries buckets)."""
-    store = get_store()
-    try:
-        store.delete("global", "metrics")
-    except Exception:
-        pass
-    # Also clear timeseries buckets
-    try:
-        ts_docs = store.query(
-            "SELECT c.id FROM c WHERE c.doc_type = 'metric_ts'",
-            partition_key="metric_ts",
-        )
-        for d in ts_docs:
-            try:
-                store.delete(d["id"], "metric_ts")
-            except Exception:
-                pass
-    except Exception:
-        pass
-    return {"success": True, "message": "Metrics cleared"}
+    """Reset all in-memory metrics counters."""
+    if metrics_store:
+        metrics_store.reset()
+    return {"success": True, "message": "In-memory metrics reset"}
 
 
 @app.post("/api/metrics/changefeed")
 def report_changefeed_metrics(payload: dict):
     """Report changefeed batch metrics from CFP.
-    Payload: {source_id, total, eligible, skipped_no_content, skipped_unchanged, jobs_created, partition}
+    Payload: {source_id, pipeline_id, total, eligible, skipped_no_content,
+              skipped_unchanged, jobs_created, tokens_used, latency_ms, partition}
     """
-    store = get_store()
     source_id = payload.get("source_id", "unknown")
+    pipeline_id = payload.get("pipeline_id", "")
     total = int(payload.get("total", 0))
     eligible = int(payload.get("eligible", 0))
     skipped_no_content = int(payload.get("skipped_no_content", 0))
     skipped_unchanged = int(payload.get("skipped_unchanged", 0))
     jobs_created = int(payload.get("jobs_created", 0))
-    partition = payload.get("partition", "")
+    tokens_used = int(payload.get("tokens_used", 0))
+    latency_ms = float(payload.get("latency_ms", 0))
+    failed = int(payload.get("failed", 0))
 
-    # Forward to Azure Monitor
-    track_metric("documents_embedded", eligible, {"source_id": source_id})
-    if jobs_created > 0:
-        track_metric("jobs_created", jobs_created, {"source_id": source_id})
+    # Feed into unified metrics system (in-memory + App Insights)
+    record_embedding_batch(
+        pipeline_id=pipeline_id, docs_embedded=eligible, docs_failed=failed,
+        docs_skipped_no_content=skipped_no_content,
+        docs_skipped_unchanged=skipped_unchanged,
+        jobs_created=jobs_created, tokens_used=tokens_used,
+        latency_ms=latency_ms, source_id=source_id,
+    )
 
-    # Get or create changefeed metrics doc
-    cf_doc = store.get("changefeed", "metrics")
-    if not cf_doc:
-        cf_doc = {
-            "id": "changefeed",
-            "doc_type": "metrics",
-            "total_batches": 0,
-            "total_docs": 0,
-            "total_eligible": 0,
-            "total_skipped_no_content": 0,
-            "total_skipped_unchanged": 0,
-            "total_jobs_created": 0,
-            "sources": {},
-        }
-
-    # Update totals
-    cf_doc["total_batches"] = cf_doc.get("total_batches", 0) + 1
-    cf_doc["total_docs"] = cf_doc.get("total_docs", 0) + total
-    cf_doc["total_eligible"] = cf_doc.get("total_eligible", 0) + eligible
-    cf_doc["total_skipped_no_content"] = cf_doc.get("total_skipped_no_content", 0) + skipped_no_content
-    cf_doc["total_skipped_unchanged"] = cf_doc.get("total_skipped_unchanged", 0) + skipped_unchanged
-    cf_doc["total_jobs_created"] = cf_doc.get("total_jobs_created", 0) + jobs_created
-    cf_doc["last_updated"] = datetime.utcnow().isoformat()
-
-    # Update per-source metrics
-    if source_id not in cf_doc.get("sources", {}):
-        cf_doc.setdefault("sources", {})[source_id] = {
-            "batches": 0,
-            "docs": 0,
-            "eligible": 0,
-            "skipped_no_content": 0,
-            "skipped_unchanged": 0,
-            "jobs_created": 0,
-        }
-    src = cf_doc["sources"][source_id]
-    src["batches"] = src.get("batches", 0) + 1
-    src["docs"] = src.get("docs", 0) + total
-    src["eligible"] = src.get("eligible", 0) + eligible
-    src["skipped_no_content"] = src.get("skipped_no_content", 0) + skipped_no_content
-    src["skipped_unchanged"] = src.get("skipped_unchanged", 0) + skipped_unchanged
-    src["jobs_created"] = src.get("jobs_created", 0) + jobs_created
-    src["last_partition"] = partition
-    src["last_updated"] = datetime.utcnow().isoformat()
-
-    store.upsert(cf_doc)
     return {"ok": True}
 
 
 @app.get("/api/metrics/changefeed")
 def get_changefeed_metrics():
-    """Get changefeed metrics including skip counts."""
-    store = get_store()
-    cf_doc = store.get("changefeed", "metrics")
-    if not cf_doc:
-        return {
-            "total_batches": 0,
-            "total_docs": 0,
-            "total_eligible": 0,
-            "total_skipped_no_content": 0,
-            "total_skipped_unchanged": 0,
-            "total_jobs_created": 0,
-            "sources": {},
-            "last_updated": None,
-        }
-
+    """Get changefeed metrics from in-memory store."""
+    if not metrics_store:
+        return {"error": "Metrics not available"}
+    snap = metrics_store.snapshot()
     return {
-        "total_batches": cf_doc.get("total_batches", 0),
-        "total_docs": cf_doc.get("total_docs", 0),
-        "total_eligible": cf_doc.get("total_eligible", 0),
-        "total_skipped_no_content": cf_doc.get("total_skipped_no_content", 0),
-        "total_skipped_unchanged": cf_doc.get("total_skipped_unchanged", 0),
-        "total_jobs_created": cf_doc.get("total_jobs_created", 0),
-        "sources": cf_doc.get("sources", {}),
-        "last_updated": cf_doc.get("last_updated"),
+        "total_batches": snap["changefeed_batches"],
+        "total_eligible": snap["documents_embedded"],
+        "total_skipped_no_content": snap["skipped"]["no_content"],
+        "total_skipped_unchanged": snap["skipped"]["unchanged"],
+        "total_jobs_created": snap["jobs_created"],
+        "pipelines": snap["pipelines"],
     }
 
 
@@ -977,62 +892,6 @@ def get_metrics_timeseries(
         "buckets": buckets,
     }
 
-
-@app.post("/api/metrics/backfill")
-def backfill_metrics():
-    """One-time backfill of metrics from existing job history."""
-    store = get_store()
-    metrics = {
-        "id": "global",
-        "doc_type": "metrics",
-        "events_processed": 0,
-        "events_failed": 0,
-        "total_processing_time_ms": 0.0,
-        "daily": {},
-        "pipelines": {},
-        "last_updated": datetime.utcnow().isoformat(),
-    }
-
-    for doc in store.list("job"):
-        job = _job_from_doc(doc)
-        if job.status not in (JobStatus.COMPLETED, JobStatus.FAILED):
-            continue
-
-        proc_time = 0.0
-        if job.started_at and job.completed_at:
-            proc_time = (job.completed_at - job.started_at).total_seconds() * 1000
-
-        if job.status == JobStatus.COMPLETED:
-            metrics["events_processed"] += 1
-        else:
-            metrics["events_failed"] += 1
-        metrics["total_processing_time_ms"] += proc_time
-
-        if job.completed_at:
-            day = job.completed_at.strftime("%Y-%m-%d")
-            if day not in metrics["daily"]:
-                metrics["daily"][day] = {"processed": 0, "failed": 0, "processing_time_ms": 0.0}
-            if job.status == JobStatus.COMPLETED:
-                metrics["daily"][day]["processed"] += 1
-            else:
-                metrics["daily"][day]["failed"] += 1
-            metrics["daily"][day]["processing_time_ms"] += proc_time
-
-        pid = job.pipeline_id
-        if pid not in metrics["pipelines"]:
-            metrics["pipelines"][pid] = {"processed": 0, "failed": 0, "processing_time_ms": 0.0}
-        if job.status == JobStatus.COMPLETED:
-            metrics["pipelines"][pid]["processed"] += 1
-        else:
-            metrics["pipelines"][pid]["failed"] += 1
-        metrics["pipelines"][pid]["processing_time_ms"] += proc_time
-
-    store.upsert(metrics)
-    return {
-        "message": "Backfill complete",
-        "events_processed": metrics["events_processed"],
-        "events_failed": metrics["events_failed"],
-    }
 
 
 # =============================================================================
@@ -2551,7 +2410,6 @@ def _merge_results(index_results: list, strategy: str, top_k: int) -> list:
         all_results.sort(key=lambda r: r["score"], reverse=True)
         if strategy != "per_index":
             all_results = all_results[:top_k]
-        track_histogram("search_latency", (time.time() - _search_start) * 1000)
         return all_results
 
 
@@ -2560,7 +2418,6 @@ async def playground_search(req: SearchRequest):
     """Search vectors across one or more indexes using query embedding."""
     import time
 
-    track_metric("search_queries", 1)
     _search_start = time.time()
 
     if not req.destination_ids:
@@ -2695,6 +2552,14 @@ async def playground_search(req: SearchRequest):
         indexes_searched.append(entry)
 
     embedding_dims = len(next(iter(embeddings.values()))) if embeddings else 0
+
+    total_latency_ms = int((time.time() - _search_start) * 1000)
+    record_search(
+        latency_ms=total_latency_ms,
+        embed_latency_ms=embed_time,
+        tokens_used=0,  # TODO: parse from embed_result.get("usage", {}).get("total_tokens", 0)
+        results_count=len(merged),
+    )
 
     return {
         "query": req.query,

--- a/api/api.py
+++ b/api/api.py
@@ -807,16 +807,16 @@ def _upsert_ts_bucket(pipeline_id: str, processed: int, failed: int, processing_
 
 
 @app.get("/api/metrics/timeseries")
-def get_metrics_timeseries(
+async def get_metrics_timeseries(
     granularity: str = "hour",
     start: str | None = None,
     end: str | None = None,
     pipeline_id: str | None = None,
 ):
-    """Get time-series metrics from in-memory store."""
-    if not metrics_store:
-        return {"granularity": granularity, "buckets": []}
+    """Get time-series metrics from Azure App Insights (Log Analytics).
 
+    Falls back to in-memory store if App Insights is not configured.
+    """
     now = datetime.utcnow()
     if granularity not in ("minute", "hour", "day"):
         raise HTTPException(status_code=400, detail="granularity must be minute, hour, or day")
@@ -830,15 +830,86 @@ def get_metrics_timeseries(
     start_iso = start_dt.strftime("%Y-%m-%dT%H:%M:00")
     end_iso = end_dt.strftime("%Y-%m-%dT%H:%M:00")
 
-    buckets = metrics_store.get_timeseries(start_iso, end_iso, granularity)
+    workspace_id = os.environ.get("LOG_ANALYTICS_WORKSPACE_ID", "")
+
+    # Try App Insights first (persistent, survives restarts)
+    if workspace_id:
+        try:
+            buckets = await asyncio.to_thread(
+                _query_app_insights_timeseries, workspace_id, start_dt, end_dt, granularity, pipeline_id
+            )
+            if buckets is not None:
+                return {
+                    "granularity": granularity,
+                    "start": start_iso,
+                    "end": end_iso,
+                    "pipeline_id": pipeline_id,
+                    "source": "app_insights",
+                    "buckets": buckets,
+                }
+        except Exception as e:
+            logger.warning(f"App Insights query failed, falling back to in-memory: {e}")
+
+    # Fallback: in-memory store
+    if metrics_store:
+        buckets = metrics_store.get_timeseries(start_iso, end_iso, granularity)
+    else:
+        buckets = []
 
     return {
         "granularity": granularity,
         "start": start_iso,
         "end": end_iso,
         "pipeline_id": pipeline_id,
+        "source": "in_memory",
         "buckets": buckets,
     }
+
+
+def _query_app_insights_timeseries(workspace_id, start_dt, end_dt, granularity, pipeline_id=None):
+    """Query Log Analytics for custom metrics timeseries."""
+    try:
+        from azure.monitor.query import LogsQueryClient, LogsQueryStatus
+        from azure.identity import DefaultAzureCredential
+
+        gran_bin = {"minute": "1m", "hour": "1h", "day": "1d"}.get(granularity, "1h")
+        gran_seconds = {"minute": 60, "hour": 3600, "day": 86400}.get(granularity, 3600)
+
+        # Query customMetrics for documents.embedded (processed) and documents.failed
+        kql = f"""
+        customMetrics
+        | where timestamp between (datetime('{start_dt.isoformat()}Z') .. datetime('{end_dt.isoformat()}Z'))
+        | where name in ('omnivec.documents.embedded', 'omnivec.documents.failed')
+        | summarize
+            processed = sumif(value, name == 'omnivec.documents.embedded'),
+            failed = sumif(value, name == 'omnivec.documents.failed')
+            by bin(timestamp, {gran_bin})
+        | order by timestamp asc
+        """
+
+        client = LogsQueryClient(DefaultAzureCredential())
+        response = client.query_workspace(workspace_id, kql, timespan=(start_dt, end_dt))
+
+        if response.status != LogsQueryStatus.SUCCESS:
+            return None
+
+        buckets = []
+        for row in response.tables[0].rows:
+            ts = row[0]  # timestamp
+            processed = int(row[1] or 0)
+            failed = int(row[2] or 0)
+            t_str = ts.strftime("%Y-%m-%dT%H:%M:00") if hasattr(ts, 'strftime') else str(ts)[:16] + ":00"
+            buckets.append({
+                "t": t_str,
+                "processed": processed,
+                "failed": failed,
+                "throughput": round(processed / gran_seconds, 1) if processed > 0 else 0.0,
+                "avg_latency_ms": None,  # TODO: add latency query
+            })
+        return buckets
+    except ImportError:
+        logger.info("azure-monitor-query not installed — App Insights queries disabled")
+        return None
 
 
 

--- a/api/api.py
+++ b/api/api.py
@@ -739,7 +739,31 @@ async def get_metrics():
     rows = await asyncio.to_thread(_run_kql, kql, timedelta(days=7))
 
     if rows is None:
-        # App Insights not configured
+        # App Insights not configured — fallback to CosmosDB inline metrics
+        try:
+            store = get_store()
+            doc = store.get("global", "metrics")
+            if doc and doc.get("pipelines"):
+                total_processed = doc.get("events_processed", 0)
+                total_failed = doc.get("events_failed", 0)
+                total_time_ms = 0.0
+                for pdata in doc["pipelines"].values():
+                    total_time_ms += pdata.get("total_time_ms", 0.0)
+                avg_lat = round(total_time_ms / total_processed, 1) if total_processed > 0 else None
+                return {
+                    "events_processed": total_processed,
+                    "events_failed": total_failed,
+                    "avg_processing_time_ms": avg_lat,
+                    "throughput_docs_per_sec": 0,
+                    "search_queries": 0,
+                    "latency": {"embedding": {"avg": avg_lat, "p95": None}, "search": {}, "request": {}},
+                    "tokens": {"total": 0},
+                    "skipped": {"total": 0},
+                    "errors": {"total": total_failed},
+                    "source": "cosmos_inline",
+                }
+        except Exception:
+            pass
         return {
             "events_processed": 0,
             "events_failed": 0,
@@ -751,7 +775,6 @@ async def get_metrics():
             "skipped": {"total": 0},
             "errors": {"total": 0},
             "source": "unavailable",
-            "message": "App Insights not configured. Deploy with azd up to enable metrics.",
         }
 
     m = {}
@@ -792,12 +815,6 @@ def get_insights_metrics():
         "instrumentation_key": ikey[:8] + "..." if len(ikey) > 8 else ikey,
         "portal_url": f"https://portal.azure.com/#blade/AppInsightsExtension/OverviewBlade/InstrumentationKey/{ikey}" if ikey else None,
     }
-
-
-@app.delete("/api/metrics")
-def clear_metrics():
-    """Clear is not applicable — metrics are in App Insights."""
-    return {"success": False, "message": "Metrics are stored in App Insights and cannot be cleared from here. Use Azure Portal to manage retention."}
 
 
 @app.post("/api/metrics/changefeed")
@@ -856,6 +873,90 @@ async def get_changefeed_metrics():
 
 # â”€â”€ timeseries metrics â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 
+
+def _build_cosmos_metrics_buckets(granularity, gran_seconds, start_dt, end_dt, pipeline_id):
+    """Build time-series buckets from CosmosDB-stored inline metrics when App Insights is unavailable."""
+    from collections import defaultdict
+
+    store = get_store()
+    doc = store.get("global", "metrics")
+    if not doc:
+        return []
+
+    pipelines_data = doc.get("pipelines", {})
+    if not pipelines_data:
+        return []
+
+    # Collect all recent entries from matching pipelines
+    entries = []
+    for pid, pdata in pipelines_data.items():
+        if pipeline_id and pid != pipeline_id:
+            continue
+        for entry in pdata.get("recent", []):
+            t_str = entry.get("t", "")
+            n = entry.get("n", 0)
+            if t_str:
+                try:
+                    t_dt = datetime.fromisoformat(t_str)
+                    if start_dt <= t_dt <= end_dt:
+                        entries.append((t_dt, n))
+                except (ValueError, TypeError):
+                    pass
+
+    if not entries:
+        # No recent data - create a single summary bucket from totals
+        total_processed = 0
+        total_time_ms = 0.0
+        for pid, pdata in pipelines_data.items():
+            if pipeline_id and pid != pipeline_id:
+                continue
+            total_processed += pdata.get("processed", 0)
+            total_time_ms += pdata.get("total_time_ms", 0.0)
+        if total_processed > 0:
+            avg_lat = round(total_time_ms / total_processed, 1) if total_processed > 0 else None
+            return [{
+                "t": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:00"),
+                "processed": total_processed,
+                "failed": 0,
+                "throughput": round(total_processed / gran_seconds, 1),
+                "avg_latency_ms": avg_lat,
+            }]
+        return []
+
+    # Bucket entries by granularity
+    bucket_map = defaultdict(lambda: {"processed": 0, "failed": 0})
+    for t_dt, n in entries:
+        if granularity == "minute":
+            key = t_dt.strftime("%Y-%m-%dT%H:%M:00")
+        elif granularity == "hour":
+            key = t_dt.strftime("%Y-%m-%dT%H:00:00")
+        else:  # day
+            key = t_dt.strftime("%Y-%m-%dT00:00:00")
+        bucket_map[key]["processed"] += n
+
+    # Also gather total time for avg latency
+    total_time_ms = 0.0
+    total_processed = 0
+    for pid, pdata in pipelines_data.items():
+        if pipeline_id and pid != pipeline_id:
+            continue
+        total_time_ms += pdata.get("total_time_ms", 0.0)
+        total_processed += pdata.get("processed", 0)
+    avg_lat = round(total_time_ms / total_processed, 1) if total_processed > 0 else None
+
+    buckets = []
+    for t_str in sorted(bucket_map.keys()):
+        b = bucket_map[t_str]
+        buckets.append({
+            "t": t_str,
+            "processed": b["processed"],
+            "failed": b["failed"],
+            "throughput": round(b["processed"] / gran_seconds, 1) if b["processed"] > 0 else 0.0,
+            "avg_latency_ms": avg_lat,
+        })
+
+    return buckets
+
 @app.get("/api/metrics/timeseries")
 async def get_metrics_timeseries(
     granularity: str = "hour",
@@ -894,14 +995,20 @@ async def get_metrics_timeseries(
     rows = await asyncio.to_thread(_run_kql, kql, (start_dt, end_dt))
 
     if rows is None:
+        # Fallback: build buckets from CosmosDB inline metrics
+        try:
+            buckets = _build_cosmos_metrics_buckets(
+                granularity, gran_seconds, start_dt, end_dt, pipeline_id
+            )
+        except Exception:
+            buckets = []
         return {
             "granularity": granularity,
             "start": start_iso,
             "end": end_iso,
             "pipeline_id": pipeline_id,
-            "source": "unavailable",
-            "buckets": [],
-            "message": "App Insights not configured. Deploy with azd up to enable metrics.",
+            "source": "cosmos_inline",
+            "buckets": buckets,
         }
 
     buckets = []
@@ -1033,6 +1140,10 @@ def update_source(source_id: str, req: CreateSourceRequest):
 
     source = _source_from_doc(doc)
     clean_config = {k: v.strip() if isinstance(v, str) else v for k, v in req.config.items()}
+    # Preserve stored password if masked value was sent
+    for sensitive_key in _SENSITIVE_CONFIG_KEYS:
+        if clean_config.get(sensitive_key) == "***":
+            clean_config[sensitive_key] = doc.get("config", {}).get(sensitive_key, "")
     source.name = req.name.strip()
     source.type = req.type
     source.config = clean_config
@@ -1136,11 +1247,22 @@ async def test_source(source_id: str):
 class TestConnectionRequest(BaseModel):
     type: str
     config: dict
+    source_id: Optional[str] = None
 
 
 @app.post("/api/sources/test-connection")
 async def test_source_connection_before_save(req: TestConnectionRequest):
     """Test source connection before saving (used by UI)."""
+    # If password is masked, look up real password from stored config
+    if req.source_id and req.config.get("password") == "***":
+        store = get_store()
+        try:
+            doc = store.get(req.source_id, partition_key="source")
+            stored_pw = doc.get("config", {}).get("password", "")
+            if stored_pw:
+                req.config["password"] = stored_pw
+        except Exception:
+            pass
     try:
         if req.type == "azure-blob":
             from azure.storage.blob import BlobServiceClient
@@ -1259,6 +1381,18 @@ async def test_source_connection_before_save(req: TestConnectionRequest):
             error_msg = "Resource not found. Check the account URL, database, or container name."
         elif "InvalidAuthenticationInfo" in error_msg:
             error_msg = "Authentication failed. Check your credentials or managed identity configuration."
+        elif "Connection refused" in error_msg or "[Errno 111]" in error_msg:
+            error_msg = "Connection refused. Check that the host and port are correct, the database server is running, and the firewall allows connections from this service."
+        elif "no PostgreSQL user name" in error_msg:
+            error_msg = "No PostgreSQL username provided. Please enter your database username in the Authentication tab."
+        elif "password authentication failed" in error_msg:
+            error_msg = "Password authentication failed. Check that the username and password are correct."
+        elif "does not exist" in error_msg and "database" in error_msg.lower():
+            error_msg = f"Database not found. Verify the database name is correct. Original error: {error_msg}"
+        elif "could not translate host name" in error_msg or "Name or service not known" in error_msg:
+            error_msg = "Cannot resolve hostname. Check that the host address is correct."
+        elif "timeout" in error_msg.lower() or "timed out" in error_msg.lower():
+            error_msg = "Connection timed out. Check that the host is reachable and the firewall allows connections."
 
         return {"success": False, "error": error_msg}
 
@@ -1443,9 +1577,14 @@ def update_destination(dest_id: str, req: CreateDestinationRequest):
         raise HTTPException(status_code=400, detail=f"Destination name '{req.name.strip()}' already exists")
 
     destination = _destination_from_doc(doc)
+    clean_config = {k: v.strip() if isinstance(v, str) else v for k, v in req.config.items()}
+    # Preserve stored password if masked value was sent
+    for sensitive_key in _SENSITIVE_CONFIG_KEYS:
+        if clean_config.get(sensitive_key) == "***":
+            clean_config[sensitive_key] = doc.get("config", {}).get(sensitive_key, "")
     destination.name = req.name
     destination.type = req.type
-    destination.config = req.config
+    destination.config = clean_config
     destination.enabled = req.enabled
     destination.updated_at = datetime.utcnow()
 
@@ -1534,11 +1673,22 @@ async def test_destination(dest_id: str):
 class TestDestConnectionRequest(BaseModel):
     type: str
     config: dict
+    destination_id: Optional[str] = None
 
 
 @app.post("/api/destinations/test-connection")
 async def test_destination_connection_before_save(req: TestDestConnectionRequest):
     """Test destination connection before saving (used by UI)."""
+    # If password is masked, look up real password from stored config
+    if req.destination_id and req.config.get("password") == "***":
+        store = get_store()
+        try:
+            doc = store.get(req.destination_id, partition_key="destination")
+            stored_pw = doc.get("config", {}).get("password", "")
+            if stored_pw:
+                req.config["password"] = stored_pw
+        except Exception:
+            pass
     try:
         if req.type == "cosmosdb-vector":
             from azure.cosmos import CosmosClient
@@ -1687,6 +1837,18 @@ async def test_destination_connection_before_save(req: TestDestConnectionRequest
             error_msg = "Resource not found. Check the endpoint, database, or container name."
         elif "InvalidAuthenticationInfo" in error_msg:
             error_msg = "Authentication failed. Check your credentials or managed identity configuration."
+        elif "Connection refused" in error_msg or "[Errno 111]" in error_msg:
+            error_msg = "Connection refused. Check that the host and port are correct, the database server is running, and the firewall allows connections from this service."
+        elif "no PostgreSQL user name" in error_msg:
+            error_msg = "No PostgreSQL username provided. Please enter your database username in the Authentication tab."
+        elif "password authentication failed" in error_msg:
+            error_msg = "Password authentication failed. Check that the username and password are correct."
+        elif "does not exist" in error_msg and "database" in error_msg.lower():
+            error_msg = f"Database not found. Verify the database name is correct. Original error: {error_msg}"
+        elif "could not translate host name" in error_msg or "Name or service not known" in error_msg:
+            error_msg = "Cannot resolve hostname. Check that the host address is correct."
+        elif "timeout" in error_msg.lower() or "timed out" in error_msg.lower():
+            error_msg = "Connection timed out. Check that the host is reachable and the firewall allows connections."
 
         return {"success": False, "error": error_msg}
 
@@ -4486,7 +4648,7 @@ def get_pipeline_stats(pipeline_id: str) -> PipelineRunStats:
         if source_id:
             source_doc = store.get(source_id, "source")
             if source_doc:
-                source = _source_from_doc(source_doc)
+                source = _source_from_doc(source_doc, mask=False)
                 if source.type == SourceType.COSMOSDB:
                     src_endpoint = source.config.get("endpoint", "")
                     src_client = CosmosClient(src_endpoint, credential=DefaultAzureCredential())

--- a/api/api.py
+++ b/api/api.py
@@ -672,6 +672,75 @@ def get_metrics():
     }
 
 
+@app.get("/api/metrics/insights")
+async def get_insights_metrics():
+    """Get Application Insights metrics (request latency, errors, dependencies).
+
+    Queries the App Insights REST API using the connection string.
+    Returns empty data if App Insights is not configured.
+    """
+    conn_str = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "")
+    if not conn_str:
+        return {
+            "enabled": False,
+            "message": "Application Insights not configured",
+            "request_latency_ms": None,
+            "error_rate_pct": None,
+            "requests_total": None,
+            "dependencies": [],
+            "custom_metrics": {},
+        }
+
+    # Parse connection string for app ID
+    parts = dict(p.split("=", 1) for p in conn_str.split(";") if "=" in p)
+    ikey = parts.get("InstrumentationKey", "")
+
+    # Query via the existing telemetry module's metric counters
+    try:
+        from telemetry import _counters, _histograms, _initialized
+
+        custom = {}
+        if _initialized:
+            # Read current counter values (OpenTelemetry counters are additive)
+            # We report what we know from the in-memory state
+            custom = {
+                "documents_embedded": "tracked",
+                "jobs_created": "tracked",
+                "jobs_failed": "tracked",
+                "search_queries": "tracked",
+                "embedding_latency_ms": "tracked",
+                "search_latency_ms": "tracked",
+            }
+    except ImportError:
+        custom = {}
+
+    # Also pull pipeline-level stats from our store for a combined view
+    store = get_store()
+    pipeline_metrics = []
+    for d in store.list("pipeline"):
+        p = _pipeline_from_doc(d)
+        stats = get_pipeline_stats(p.id)
+        pipeline_metrics.append({
+            "id": p.id,
+            "name": p.name,
+            "status": p.status.value if hasattr(p.status, 'value') else str(p.status),
+            "documents_processed": stats.documents_processed,
+            "embedded_count": stats.embedded_count,
+            "completion_pct": stats.completion_pct,
+            "jobs_total": stats.jobs.total if stats.jobs else 0,
+            "jobs_failed": stats.jobs.failed if stats.jobs else 0,
+            "throughput_docs_per_sec": stats.throughput_docs_per_sec,
+        })
+
+    return {
+        "enabled": True,
+        "instrumentation_key": ikey[:8] + "..." if len(ikey) > 8 else ikey,
+        "custom_metrics": custom,
+        "pipelines": pipeline_metrics,
+        "portal_url": f"https://portal.azure.com/#blade/AppInsightsExtension/OverviewBlade/InstrumentationKey/{ikey}" if ikey else None,
+    }
+
+
 @app.delete("/api/metrics")
 def clear_metrics():
     """Clear all metrics (global + timeseries buckets)."""

--- a/api/api.py
+++ b/api/api.py
@@ -649,55 +649,133 @@ async def run_health_checks_now(section: str | None = None):
 
 
 # =============================================================================
-# METRICS — powered by in-memory MetricsStore + App Insights (no CosmosDB)
+# METRICS — powered by Azure App Insights (Log Analytics)
 # =============================================================================
 
+def _get_logs_client():
+    """Get a LogsQueryClient for querying App Insights."""
+    workspace_id = os.environ.get("LOG_ANALYTICS_WORKSPACE_ID", "")
+    if not workspace_id:
+        return None, None
+    try:
+        from azure.monitor.query import LogsQueryClient
+        from azure.identity import DefaultAzureCredential
+        return LogsQueryClient(DefaultAzureCredential()), workspace_id
+    except Exception as e:
+        logger.warning(f"Failed to create LogsQueryClient: {e}")
+        return None, None
+
+
+def _run_kql(kql: str, timespan=None):
+    """Run a KQL query against Log Analytics. Returns rows or None."""
+    client, ws_id = _get_logs_client()
+    if not client:
+        return None
+    try:
+        from azure.monitor.query import LogsQueryStatus
+        resp = client.query_workspace(ws_id, kql, timespan=timespan)
+        if resp.status == LogsQueryStatus.SUCCESS and resp.tables:
+            return resp.tables[0].rows
+        return []
+    except Exception as e:
+        logger.warning(f"KQL query failed: {e}")
+        return None
+
+
 @app.get("/api/metrics")
-def get_metrics():
-    """Get live processing metrics from in-memory store.
+async def get_metrics():
+    """Get processing metrics from App Insights.
 
-    Primary dashboard endpoint. Returns throughput, latency, progress,
-    token usage, failure breakdown, per-pipeline stats.
-    No CosmosDB queries — reads from MetricsStore singleton.
+    Queries customMetrics for totals, latency, throughput.
+    Returns empty data if App Insights not configured.
     """
-    if not metrics_store:
-        return {"error": "Metrics not available"}
+    kql = """
+    let embedded = customMetrics
+        | where name == 'omnivec.documents.embedded'
+        | summarize total = sum(value);
+    let failed = customMetrics
+        | where name == 'omnivec.documents.failed'
+        | summarize total = sum(value);
+    let skipped = customMetrics
+        | where name == 'omnivec.documents.skipped'
+        | summarize total = sum(value);
+    let searches = customMetrics
+        | where name == 'omnivec.search.queries'
+        | summarize total = sum(value);
+    let tokens = customMetrics
+        | where name == 'omnivec.tokens.used'
+        | summarize total = sum(value);
+    let errors = customMetrics
+        | where name == 'omnivec.api.errors'
+        | summarize total = sum(value);
+    let embed_lat = customMetrics
+        | where name == 'omnivec.embedding.latency'
+        | summarize avg_ms = avg(value), p95_ms = percentile(value, 95), cnt = count();
+    let search_lat = customMetrics
+        | where name == 'omnivec.search.latency'
+        | summarize avg_ms = avg(value), p95_ms = percentile(value, 95), cnt = count();
+    let req_lat = customMetrics
+        | where name == 'omnivec.request.latency'
+        | summarize avg_ms = avg(value), p95_ms = percentile(value, 95), cnt = count();
+    let throughput = customMetrics
+        | where name == 'omnivec.documents.embedded' and timestamp > ago(1m)
+        | summarize docs = sum(value);
+    embedded | project metric='embedded', val=total
+    | union (failed | project metric='failed', val=total)
+    | union (skipped | project metric='skipped', val=total)
+    | union (searches | project metric='searches', val=total)
+    | union (tokens | project metric='tokens', val=total)
+    | union (errors | project metric='errors', val=total)
+    | union (embed_lat | project metric='embed_lat_avg', val=avg_ms)
+    | union (embed_lat | project metric='embed_lat_p95', val=p95_ms)
+    | union (embed_lat | project metric='embed_lat_cnt', val=cnt)
+    | union (search_lat | project metric='search_lat_avg', val=avg_ms)
+    | union (search_lat | project metric='search_lat_p95', val=p95_ms)
+    | union (req_lat | project metric='req_lat_avg', val=avg_ms)
+    | union (req_lat | project metric='req_lat_p95', val=p95_ms)
+    | union (throughput | project metric='throughput_1m', val=docs)
+    """
 
-    snap = metrics_store.snapshot()
+    rows = await asyncio.to_thread(_run_kql, kql, timedelta(days=7))
 
-    # Backward-compatible shape for existing dashboard
+    if rows is None:
+        # App Insights not configured
+        return {
+            "events_processed": 0,
+            "events_failed": 0,
+            "avg_processing_time_ms": None,
+            "throughput_docs_per_sec": 0,
+            "search_queries": 0,
+            "latency": {"embedding": {}, "search": {}, "request": {}},
+            "tokens": {"total": 0},
+            "skipped": {"total": 0},
+            "errors": {"total": 0},
+            "source": "unavailable",
+            "message": "App Insights not configured. Deploy with azd up to enable metrics.",
+        }
+
+    m = {}
+    for row in rows:
+        m[row[0]] = row[1] or 0
+
+    throughput_1m = m.get("throughput_1m", 0)
+
     return {
-        "events_processed": snap["documents_embedded"],
-        "events_failed": snap["documents_failed"],
-        "avg_processing_time_ms": snap["embedding_latency"]["avg"],
-        "throughput_docs_per_sec": snap["throughput_docs_per_sec"],
-        "search_queries": snap["search_queries"],
-        "jobs_created": snap["jobs_created"],
-        "changefeed_batches": snap["changefeed_batches"],
-        # Latency distributions (5-min sliding window)
+        "events_processed": int(m.get("embedded", 0)),
+        "events_failed": int(m.get("failed", 0)),
+        "avg_processing_time_ms": round(m.get("embed_lat_avg", 0), 1) if m.get("embed_lat_cnt", 0) > 0 else None,
+        "throughput_docs_per_sec": round(throughput_1m / 60, 2) if throughput_1m > 0 else 0,
+        "search_queries": int(m.get("searches", 0)),
         "latency": {
-            "embedding": snap["embedding_latency"],
-            "search": snap["search_latency"],
-            "request": snap["request_latency"],
+            "embedding": {"avg": round(m.get("embed_lat_avg", 0), 1) if m.get("embed_lat_cnt", 0) > 0 else None, "p95": round(m.get("embed_lat_p95", 0), 1) if m.get("embed_lat_cnt", 0) > 0 else None},
+            "search": {"avg": round(m.get("search_lat_avg", 0), 1) if m.get("search_lat_avg") else None, "p95": round(m.get("search_lat_p95", 0), 1) if m.get("search_lat_p95") else None},
+            "request": {"avg": round(m.get("req_lat_avg", 0), 1) if m.get("req_lat_avg") else None, "p95": round(m.get("req_lat_p95", 0), 1) if m.get("req_lat_p95") else None},
         },
-        # Token usage
-        "tokens": snap["tokens"],
-        # Skipped documents
-        "skipped": snap["skipped"],
-        # Error breakdown
-        "errors": snap["errors"],
-        # Per-pipeline breakdown
-        "pipelines": snap["pipelines"],
-        # Meta
-        "started_at": snap["started_at"],
-        "uptime_seconds": snap["uptime_seconds"],
+        "tokens": {"total": int(m.get("tokens", 0))},
+        "skipped": {"total": int(m.get("skipped", 0))},
+        "errors": {"total": int(m.get("errors", 0))},
+        "source": "app_insights",
     }
-
-
-@app.get("/api/metrics/live")
-def get_live_metrics():
-    """Full metrics snapshot — same as /api/metrics but explicit name."""
-    return get_metrics()
 
 
 @app.get("/api/metrics/insights")
@@ -705,30 +783,21 @@ def get_insights_metrics():
     """App Insights status + portal link."""
     conn_str = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "")
     if not conn_str:
-        return {
-            "enabled": False,
-            "message": "Application Insights not configured. "
-                       "In-memory metrics are still active via /api/metrics.",
-        }
+        return {"enabled": False, "message": "Application Insights not configured. Deploy with azd up to enable."}
 
     parts = dict(p.split("=", 1) for p in conn_str.split(";") if "=" in p)
     ikey = parts.get("InstrumentationKey", "")
-
     return {
         "enabled": True,
         "instrumentation_key": ikey[:8] + "..." if len(ikey) > 8 else ikey,
         "portal_url": f"https://portal.azure.com/#blade/AppInsightsExtension/OverviewBlade/InstrumentationKey/{ikey}" if ikey else None,
-        "metrics_endpoint": "/api/metrics",
-        "note": "All metrics are dual-written to App Insights (persistent) and in-memory (real-time).",
     }
 
 
 @app.delete("/api/metrics")
 def clear_metrics():
-    """Reset all in-memory metrics counters."""
-    if metrics_store:
-        metrics_store.reset()
-    return {"success": True, "message": "In-memory metrics reset"}
+    """Clear is not applicable — metrics are in App Insights."""
+    return {"success": False, "message": "Metrics are stored in App Insights and cannot be cleared from here. Use Azure Portal to manage retention."}
 
 
 @app.post("/api/metrics/changefeed")
@@ -761,50 +830,31 @@ def report_changefeed_metrics(payload: dict):
 
 
 @app.get("/api/metrics/changefeed")
-def get_changefeed_metrics():
-    """Get changefeed metrics from in-memory store."""
-    if not metrics_store:
-        return {"error": "Metrics not available"}
-    snap = metrics_store.snapshot()
+async def get_changefeed_metrics():
+    """Get changefeed metrics from App Insights."""
+    kql = """
+    customMetrics
+    | where name in ('omnivec.documents.embedded', 'omnivec.documents.failed', 'omnivec.documents.skipped', 'omnivec.pipeline.jobs_created')
+    | summarize
+        embedded = sumif(value, name == 'omnivec.documents.embedded'),
+        failed = sumif(value, name == 'omnivec.documents.failed'),
+        skipped = sumif(value, name == 'omnivec.documents.skipped'),
+        jobs = sumif(value, name == 'omnivec.pipeline.jobs_created')
+    """
+    rows = await asyncio.to_thread(_run_kql, kql, timedelta(days=7))
+    if rows is None or not rows:
+        return {"total_eligible": 0, "total_failed": 0, "total_skipped": 0, "total_jobs_created": 0, "source": "unavailable"}
+    row = rows[0]
     return {
-        "total_batches": snap["changefeed_batches"],
-        "total_eligible": snap["documents_embedded"],
-        "total_skipped_no_content": snap["skipped"]["no_content"],
-        "total_skipped_unchanged": snap["skipped"]["unchanged"],
-        "total_jobs_created": snap["jobs_created"],
-        "pipelines": snap["pipelines"],
+        "total_eligible": int(row[0] or 0),
+        "total_failed": int(row[1] or 0),
+        "total_skipped": int(row[2] or 0),
+        "total_jobs_created": int(row[3] or 0),
+        "source": "app_insights",
     }
 
 
 # â”€â”€ timeseries metrics â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
-
-def _upsert_ts_bucket(pipeline_id: str, processed: int, failed: int, processing_time_ms: float):
-    """Upsert a minute-level timeseries bucket for the given pipeline."""
-    if processed == 0 and failed == 0:
-        return
-    store = get_store()
-    now = datetime.utcnow()
-    bucket_key = now.strftime("%Y%m%dT%H%M")
-    bucket_iso = now.strftime("%Y-%m-%dT%H:%M:00")
-    doc_id = f"mts-{pipeline_id}-{bucket_key}"
-
-    existing = store.get(doc_id, "metric_ts")
-    if existing:
-        existing["processed"] = existing.get("processed", 0) + processed
-        existing["failed"] = existing.get("failed", 0) + failed
-        existing["processing_time_ms"] = existing.get("processing_time_ms", 0.0) + processing_time_ms
-        store.upsert(existing)
-    else:
-        store.upsert({
-            "id": doc_id,
-            "doc_type": "metric_ts",
-            "pipeline_id": pipeline_id,
-            "bucket": bucket_iso,
-            "processed": processed,
-            "failed": failed,
-            "processing_time_ms": processing_time_ms,
-        })
-
 
 @app.get("/api/metrics/timeseries")
 async def get_metrics_timeseries(
@@ -813,10 +863,7 @@ async def get_metrics_timeseries(
     end: str | None = None,
     pipeline_id: str | None = None,
 ):
-    """Get time-series metrics from Azure App Insights (Log Analytics).
-
-    Falls back to in-memory store if App Insights is not configured.
-    """
+    """Get time-series metrics from Azure App Insights (Log Analytics)."""
     now = datetime.utcnow()
     if granularity not in ("minute", "hour", "day"):
         raise HTTPException(status_code=400, detail="granularity must be minute, hour, or day")
@@ -830,86 +877,56 @@ async def get_metrics_timeseries(
     start_iso = start_dt.strftime("%Y-%m-%dT%H:%M:00")
     end_iso = end_dt.strftime("%Y-%m-%dT%H:%M:00")
 
-    workspace_id = os.environ.get("LOG_ANALYTICS_WORKSPACE_ID", "")
+    gran_bin = {"minute": "1m", "hour": "1h", "day": "1d"}.get(granularity, "1h")
+    gran_seconds = {"minute": 60, "hour": 3600, "day": 86400}.get(granularity, 3600)
 
-    # Try App Insights first (persistent, survives restarts)
-    if workspace_id:
-        try:
-            buckets = await asyncio.to_thread(
-                _query_app_insights_timeseries, workspace_id, start_dt, end_dt, granularity, pipeline_id
-            )
-            if buckets is not None:
-                return {
-                    "granularity": granularity,
-                    "start": start_iso,
-                    "end": end_iso,
-                    "pipeline_id": pipeline_id,
-                    "source": "app_insights",
-                    "buckets": buckets,
-                }
-        except Exception as e:
-            logger.warning(f"App Insights query failed, falling back to in-memory: {e}")
+    kql = f"""
+    customMetrics
+    | where name in ('omnivec.documents.embedded', 'omnivec.documents.failed', 'omnivec.embedding.latency')
+    | summarize
+        processed = sumif(value, name == 'omnivec.documents.embedded'),
+        failed = sumif(value, name == 'omnivec.documents.failed'),
+        avg_latency = avgif(value, name == 'omnivec.embedding.latency')
+        by bin(timestamp, {gran_bin})
+    | order by timestamp asc
+    """
 
-    # Fallback: in-memory store
-    if metrics_store:
-        buckets = metrics_store.get_timeseries(start_iso, end_iso, granularity)
-    else:
-        buckets = []
+    rows = await asyncio.to_thread(_run_kql, kql, (start_dt, end_dt))
+
+    if rows is None:
+        return {
+            "granularity": granularity,
+            "start": start_iso,
+            "end": end_iso,
+            "pipeline_id": pipeline_id,
+            "source": "unavailable",
+            "buckets": [],
+            "message": "App Insights not configured. Deploy with azd up to enable metrics.",
+        }
+
+    buckets = []
+    for row in rows:
+        ts = row[0]
+        processed = int(row[1] or 0)
+        failed = int(row[2] or 0)
+        avg_lat = round(row[3], 1) if row[3] else None
+        t_str = ts.strftime("%Y-%m-%dT%H:%M:00") if hasattr(ts, 'strftime') else str(ts)[:16] + ":00"
+        buckets.append({
+            "t": t_str,
+            "processed": processed,
+            "failed": failed,
+            "throughput": round(processed / gran_seconds, 1) if processed > 0 else 0.0,
+            "avg_latency_ms": avg_lat,
+        })
 
     return {
         "granularity": granularity,
         "start": start_iso,
         "end": end_iso,
         "pipeline_id": pipeline_id,
-        "source": "in_memory",
+        "source": "app_insights",
         "buckets": buckets,
     }
-
-
-def _query_app_insights_timeseries(workspace_id, start_dt, end_dt, granularity, pipeline_id=None):
-    """Query Log Analytics for custom metrics timeseries."""
-    try:
-        from azure.monitor.query import LogsQueryClient, LogsQueryStatus
-        from azure.identity import DefaultAzureCredential
-
-        gran_bin = {"minute": "1m", "hour": "1h", "day": "1d"}.get(granularity, "1h")
-        gran_seconds = {"minute": 60, "hour": 3600, "day": 86400}.get(granularity, 3600)
-
-        # Query customMetrics for documents.embedded (processed) and documents.failed
-        kql = f"""
-        customMetrics
-        | where timestamp between (datetime('{start_dt.isoformat()}Z') .. datetime('{end_dt.isoformat()}Z'))
-        | where name in ('omnivec.documents.embedded', 'omnivec.documents.failed')
-        | summarize
-            processed = sumif(value, name == 'omnivec.documents.embedded'),
-            failed = sumif(value, name == 'omnivec.documents.failed')
-            by bin(timestamp, {gran_bin})
-        | order by timestamp asc
-        """
-
-        client = LogsQueryClient(DefaultAzureCredential())
-        response = client.query_workspace(workspace_id, kql, timespan=(start_dt, end_dt))
-
-        if response.status != LogsQueryStatus.SUCCESS:
-            return None
-
-        buckets = []
-        for row in response.tables[0].rows:
-            ts = row[0]  # timestamp
-            processed = int(row[1] or 0)
-            failed = int(row[2] or 0)
-            t_str = ts.strftime("%Y-%m-%dT%H:%M:00") if hasattr(ts, 'strftime') else str(ts)[:16] + ":00"
-            buckets.append({
-                "t": t_str,
-                "processed": processed,
-                "failed": failed,
-                "throughput": round(processed / gran_seconds, 1) if processed > 0 else 0.0,
-                "avg_latency_ms": None,  # TODO: add latency query
-            })
-        return buckets
-    except ImportError:
-        logger.info("azure-monitor-query not installed — App Insights queries disabled")
-        return None
 
 
 
@@ -2074,9 +2091,6 @@ def report_inline_metrics(pipeline_id: str, payload: dict):
     pip["recent"] = recent
 
     store.upsert(doc)
-
-    # Write minute-level timeseries bucket
-    _upsert_ts_bucket(pipeline_id, processed, failed, processing_time_ms)
 
     return {"ok": True}
 

--- a/api/api.py
+++ b/api/api.py
@@ -18,6 +18,20 @@ from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from pydantic import BaseModel
 
+# Initialize Azure Monitor telemetry (safe if connection string not set)
+try:
+    from telemetry import init_telemetry, track_metric, track_histogram, track_event, Timer
+    init_telemetry()
+except ImportError:
+    # Telemetry module not available — define no-ops
+    def track_metric(*a, **kw): pass
+    def track_histogram(*a, **kw): pass
+    def track_event(*a, **kw): pass
+    class Timer:
+        def __init__(self, *a, **kw): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): pass
+
 from models import (
     Source, Destination, Pipeline, Job, JobStatus, JobStats,
     CreateSourceRequest, CreateDestinationRequest, CreatePipelineRequest,
@@ -695,6 +709,11 @@ def report_changefeed_metrics(payload: dict):
     skipped_unchanged = int(payload.get("skipped_unchanged", 0))
     jobs_created = int(payload.get("jobs_created", 0))
     partition = payload.get("partition", "")
+
+    # Forward to Azure Monitor
+    track_metric("documents_embedded", eligible, {"source_id": source_id})
+    if jobs_created > 0:
+        track_metric("jobs_created", jobs_created, {"source_id": source_id})
 
     # Get or create changefeed metrics doc
     cf_doc = store.get("changefeed", "metrics")
@@ -2463,6 +2482,7 @@ def _merge_results(index_results: list, strategy: str, top_k: int) -> list:
         all_results.sort(key=lambda r: r["score"], reverse=True)
         if strategy != "per_index":
             all_results = all_results[:top_k]
+        track_histogram("search_latency", (time.time() - _search_start) * 1000)
         return all_results
 
 
@@ -2470,6 +2490,9 @@ def _merge_results(index_results: list, strategy: str, top_k: int) -> list:
 async def playground_search(req: SearchRequest):
     """Search vectors across one or more indexes using query embedding."""
     import time
+
+    track_metric("search_queries", 1)
+    _search_start = time.time()
 
     if not req.destination_ids:
         raise HTTPException(status_code=400, detail="No destination_ids provided")

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -16,3 +16,4 @@ aiofiles>=23.2.0
 kubernetes>=28.1.0
 asyncpg>=0.29.0
 pyodbc>=5.1.0
+azure-monitor-opentelemetry>=1.3.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -17,3 +17,4 @@ kubernetes>=28.1.0
 asyncpg>=0.29.0
 pyodbc>=5.1.0
 azure-monitor-opentelemetry>=1.3.0
+azure-monitor-query>=1.2.0

--- a/api/telemetry.py
+++ b/api/telemetry.py
@@ -143,6 +143,12 @@ class MetricsStore:
         # --- Throughput tracker (rolling 60s) ---
         self.throughput = _ThroughputTracker(60)
 
+        # --- Time-series buckets (minute granularity, last 24h) ---
+        # { "2026-04-16T14:30:00": {processed, failed, processing_time_ms} }
+        self._timeseries: Dict[str, dict] = defaultdict(lambda: {
+            "processed": 0, "failed": 0, "processing_time_ms": 0.0,
+        })
+
     # -- Recording methods (thread-safe) --
 
     def record_embedding_batch(self, pipeline_id: str, docs_embedded: int = 0,
@@ -167,6 +173,13 @@ class MetricsStore:
                 p["skipped_unchanged"] += docs_skipped_unchanged
                 p["jobs_created"] += jobs_created
                 p["tokens"] += tokens_used
+
+            # Time-series bucket (minute granularity)
+            bucket = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:00")
+            ts = self._timeseries[bucket]
+            ts["processed"] += docs_embedded
+            ts["failed"] += docs_failed
+            ts["processing_time_ms"] += latency_ms
 
         if docs_embedded > 0:
             self.throughput.record(docs_embedded)
@@ -247,6 +260,44 @@ class MetricsStore:
                 "pipelines": pipelines,
             }
 
+    def get_timeseries(self, start: str, end: str, granularity: str = "hour") -> list:
+        """Return time-series buckets between start and end, aggregated by granularity."""
+        gran_seconds = {"minute": 60, "hour": 3600, "day": 86400}.get(granularity, 3600)
+
+        def _trunc(bucket_str: str) -> str:
+            if granularity == "minute":
+                return bucket_str  # already minute granularity
+            elif granularity == "hour":
+                return bucket_str[:13] + ":00:00"
+            else:
+                return bucket_str[:10] + "T00:00:00"
+
+        with self._lock:
+            agg: Dict[str, dict] = {}
+            for bucket, data in self._timeseries.items():
+                if bucket < start or bucket > end:
+                    continue
+                key = _trunc(bucket)
+                if key not in agg:
+                    agg[key] = {"processed": 0, "failed": 0, "processing_time_ms": 0.0}
+                agg[key]["processed"] += data["processed"]
+                agg[key]["failed"] += data["failed"]
+                agg[key]["processing_time_ms"] += data["processing_time_ms"]
+
+        buckets = []
+        for t in sorted(agg.keys()):
+            a = agg[t]
+            p = a["processed"]
+            f = a["failed"]
+            buckets.append({
+                "t": t,
+                "processed": p,
+                "failed": f,
+                "throughput": round(p / gran_seconds, 1) if p > 0 else 0.0,
+                "avg_latency_ms": round(a["processing_time_ms"] / p, 1) if p > 0 else None,
+            })
+        return buckets
+
     def reset(self):
         """Reset all counters (for testing or manual clear)."""
         with self._lock:
@@ -257,6 +308,7 @@ class MetricsStore:
                 setattr(self, attr, 0)
             self._pipelines.clear()
             self._failure_types.clear()
+            self._timeseries.clear()
             self._started_at = datetime.now(timezone.utc).isoformat()
         self.embedding_latency = _SlidingWindow(300)
         self.search_latency = _SlidingWindow(300)

--- a/api/telemetry.py
+++ b/api/telemetry.py
@@ -1,35 +1,296 @@
-"""OmniVec Telemetry — Azure Monitor / Application Insights integration.
+"""OmniVec Telemetry — Unified metrics system.
+
+Architecture:
+  - In-memory MetricsStore: thread-safe counters + sliding-window histograms.
+    Always active. Powers /api/metrics/live for real-time dashboard.
+  - Azure Monitor / App Insights: persistent, multi-replica-safe.
+    Receives the same events via OpenTelemetry. Powers historical queries.
+  - No CosmosDB metrics docs — zero DB cost for metrics reads.
 
 Usage:
-    from telemetry import init_telemetry, track_metric, track_event
-
-    init_telemetry()  # call once at startup
-    track_metric("omnivec.documents.embedded", 1, {"pipeline_id": "pip-123"})
-    track_event("pipeline_created", {"pipeline_id": "pip-123", "source_type": "cosmosdb"})
+    from telemetry import (
+        init_telemetry, metrics_store,
+        record_embedding_batch, record_search, record_error,
+        track_metric, track_histogram, track_event, Timer,
+    )
+    init_telemetry()
+    record_embedding_batch(pipeline_id="p1", docs_embedded=50, docs_skipped=3,
+                           tokens_used=12000, latency_ms=340)
+    record_search(latency_ms=120, tokens_used=800, results_count=5)
 """
 
 import os
 import logging
 import time
-from typing import Dict, Optional
+import threading
+from collections import defaultdict, deque
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-# Global telemetry state
+# ---------------------------------------------------------------------------
+# In-memory MetricsStore — always active, thread-safe
+# ---------------------------------------------------------------------------
+
+class _SlidingWindow:
+    """Fixed-duration sliding window for latency/throughput samples."""
+
+    def __init__(self, window_seconds: int = 300):
+        self.window = window_seconds
+        self._samples: deque = deque()  # (timestamp, value)
+        self._lock = threading.Lock()
+
+    def record(self, value: float):
+        now = time.time()
+        with self._lock:
+            self._samples.append((now, value))
+            self._trim(now)
+
+    def _trim(self, now: float):
+        cutoff = now - self.window
+        while self._samples and self._samples[0][0] < cutoff:
+            self._samples.popleft()
+
+    def stats(self) -> dict:
+        now = time.time()
+        with self._lock:
+            self._trim(now)
+            if not self._samples:
+                return {"count": 0, "avg": None, "p50": None, "p95": None, "p99": None, "min": None, "max": None}
+            vals = sorted(v for _, v in self._samples)
+            n = len(vals)
+            return {
+                "count": n,
+                "avg": round(sum(vals) / n, 1),
+                "p50": round(vals[n // 2], 1),
+                "p95": round(vals[int(n * 0.95)], 1) if n >= 2 else round(vals[-1], 1),
+                "p99": round(vals[int(n * 0.99)], 1) if n >= 2 else round(vals[-1], 1),
+                "min": round(vals[0], 1),
+                "max": round(vals[-1], 1),
+            }
+
+
+class _ThroughputTracker:
+    """Rolling window throughput (events/sec)."""
+
+    def __init__(self, window_seconds: int = 60):
+        self.window = window_seconds
+        self._events: deque = deque()  # (timestamp, count)
+        self._lock = threading.Lock()
+
+    def record(self, count: int = 1):
+        now = time.time()
+        with self._lock:
+            self._events.append((now, count))
+            self._trim(now)
+
+    def _trim(self, now: float):
+        cutoff = now - self.window
+        while self._events and self._events[0][0] < cutoff:
+            self._events.popleft()
+
+    def rate(self) -> float:
+        now = time.time()
+        with self._lock:
+            self._trim(now)
+            if not self._events:
+                return 0.0
+            total = sum(c for _, c in self._events)
+            span = now - self._events[0][0] if len(self._events) > 1 else self.window
+            return round(total / max(span, 1), 2)
+
+
+class MetricsStore:
+    """Thread-safe in-memory metrics accumulator.
+
+    Counters are global + per-pipeline. Histograms use sliding windows.
+    This is the primary read source for the dashboard.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._started_at = datetime.now(timezone.utc).isoformat()
+
+        # --- Global counters ---
+        self.documents_embedded = 0
+        self.documents_failed = 0
+        self.documents_skipped_no_content = 0
+        self.documents_skipped_unchanged = 0
+        self.jobs_created = 0
+        self.search_queries = 0
+        self.api_errors_4xx = 0
+        self.api_errors_5xx = 0
+        self.tokens_embedding = 0    # tokens used for pipeline embedding
+        self.tokens_search = 0       # tokens used for search-time embedding
+        self.changefeed_batches = 0
+
+        # --- Per-pipeline counters ---
+        # { pipeline_id: {embedded, failed, skipped, tokens, ...} }
+        self._pipelines: Dict[str, dict] = defaultdict(lambda: {
+            "embedded": 0, "failed": 0, "skipped_no_content": 0,
+            "skipped_unchanged": 0, "jobs_created": 0, "tokens": 0,
+        })
+
+        # --- Failure breakdown { error_category: count } ---
+        self._failure_types: Dict[str, int] = defaultdict(int)
+
+        # --- Sliding-window histograms (last 5 min) ---
+        self.embedding_latency = _SlidingWindow(300)
+        self.search_latency = _SlidingWindow(300)
+        self.request_latency = _SlidingWindow(300)
+
+        # --- Throughput tracker (rolling 60s) ---
+        self.throughput = _ThroughputTracker(60)
+
+    # -- Recording methods (thread-safe) --
+
+    def record_embedding_batch(self, pipeline_id: str, docs_embedded: int = 0,
+                                docs_failed: int = 0, docs_skipped_no_content: int = 0,
+                                docs_skipped_unchanged: int = 0, jobs_created: int = 0,
+                                tokens_used: int = 0, latency_ms: float = 0,
+                                source_id: str = ""):
+        with self._lock:
+            self.documents_embedded += docs_embedded
+            self.documents_failed += docs_failed
+            self.documents_skipped_no_content += docs_skipped_no_content
+            self.documents_skipped_unchanged += docs_skipped_unchanged
+            self.jobs_created += jobs_created
+            self.tokens_embedding += tokens_used
+            self.changefeed_batches += 1
+
+            if pipeline_id:
+                p = self._pipelines[pipeline_id]
+                p["embedded"] += docs_embedded
+                p["failed"] += docs_failed
+                p["skipped_no_content"] += docs_skipped_no_content
+                p["skipped_unchanged"] += docs_skipped_unchanged
+                p["jobs_created"] += jobs_created
+                p["tokens"] += tokens_used
+
+        if docs_embedded > 0:
+            self.throughput.record(docs_embedded)
+        if latency_ms > 0:
+            self.embedding_latency.record(latency_ms)
+
+    def record_search(self, latency_ms: float = 0, tokens_used: int = 0,
+                      results_count: int = 0, embed_latency_ms: float = 0):
+        with self._lock:
+            self.search_queries += 1
+            self.tokens_search += tokens_used
+        if latency_ms > 0:
+            self.search_latency.record(latency_ms)
+        if embed_latency_ms > 0:
+            self.embedding_latency.record(embed_latency_ms)
+
+    def record_error(self, status_code: int = 500, category: str = ""):
+        with self._lock:
+            if 400 <= status_code < 500:
+                self.api_errors_4xx += 1
+            else:
+                self.api_errors_5xx += 1
+            if category:
+                self._failure_types[category] += 1
+
+    def record_request(self, latency_ms: float):
+        self.request_latency.record(latency_ms)
+
+    def record_failure(self, pipeline_id: str = "", error_type: str = "unknown"):
+        with self._lock:
+            self.documents_failed += 1
+            if pipeline_id:
+                self._pipelines[pipeline_id]["failed"] += 1
+            self._failure_types[error_type] += 1
+
+    # -- Snapshot for dashboard --
+
+    def snapshot(self) -> dict:
+        """Return full metrics snapshot for /api/metrics/live."""
+        with self._lock:
+            pipelines = {}
+            for pid, counters in self._pipelines.items():
+                pipelines[pid] = dict(counters)
+
+            total_tokens = self.tokens_embedding + self.tokens_search
+
+            return {
+                "started_at": self._started_at,
+                "uptime_seconds": round(time.time() - datetime.fromisoformat(self._started_at).timestamp()),
+                # Primary: throughput, latency, progress
+                "throughput_docs_per_sec": self.throughput.rate(),
+                "embedding_latency": self.embedding_latency.stats(),
+                "search_latency": self.search_latency.stats(),
+                "request_latency": self.request_latency.stats(),
+                # Counters
+                "documents_embedded": self.documents_embedded,
+                "documents_failed": self.documents_failed,
+                "jobs_created": self.jobs_created,
+                "search_queries": self.search_queries,
+                "changefeed_batches": self.changefeed_batches,
+                # Secondary: tokens, skips, failure types
+                "tokens": {
+                    "embedding": self.tokens_embedding,
+                    "search": self.tokens_search,
+                    "total": total_tokens,
+                },
+                "skipped": {
+                    "no_content": self.documents_skipped_no_content,
+                    "unchanged": self.documents_skipped_unchanged,
+                    "total": self.documents_skipped_no_content + self.documents_skipped_unchanged,
+                },
+                "errors": {
+                    "client_4xx": self.api_errors_4xx,
+                    "server_5xx": self.api_errors_5xx,
+                    "failure_types": dict(self._failure_types),
+                },
+                # Per-pipeline breakdown
+                "pipelines": pipelines,
+            }
+
+    def reset(self):
+        """Reset all counters (for testing or manual clear)."""
+        with self._lock:
+            for attr in ("documents_embedded", "documents_failed",
+                         "documents_skipped_no_content", "documents_skipped_unchanged",
+                         "jobs_created", "search_queries", "api_errors_4xx", "api_errors_5xx",
+                         "tokens_embedding", "tokens_search", "changefeed_batches"):
+                setattr(self, attr, 0)
+            self._pipelines.clear()
+            self._failure_types.clear()
+            self._started_at = datetime.now(timezone.utc).isoformat()
+        self.embedding_latency = _SlidingWindow(300)
+        self.search_latency = _SlidingWindow(300)
+        self.request_latency = _SlidingWindow(300)
+        self.throughput = _ThroughputTracker(60)
+
+
+# Singleton — importable anywhere
+metrics_store = MetricsStore()
+
+
+# ---------------------------------------------------------------------------
+# Azure Monitor / App Insights — optional persistent layer
+# ---------------------------------------------------------------------------
+
 _initialized = False
 _meter = None
 _tracer = None
-_counters = {}
-_histograms = {}
+_counters: Dict = {}
+_histograms: Dict = {}
 
 
 def init_telemetry():
-    """Initialize Azure Monitor OpenTelemetry if connection string is available."""
+    """Initialize Azure Monitor if connection string is set.
+
+    Always safe to call — no-ops if not configured.
+    The in-memory MetricsStore works regardless.
+    """
     global _initialized, _meter, _tracer
 
     conn_str = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "")
     if not conn_str:
-        logger.info("No APPLICATIONINSIGHTS_CONNECTION_STRING — telemetry disabled.")
+        logger.info("No APPLICATIONINSIGHTS_CONNECTION_STRING — App Insights disabled. "
+                     "In-memory metrics still active.")
         return
 
     try:
@@ -44,67 +305,133 @@ def init_telemetry():
         _meter = metrics.get_meter("omnivec", "1.0.0")
         _tracer = trace.get_tracer("omnivec", "1.0.0")
 
-        # Pre-create common metrics
         _counters["documents_embedded"] = _meter.create_counter(
-            "omnivec.documents.embedded",
-            description="Number of documents successfully embedded",
-            unit="documents",
-        )
+            "omnivec.documents.embedded", unit="documents")
+        _counters["documents_failed"] = _meter.create_counter(
+            "omnivec.documents.failed", unit="documents")
+        _counters["documents_skipped"] = _meter.create_counter(
+            "omnivec.documents.skipped", unit="documents")
         _counters["jobs_created"] = _meter.create_counter(
-            "omnivec.pipeline.jobs_created",
-            description="Number of jobs created by the controller",
-            unit="jobs",
-        )
-        _counters["jobs_failed"] = _meter.create_counter(
-            "omnivec.pipeline.jobs_failed",
-            description="Number of jobs that failed processing",
-            unit="jobs",
-        )
+            "omnivec.pipeline.jobs_created", unit="jobs")
         _counters["search_queries"] = _meter.create_counter(
-            "omnivec.search.queries",
-            description="Number of vector search queries",
-            unit="queries",
-        )
+            "omnivec.search.queries", unit="queries")
+        _counters["tokens_used"] = _meter.create_counter(
+            "omnivec.tokens.used", unit="tokens")
         _counters["api_errors"] = _meter.create_counter(
-            "omnivec.api.errors",
-            description="Number of API errors",
-            unit="errors",
-        )
+            "omnivec.api.errors", unit="errors")
+
         _histograms["embedding_latency"] = _meter.create_histogram(
-            "omnivec.embedding.latency",
-            description="Embedding generation latency",
-            unit="ms",
-        )
+            "omnivec.embedding.latency", unit="ms")
         _histograms["search_latency"] = _meter.create_histogram(
-            "omnivec.search.latency",
-            description="Vector search latency",
-            unit="ms",
-        )
+            "omnivec.search.latency", unit="ms")
+        _histograms["request_latency"] = _meter.create_histogram(
+            "omnivec.request.latency", unit="ms")
 
         _initialized = True
         logger.info("Azure Monitor telemetry initialized.")
     except ImportError:
-        logger.warning("azure-monitor-opentelemetry not installed — telemetry disabled.")
+        logger.warning("azure-monitor-opentelemetry not installed — App Insights disabled.")
     except Exception as e:
-        logger.warning(f"Failed to initialize telemetry: {e}")
+        logger.warning(f"Failed to init App Insights: {e}")
 
+
+def _ai_counter(name: str, value: float, attrs: dict = None):
+    """Forward to App Insights counter (no-op if not initialized)."""
+    if _initialized:
+        c = _counters.get(name)
+        if c:
+            c.add(value, attrs or {})
+
+
+def _ai_histogram(name: str, value: float, attrs: dict = None):
+    """Forward to App Insights histogram."""
+    if _initialized:
+        h = _histograms.get(name)
+        if h:
+            h.record(value, attrs or {})
+
+
+# ---------------------------------------------------------------------------
+# High-level recording functions — write to BOTH in-memory + App Insights
+# ---------------------------------------------------------------------------
+
+def record_embedding_batch(pipeline_id: str = "", docs_embedded: int = 0,
+                           docs_failed: int = 0, docs_skipped_no_content: int = 0,
+                           docs_skipped_unchanged: int = 0, jobs_created: int = 0,
+                           tokens_used: int = 0, latency_ms: float = 0,
+                           source_id: str = ""):
+    """Record a changefeed embedding batch — primary metrics event."""
+    attrs = {"pipeline_id": pipeline_id, "source_id": source_id}
+
+    # In-memory
+    metrics_store.record_embedding_batch(
+        pipeline_id=pipeline_id, docs_embedded=docs_embedded,
+        docs_failed=docs_failed, docs_skipped_no_content=docs_skipped_no_content,
+        docs_skipped_unchanged=docs_skipped_unchanged, jobs_created=jobs_created,
+        tokens_used=tokens_used, latency_ms=latency_ms, source_id=source_id,
+    )
+
+    # App Insights
+    if docs_embedded:
+        _ai_counter("documents_embedded", docs_embedded, attrs)
+    if docs_failed:
+        _ai_counter("documents_failed", docs_failed, attrs)
+    if docs_skipped_no_content + docs_skipped_unchanged > 0:
+        _ai_counter("documents_skipped", docs_skipped_no_content + docs_skipped_unchanged, attrs)
+    if jobs_created:
+        _ai_counter("jobs_created", jobs_created, attrs)
+    if tokens_used:
+        _ai_counter("tokens_used", tokens_used, attrs)
+    if latency_ms > 0:
+        _ai_histogram("embedding_latency", latency_ms, attrs)
+
+
+def record_search(latency_ms: float = 0, embed_latency_ms: float = 0,
+                  tokens_used: int = 0, results_count: int = 0):
+    """Record a search query event."""
+    metrics_store.record_search(
+        latency_ms=latency_ms, tokens_used=tokens_used,
+        results_count=results_count, embed_latency_ms=embed_latency_ms,
+    )
+    _ai_counter("search_queries", 1)
+    if tokens_used:
+        _ai_counter("tokens_used", tokens_used, {"source": "search"})
+    if latency_ms > 0:
+        _ai_histogram("search_latency", latency_ms)
+    if embed_latency_ms > 0:
+        _ai_histogram("embedding_latency", embed_latency_ms, {"source": "search"})
+
+
+def record_error(status_code: int = 500, category: str = "", path: str = ""):
+    """Record an API error."""
+    metrics_store.record_error(status_code=status_code, category=category)
+    _ai_counter("api_errors", 1, {"status_code": str(status_code), "category": category, "path": path})
+
+
+def record_request(latency_ms: float, method: str = "", path: str = ""):
+    """Record API request latency."""
+    metrics_store.record_request(latency_ms)
+    _ai_histogram("request_latency", latency_ms, {"method": method, "path": path})
+
+
+def record_failure(pipeline_id: str = "", error_type: str = "unknown"):
+    """Record a document/job failure with categorization."""
+    metrics_store.record_failure(pipeline_id=pipeline_id, error_type=error_type)
+    _ai_counter("documents_failed", 1, {"pipeline_id": pipeline_id, "error_type": error_type})
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible wrappers (for existing call sites)
+# ---------------------------------------------------------------------------
 
 def track_metric(name: str, value: float = 1, attributes: Optional[Dict] = None):
-    """Increment a counter metric."""
-    if not _initialized:
-        return
-    counter = _counters.get(name)
-    if counter:
-        counter.add(value, attributes or {})
+    """Legacy: increment a counter. Prefer record_* functions."""
+    _ai_counter(name, value, attributes)
 
 
 def track_histogram(name: str, value: float, attributes: Optional[Dict] = None):
-    """Record a histogram value (latency, size, etc.)."""
-    if not _initialized:
-        return
-    hist = _histograms.get(name)
-    if hist:
-        hist.record(value, attributes or {})
+    """Legacy: record a histogram value. Prefer record_* functions."""
+    _ai_histogram(name, value, attributes)
 
 
 def track_event(name: str, properties: Optional[Dict] = None):
@@ -118,17 +445,18 @@ def track_event(name: str, properties: Optional[Dict] = None):
 
 
 class Timer:
-    """Context manager for timing operations and recording to histogram."""
+    """Context manager for timing operations."""
 
     def __init__(self, metric_name: str, attributes: Optional[Dict] = None):
         self.metric_name = metric_name
         self.attributes = attributes or {}
         self.start = None
+        self.elapsed_ms = 0
 
     def __enter__(self):
         self.start = time.time()
         return self
 
     def __exit__(self, *args):
-        elapsed_ms = (time.time() - self.start) * 1000
-        track_histogram(self.metric_name, elapsed_ms, self.attributes)
+        self.elapsed_ms = (time.time() - self.start) * 1000
+        _ai_histogram(self.metric_name, self.elapsed_ms, self.attributes)

--- a/api/telemetry.py
+++ b/api/telemetry.py
@@ -1,0 +1,134 @@
+"""OmniVec Telemetry — Azure Monitor / Application Insights integration.
+
+Usage:
+    from telemetry import init_telemetry, track_metric, track_event
+
+    init_telemetry()  # call once at startup
+    track_metric("omnivec.documents.embedded", 1, {"pipeline_id": "pip-123"})
+    track_event("pipeline_created", {"pipeline_id": "pip-123", "source_type": "cosmosdb"})
+"""
+
+import os
+import logging
+import time
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Global telemetry state
+_initialized = False
+_meter = None
+_tracer = None
+_counters = {}
+_histograms = {}
+
+
+def init_telemetry():
+    """Initialize Azure Monitor OpenTelemetry if connection string is available."""
+    global _initialized, _meter, _tracer
+
+    conn_str = os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING", "")
+    if not conn_str:
+        logger.info("No APPLICATIONINSIGHTS_CONNECTION_STRING — telemetry disabled.")
+        return
+
+    try:
+        from azure.monitor.opentelemetry import configure_azure_monitor
+        from opentelemetry import metrics, trace
+
+        configure_azure_monitor(
+            connection_string=conn_str,
+            enable_live_metrics=True,
+        )
+
+        _meter = metrics.get_meter("omnivec", "1.0.0")
+        _tracer = trace.get_tracer("omnivec", "1.0.0")
+
+        # Pre-create common metrics
+        _counters["documents_embedded"] = _meter.create_counter(
+            "omnivec.documents.embedded",
+            description="Number of documents successfully embedded",
+            unit="documents",
+        )
+        _counters["jobs_created"] = _meter.create_counter(
+            "omnivec.pipeline.jobs_created",
+            description="Number of jobs created by the controller",
+            unit="jobs",
+        )
+        _counters["jobs_failed"] = _meter.create_counter(
+            "omnivec.pipeline.jobs_failed",
+            description="Number of jobs that failed processing",
+            unit="jobs",
+        )
+        _counters["search_queries"] = _meter.create_counter(
+            "omnivec.search.queries",
+            description="Number of vector search queries",
+            unit="queries",
+        )
+        _counters["api_errors"] = _meter.create_counter(
+            "omnivec.api.errors",
+            description="Number of API errors",
+            unit="errors",
+        )
+        _histograms["embedding_latency"] = _meter.create_histogram(
+            "omnivec.embedding.latency",
+            description="Embedding generation latency",
+            unit="ms",
+        )
+        _histograms["search_latency"] = _meter.create_histogram(
+            "omnivec.search.latency",
+            description="Vector search latency",
+            unit="ms",
+        )
+
+        _initialized = True
+        logger.info("Azure Monitor telemetry initialized.")
+    except ImportError:
+        logger.warning("azure-monitor-opentelemetry not installed — telemetry disabled.")
+    except Exception as e:
+        logger.warning(f"Failed to initialize telemetry: {e}")
+
+
+def track_metric(name: str, value: float = 1, attributes: Optional[Dict] = None):
+    """Increment a counter metric."""
+    if not _initialized:
+        return
+    counter = _counters.get(name)
+    if counter:
+        counter.add(value, attributes or {})
+
+
+def track_histogram(name: str, value: float, attributes: Optional[Dict] = None):
+    """Record a histogram value (latency, size, etc.)."""
+    if not _initialized:
+        return
+    hist = _histograms.get(name)
+    if hist:
+        hist.record(value, attributes or {})
+
+
+def track_event(name: str, properties: Optional[Dict] = None):
+    """Track a custom event via trace span."""
+    if not _initialized or not _tracer:
+        return
+    with _tracer.start_as_current_span(name) as span:
+        if properties:
+            for k, v in properties.items():
+                span.set_attribute(k, str(v))
+
+
+class Timer:
+    """Context manager for timing operations and recording to histogram."""
+
+    def __init__(self, metric_name: str, attributes: Optional[Dict] = None):
+        self.metric_name = metric_name
+        self.attributes = attributes or {}
+        self.start = None
+
+    def __enter__(self):
+        self.start = time.time()
+        return self
+
+    def __exit__(self, *args):
+        elapsed_ms = (time.time() - self.start) * 1000
+        track_histogram(self.metric_name, elapsed_ms, self.attributes)

--- a/cli/cmd_metrics.go
+++ b/cli/cmd_metrics.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newMetricsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "metrics",
+		Aliases: []string{"metric", "stats"},
+		Short:   "Show pipeline and system metrics",
+	}
+	cmd.AddCommand(
+		newMetricsSummaryCmd(),
+		newMetricsInsightsCmd(),
+	)
+	return cmd
+}
+
+func newMetricsSummaryCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "summary",
+		Short: "Show pipeline processing summary",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := getClient()
+			data, err := c.Get("/api/metrics", nil)
+			if err != nil {
+				exitErr("%v", err)
+			}
+
+			if flagOutput != "table" {
+				var raw any
+				json.Unmarshal(data, &raw)
+				outputResult(raw, nil)
+				return nil
+			}
+
+			resp := parseJSONObject(data)
+			processed := toFloat(resp["events_processed"])
+			failed := toFloat(resp["events_failed"])
+			avgTime := resp["avg_processing_time_ms"]
+
+			fmt.Println("OmniVec Processing Metrics")
+			fmt.Println("─────────────────────────────")
+			fmt.Printf("Documents Processed: %.0f\n", processed)
+			fmt.Printf("Documents Failed:    %.0f\n", failed)
+			if avgTime != nil {
+				fmt.Printf("Avg Processing Time: %.1fms\n", toFloat(avgTime))
+			}
+
+			if today, ok := resp["today"].(map[string]any); ok {
+				fmt.Println("\nToday:")
+				fmt.Printf("  Processed: %.0f\n", toFloat(today["processed"]))
+				fmt.Printf("  Failed:    %.0f\n", toFloat(today["failed"]))
+			}
+
+			if pipelines, ok := resp["pipelines"].(map[string]any); ok && len(pipelines) > 0 {
+				fmt.Println("\nPer Pipeline:")
+				for id, v := range pipelines {
+					if pm, ok := v.(map[string]any); ok {
+						fmt.Printf("  %s: %.0f processed, %.0f failed\n",
+							id, toFloat(pm["processed"]), toFloat(pm["failed"]))
+					}
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func newMetricsInsightsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "insights",
+		Short: "Show Application Insights metrics and pipeline health",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := getClient()
+			data, err := c.Get("/api/metrics/insights", nil)
+			if err != nil {
+				exitErr("%v", err)
+			}
+
+			if flagOutput != "table" {
+				var raw any
+				json.Unmarshal(data, &raw)
+				outputResult(raw, nil)
+				return nil
+			}
+
+			resp := parseJSONObject(data)
+
+			enabled, _ := resp["enabled"].(bool)
+			if !enabled {
+				fmt.Println("Application Insights: not configured")
+				fmt.Println("  Deploy with azd up to enable telemetry.")
+				return nil
+			}
+
+			fmt.Println("Application Insights: enabled")
+			if ikey, ok := resp["instrumentation_key"].(string); ok {
+				fmt.Printf("  Instrumentation Key: %s\n", ikey)
+			}
+			if url, ok := resp["portal_url"].(string); ok {
+				fmt.Printf("  Azure Portal: %s\n", url)
+			}
+
+			// Custom metrics
+			if cm, ok := resp["custom_metrics"].(map[string]any); ok && len(cm) > 0 {
+				fmt.Println("\nTracked Metrics:")
+				for k := range cm {
+					fmt.Printf("  ✓ %s\n", k)
+				}
+			}
+
+			// Pipeline health
+			if pipelines, ok := resp["pipelines"].([]any); ok && len(pipelines) > 0 {
+				fmt.Println("\nPipeline Health:")
+				fmt.Printf("  %-16s %-20s %-8s %8s %8s %6s %10s\n", "ID", "NAME", "STATUS", "EMBEDDED", "FAILED", "PCT", "THROUGHPUT")
+				for _, p := range pipelines {
+					if pm, ok := p.(map[string]any); ok {
+						name := pm["name"]
+						if s, ok := name.(string); ok && len(s) > 18 {
+							name = s[:18] + ".."
+						}
+						fmt.Printf("  %-16s %-20s %-8s %8.0f %8.0f %5.1f%% %8s\n",
+							pm["id"], name, pm["status"],
+							toFloat(pm["embedded_count"]),
+							toFloat(pm["jobs_failed"]),
+							toFloat(pm["completion_pct"]),
+							formatThroughput(pm["throughput_docs_per_sec"]),
+						)
+					}
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func formatThroughput(v any) string {
+	if v == nil {
+		return "—"
+	}
+	f := toFloat(v)
+	if f == 0 {
+		return "—"
+	}
+	return fmt.Sprintf("%.1f/s", f)
+}
+
+

--- a/cli/cmd_metrics.go
+++ b/cli/cmd_metrics.go
@@ -11,7 +11,7 @@ func newMetricsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "metrics",
 		Aliases: []string{"metric", "stats"},
-		Short:   "Show pipeline and system metrics",
+		Short:   "Show live pipeline and system metrics",
 	}
 	cmd.AddCommand(
 		newMetricsSummaryCmd(),
@@ -23,7 +23,7 @@ func newMetricsCmd() *cobra.Command {
 func newMetricsSummaryCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "summary",
-		Short: "Show pipeline processing summary",
+		Short: "Show live processing metrics (throughput, latency, progress)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := getClient()
 			data, err := c.Get("/api/metrics", nil)
@@ -39,33 +39,77 @@ func newMetricsSummaryCmd() *cobra.Command {
 			}
 
 			resp := parseJSONObject(data)
-			processed := toFloat(resp["events_processed"])
-			failed := toFloat(resp["events_failed"])
-			avgTime := resp["avg_processing_time_ms"]
 
-			fmt.Println("OmniVec Processing Metrics")
-			fmt.Println("─────────────────────────────")
-			fmt.Printf("Documents Processed: %.0f\n", processed)
-			fmt.Printf("Documents Failed:    %.0f\n", failed)
-			if avgTime != nil {
-				fmt.Printf("Avg Processing Time: %.1fms\n", toFloat(avgTime))
+			fmt.Println("OmniVec Live Metrics")
+			fmt.Println("════════════════════════════════════════")
+
+			// Primary: throughput, latency, progress
+			fmt.Println("\n▸ Pipeline Progress")
+			fmt.Printf("  Documents Embedded:  %.0f\n", toFloat(resp["events_processed"]))
+			fmt.Printf("  Documents Failed:    %.0f\n", toFloat(resp["events_failed"]))
+			fmt.Printf("  Throughput:          %s\n", formatThroughput(resp["throughput_docs_per_sec"]))
+			fmt.Printf("  Jobs Created:        %.0f\n", toFloat(resp["jobs_created"]))
+			fmt.Printf("  Changefeed Batches:  %.0f\n", toFloat(resp["changefeed_batches"]))
+
+			fmt.Println("\n▸ Latency (5-min window)")
+			if lat, ok := resp["latency"].(map[string]any); ok {
+				printLatency("  Embedding", lat["embedding"])
+				printLatency("  Search   ", lat["search"])
+				printLatency("  Request  ", lat["request"])
 			}
 
-			if today, ok := resp["today"].(map[string]any); ok {
-				fmt.Println("\nToday:")
-				fmt.Printf("  Processed: %.0f\n", toFloat(today["processed"]))
-				fmt.Printf("  Failed:    %.0f\n", toFloat(today["failed"]))
+			// Secondary: tokens, skips, errors
+			if tok, ok := resp["tokens"].(map[string]any); ok {
+				fmt.Println("\n▸ Token Usage")
+				fmt.Printf("  Embedding: %s\n", fmtInt(tok["embedding"]))
+				fmt.Printf("  Search:    %s\n", fmtInt(tok["search"]))
+				fmt.Printf("  Total:     %s\n", fmtInt(tok["total"]))
 			}
 
-			if pipelines, ok := resp["pipelines"].(map[string]any); ok && len(pipelines) > 0 {
-				fmt.Println("\nPer Pipeline:")
-				for id, v := range pipelines {
-					if pm, ok := v.(map[string]any); ok {
-						fmt.Printf("  %s: %.0f processed, %.0f failed\n",
-							id, toFloat(pm["processed"]), toFloat(pm["failed"]))
+			if skip, ok := resp["skipped"].(map[string]any); ok {
+				total := toFloat(skip["total"])
+				if total > 0 {
+					fmt.Println("\n▸ Skipped Documents")
+					fmt.Printf("  No Content: %.0f\n", toFloat(skip["no_content"]))
+					fmt.Printf("  Unchanged:  %.0f\n", toFloat(skip["unchanged"]))
+				}
+			}
+
+			if errs, ok := resp["errors"].(map[string]any); ok {
+				e4 := toFloat(errs["client_4xx"])
+				e5 := toFloat(errs["server_5xx"])
+				if e4+e5 > 0 {
+					fmt.Println("\n▸ Errors")
+					fmt.Printf("  Client (4xx): %.0f\n", e4)
+					fmt.Printf("  Server (5xx): %.0f\n", e5)
+					if ft, ok := errs["failure_types"].(map[string]any); ok && len(ft) > 0 {
+						fmt.Println("  Failure Types:")
+						for k, v := range ft {
+							fmt.Printf("    %s: %.0f\n", k, toFloat(v))
+						}
 					}
 				}
 			}
+
+			// Per-pipeline
+			if pipelines, ok := resp["pipelines"].(map[string]any); ok && len(pipelines) > 0 {
+				fmt.Println("\n▸ Per Pipeline")
+				fmt.Printf("  %-20s %8s %8s %8s %8s\n", "PIPELINE", "EMBEDDED", "FAILED", "SKIPPED", "TOKENS")
+				for id, v := range pipelines {
+					if pm, ok := v.(map[string]any); ok {
+						short := id
+						if len(short) > 18 {
+							short = short[:18] + ".."
+						}
+						skipped := toFloat(pm["skipped_no_content"]) + toFloat(pm["skipped_unchanged"])
+						fmt.Printf("  %-20s %8.0f %8.0f %8.0f %8s\n",
+							short, toFloat(pm["embedded"]), toFloat(pm["failed"]),
+							skipped, fmtInt(pm["tokens"]))
+					}
+				}
+			}
+
+			fmt.Printf("\nUptime: %ds\n", int(toFloat(resp["uptime_seconds"])))
 			return nil
 		},
 	}
@@ -74,7 +118,7 @@ func newMetricsSummaryCmd() *cobra.Command {
 func newMetricsInsightsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "insights",
-		Short: "Show Application Insights metrics and pipeline health",
+		Short: "Show Application Insights connection status",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := getClient()
 			data, err := c.Get("/api/metrics/insights", nil)
@@ -90,53 +134,41 @@ func newMetricsInsightsCmd() *cobra.Command {
 			}
 
 			resp := parseJSONObject(data)
-
 			enabled, _ := resp["enabled"].(bool)
 			if !enabled {
 				fmt.Println("Application Insights: not configured")
-				fmt.Println("  Deploy with azd up to enable telemetry.")
+				fmt.Println("  In-memory metrics are active via: omnivec metrics summary")
+				fmt.Println("  Deploy with azd up to enable App Insights (persistent, multi-replica).")
 				return nil
 			}
 
-			fmt.Println("Application Insights: enabled")
+			fmt.Println("Application Insights: ● enabled")
 			if ikey, ok := resp["instrumentation_key"].(string); ok {
-				fmt.Printf("  Instrumentation Key: %s\n", ikey)
+				fmt.Printf("  Key:    %s\n", ikey)
 			}
 			if url, ok := resp["portal_url"].(string); ok {
-				fmt.Printf("  Azure Portal: %s\n", url)
+				fmt.Printf("  Portal: %s\n", url)
 			}
-
-			// Custom metrics
-			if cm, ok := resp["custom_metrics"].(map[string]any); ok && len(cm) > 0 {
-				fmt.Println("\nTracked Metrics:")
-				for k := range cm {
-					fmt.Printf("  ✓ %s\n", k)
-				}
-			}
-
-			// Pipeline health
-			if pipelines, ok := resp["pipelines"].([]any); ok && len(pipelines) > 0 {
-				fmt.Println("\nPipeline Health:")
-				fmt.Printf("  %-16s %-20s %-8s %8s %8s %6s %10s\n", "ID", "NAME", "STATUS", "EMBEDDED", "FAILED", "PCT", "THROUGHPUT")
-				for _, p := range pipelines {
-					if pm, ok := p.(map[string]any); ok {
-						name := pm["name"]
-						if s, ok := name.(string); ok && len(s) > 18 {
-							name = s[:18] + ".."
-						}
-						fmt.Printf("  %-16s %-20s %-8s %8.0f %8.0f %5.1f%% %8s\n",
-							pm["id"], name, pm["status"],
-							toFloat(pm["embedded_count"]),
-							toFloat(pm["jobs_failed"]),
-							toFloat(pm["completion_pct"]),
-							formatThroughput(pm["throughput_docs_per_sec"]),
-						)
-					}
-				}
-			}
+			fmt.Println("\n  All metrics are dual-written:")
+			fmt.Println("  • In-memory → /api/metrics (real-time dashboard)")
+			fmt.Println("  • App Insights (persistent, aggregated across replicas)")
 			return nil
 		},
 	}
+}
+
+func printLatency(label string, v any) {
+	if v == nil {
+		fmt.Printf("%s: —\n", label)
+		return
+	}
+	lat, ok := v.(map[string]any)
+	if !ok || toFloat(lat["count"]) == 0 {
+		fmt.Printf("%s: —\n", label)
+		return
+	}
+	fmt.Printf("%s: avg=%.0fms  p95=%.0fms  p99=%.0fms  (n=%.0f)\n",
+		label, toFloat(lat["avg"]), toFloat(lat["p95"]), toFloat(lat["p99"]), toFloat(lat["count"]))
 }
 
 func formatThroughput(v any) string {
@@ -147,7 +179,20 @@ func formatThroughput(v any) string {
 	if f == 0 {
 		return "—"
 	}
-	return fmt.Sprintf("%.1f/s", f)
+	return fmt.Sprintf("%.1f docs/sec", f)
 }
 
+func fmtInt(v any) string {
+	f := toFloat(v)
+	if f == 0 {
+		return "0"
+	}
+	if f >= 1000000 {
+		return fmt.Sprintf("%.1fM", f/1000000)
+	}
+	if f >= 1000 {
+		return fmt.Sprintf("%.1fK", f/1000)
+	}
+	return fmt.Sprintf("%.0f", f)
+}
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -36,6 +36,7 @@ func main() {
 		newModelCmd(),
 		newTransformCmd(),
 		newSearchCmd(),
+		newMetricsCmd(),
 		newStatusCmd(),
 		newSettingsCmd(),
 		newConfigCmd(),

--- a/connectors/ingestion/dotnet/Services/PostgresCdcWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/PostgresCdcWatcher.cs
@@ -29,7 +29,7 @@ public class PostgresCdcWatcher : ISourceWatcher
     private readonly object _pipelineLock = new();
     private List<Destination> _destinations = new();
 
-    private DateTime _lastCheckpoint = DateTime.MinValue;
+    private DateTime _lastCheckpoint = DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc);
 
     public string SourceId => _source.Id;
     public string Generation { get; }
@@ -117,7 +117,7 @@ public class PostgresCdcWatcher : ISourceWatcher
 
                 List<Dictionary<string, object?>> changes;
 
-                if (trackingColumn is not null && _lastCheckpoint > DateTime.MinValue)
+                if (trackingColumn is not null && _lastCheckpoint > DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc))
                 {
                     // Incremental: rows changed since last checkpoint
                     // Use >= with PK tiebreaker to handle rows with same timestamp
@@ -151,7 +151,7 @@ public class PostgresCdcWatcher : ISourceWatcher
                     {
                         var last = changes[^1];
                         if (last.TryGetValue(trackingColumn, out var tv) && tv is DateTime dt && dt >= _lastCheckpoint)
-                            _lastCheckpoint = dt;
+                            _lastCheckpoint = DateTime.SpecifyKind(dt, DateTimeKind.Utc);
                         _lastPkValue = last.TryGetValue(pk, out var pv) ? pv?.ToString() : null;
                     }
                 }
@@ -176,7 +176,7 @@ public class PostgresCdcWatcher : ISourceWatcher
                     {
                         var last = changes[^1];
                         if (last.TryGetValue(trackingColumn, out var tv) && tv is DateTime dt)
-                            _lastCheckpoint = dt;
+                            _lastCheckpoint = DateTime.SpecifyKind(dt, DateTimeKind.Utc);
                         else
                             _lastCheckpoint = DateTime.UtcNow;
                         _lastPkValue = last.TryGetValue(pk, out var pv) ? pv?.ToString() : null;
@@ -390,9 +390,15 @@ public class PostgresCdcWatcher : ISourceWatcher
             var table = _source.Table!;
             var now = DateTime.UtcNow.ToString("O");
 
-            // Ensure cfp_generation column exists
-            await using (var alterCmd = new NpgsqlCommand(
-                $@"ALTER TABLE ""{schema}"".""{table}"" ADD COLUMN IF NOT EXISTS cfp_generation TEXT DEFAULT ''", conn))
+            // Ensure metadata columns exist
+            var ddl = $@"
+                ALTER TABLE ""{schema}"".""{table}"" ADD COLUMN IF NOT EXISTS cfp_generation TEXT DEFAULT '';
+                ALTER TABLE ""{schema}"".""{table}"" ADD COLUMN IF NOT EXISTS pipeline_id TEXT DEFAULT '';
+                ALTER TABLE ""{schema}"".""{table}"" ADD COLUMN IF NOT EXISTS pipeline_name TEXT DEFAULT '';
+                ALTER TABLE ""{schema}"".""{table}"" ADD COLUMN IF NOT EXISTS content_hash TEXT DEFAULT '';
+                ALTER TABLE ""{schema}"".""{table}"" ADD COLUMN IF NOT EXISTS embedded_at TIMESTAMPTZ DEFAULT NOW();
+                ALTER TABLE ""{schema}"".""{table}"" ADD COLUMN IF NOT EXISTS embedding_dims INTEGER DEFAULT 0;";
+            await using (var alterCmd = new NpgsqlCommand(ddl, conn))
                 try { await alterCmd.ExecuteNonQueryAsync(ct); } catch { /* ignore if exists */ }
 
             for (int i = 0; i < docs.Count; i++)

--- a/connectors/worker/dotnet/Destinations/PostgresDestinationWriter.cs
+++ b/connectors/worker/dotnet/Destinations/PostgresDestinationWriter.cs
@@ -42,12 +42,18 @@ public class PostgresDestinationWriter : IDestinationWriter
         await using var conn = new NpgsqlConnection(connStr);
         await conn.OpenAsync(ct);
 
-        // Ensure pgvector extension and cfp_generation column exist
+        // Ensure pgvector extension and required metadata columns exist
         try
         {
             await using (var cmd = new NpgsqlCommand("CREATE EXTENSION IF NOT EXISTS vector", conn))
                 await cmd.ExecuteNonQueryAsync(ct);
-            await using (var cmd2 = new NpgsqlCommand($"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS cfp_generation TEXT DEFAULT ''", conn))
+            var ddl = $@"
+                ALTER TABLE {table} ADD COLUMN IF NOT EXISTS cfp_generation TEXT DEFAULT '';
+                ALTER TABLE {table} ADD COLUMN IF NOT EXISTS pipeline_id TEXT DEFAULT '';
+                ALTER TABLE {table} ADD COLUMN IF NOT EXISTS pipeline_name TEXT DEFAULT '';
+                ALTER TABLE {table} ADD COLUMN IF NOT EXISTS content_hash TEXT DEFAULT '';
+                ALTER TABLE {table} ADD COLUMN IF NOT EXISTS embedded_at TIMESTAMPTZ DEFAULT NOW();";
+            await using (var cmd2 = new NpgsqlCommand(ddl, conn))
                 await cmd2.ExecuteNonQueryAsync(ct);
         }
         catch { /* ignore permission errors — columns may already exist */ }

--- a/docs/metrics-plan.md
+++ b/docs/metrics-plan.md
@@ -1,0 +1,157 @@
+# OmniVec Metrics — Azure Monitor + Application Insights Plan
+
+## Goal
+
+Add Azure-native observability to OmniVec using Application Insights + Azure Monitor.
+All metrics should be viewable in the OmniVec web UI dashboard AND in Azure Portal.
+
+## What gets added
+
+### 1. Infrastructure (Bicep)
+
+Add to `infra/modules/`:
+- **Log Analytics Workspace** — stores all logs and metrics
+- **Application Insights** — connected to the workspace
+
+Output: `APPINSIGHTS_CONNECTION_STRING` passed to Helm
+
+Cost: ~$2-5/month for small deployments
+
+### 2. API (Python) — Application Insights SDK
+
+Add `opencensus-ext-azure` or `azure-monitor-opentelemetry` to `api/requirements.txt`.
+
+Auto-instrumented:
+- HTTP request latency (every API call)
+- HTTP error rates (4xx, 5xx)
+- Dependency tracking (CosmosDB, DocGrok HTTP calls)
+- Exception telemetry
+
+Custom metrics to emit:
+| Metric | When | What |
+|--------|------|------|
+| `omnivec.documents.embedded` | After successful embedding | Counter per pipeline |
+| `omnivec.embedding.latency_ms` | After each embedding call | Histogram |
+| `omnivec.pipeline.jobs_created` | When controller creates jobs | Counter per pipeline |
+| `omnivec.pipeline.jobs_failed` | When job fails | Counter per pipeline |
+| `omnivec.pipeline.completion_pct` | On stats refresh | Gauge per pipeline |
+| `omnivec.search.latency_ms` | After search query | Histogram |
+| `omnivec.search.results_count` | After search query | Histogram |
+| `omnivec.changefeed.events_processed` | Reported by .NET CFP | Counter |
+| `omnivec.changefeed.lag` | Reported by .NET CFP | Gauge |
+
+Implementation: ~50 lines in `api/api.py` + `api/telemetry.py`
+
+### 3. .NET Services (Optional, Phase 2)
+
+Add `Microsoft.ApplicationInsights.WorkerService` NuGet to:
+- `connectors/ingestion/dotnet/` (changefeed processor)
+- `connectors/worker/dotnet/` (embedding worker)
+
+This gives: embedding latency from the worker perspective, Service Bus message processing time, PostgreSQL connection health.
+
+For Phase 1, the .NET services report metrics via `/api/metrics/changefeed` which the Python API can forward to App Insights.
+
+### 4. Helm Charts
+
+Add to `helm/omnivec/values.yaml`:
+```yaml
+azure:
+  appInsights:
+    connectionString: ""
+```
+
+Pass as env var `APPLICATIONINSIGHTS_CONNECTION_STRING` to:
+- `omnivec-api` deployment
+- (Phase 2) `omnivec-changefeed` and `omnivec-worker` deployments
+
+### 5. Web UI — Metrics Dashboard
+
+The UI dashboard already reads from `/api/metrics` and `/api/metrics/timeseries`.
+These endpoints already return:
+- events_processed, events_failed
+- avg_processing_time_ms
+- daily breakdown
+- per-pipeline stats
+- timeseries data (throughput per bucket)
+
+**No UI changes needed for Phase 1** — the existing dashboard already works.
+The benefit of App Insights is backend observability + alerting, not UI changes.
+
+**Phase 2 UI addition:** Add an "Azure Monitor" link in the dashboard that opens
+the Application Insights overview in Azure Portal (deep link with resource ID).
+
+## Implementation Steps
+
+### Phase 1 (do now)
+
+1. Add Bicep module: `infra/modules/appinsights.bicep`
+   - Log Analytics Workspace (PerGB2018 pricing)
+   - Application Insights (connected to workspace)
+   - Output: connection string
+
+2. Wire in `infra/main.bicep`:
+   - Add module reference
+   - Pass connection string to postprovision as Bicep output
+
+3. Add Python SDK to `api/requirements.txt`:
+   - `azure-monitor-opentelemetry` (recommended over opencensus)
+
+4. Add `api/telemetry.py`:
+   - Initialize Azure Monitor exporter
+   - Custom metric functions
+   - Request middleware for auto-instrumentation
+
+5. Update `api/api.py`:
+   - Import and initialize telemetry on startup
+   - Emit custom metrics at key points
+
+6. Update Helm chart:
+   - Add `appInsights.connectionString` value
+   - Set env var on API deployment
+
+7. Update postprovision hooks:
+   - Pass App Insights connection string from Bicep output to Helm
+
+### Phase 2 (later)
+
+8. Add App Insights to .NET services
+9. Add Azure Monitor deep link to web UI
+10. Configure alerts (error rate, pipeline stall, pod crashes)
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `infra/modules/appinsights.bicep` | NEW — Log Analytics + App Insights |
+| `infra/main.bicep` | Add appinsights module, output connection string |
+| `infra/main.parameters.json` | No change (connection string from Bicep output) |
+| `api/requirements.txt` | Add `azure-monitor-opentelemetry` |
+| `api/telemetry.py` | NEW — telemetry init + custom metrics |
+| `api/api.py` | Import telemetry, emit metrics at key points |
+| `helm/omnivec/values.yaml` | Add `appInsights.connectionString` |
+| `helm/omnivec/templates/api-deployment.yaml` | Add env var |
+| `hooks/postprovision.ps1` | Pass connection string to Helm |
+| `hooks/postprovision.sh` | Pass connection string to Helm |
+
+## What the user sees
+
+After `azd up`:
+- Application Insights resource appears in their resource group
+- API requests are automatically tracked
+- Custom metrics (embedding throughput, pipeline health) flow to Azure Monitor
+- They can open Azure Portal → Application Insights → Live Metrics for real-time view
+- Alerts can be configured for error spikes, pipeline stalls
+
+In the OmniVec UI:
+- Dashboard continues to work as before (reads from API)
+- (Phase 2) "View in Azure Monitor" link on dashboard
+
+## Cost
+
+| Resource | Monthly cost |
+|----------|-------------|
+| Log Analytics Workspace | ~$2/GB (first 5GB/month free) |
+| Application Insights | Uses Log Analytics pricing |
+| Data ingestion estimate | ~1-3 GB/month for small deployment |
+| **Total** | **~$2-5/month** |

--- a/helm/omnivec/templates/api-deployment.yaml
+++ b/helm/omnivec/templates/api-deployment.yaml
@@ -50,6 +50,10 @@ spec:
             - name: KEY_VAULT_URI
               value: {{ .Values.azure.keyVault.uri | quote }}
             {{- end }}
+            {{- if .Values.azure.appInsights.connectionString }}
+            - name: APPLICATIONINSIGHTS_CONNECTION_STRING
+              value: {{ .Values.azure.appInsights.connectionString | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
           livenessProbe:

--- a/helm/omnivec/templates/api-deployment.yaml
+++ b/helm/omnivec/templates/api-deployment.yaml
@@ -53,6 +53,10 @@ spec:
             {{- if .Values.azure.appInsights.connectionString }}
             - name: APPLICATIONINSIGHTS_CONNECTION_STRING
               value: {{ .Values.azure.appInsights.connectionString | quote }}
+            {{- if .Values.azure.appInsights.workspaceId }}
+            - name: LOG_ANALYTICS_WORKSPACE_ID
+              value: {{ .Values.azure.appInsights.workspaceId | quote }}
+            {{- end }}
             {{- end }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}

--- a/helm/omnivec/values.yaml
+++ b/helm/omnivec/values.yaml
@@ -232,6 +232,7 @@ azure:
   # Application Insights
   appInsights:
     connectionString: ""
+    workspaceId: ""
 
 # =============================================================================
 # DOCGROK (Submodule)

--- a/helm/omnivec/values.yaml
+++ b/helm/omnivec/values.yaml
@@ -227,7 +227,11 @@ azure:
 
   # Key Vault
   keyVault:
-    uri: "" # Set from Terraform output
+    uri: ""
+
+  # Application Insights
+  appInsights:
+    connectionString: ""
 
 # =============================================================================
 # DOCGROK (Submodule)

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -62,6 +62,7 @@ $STORAGE_BLOB_ENDPOINT = Get-AzdValue "AZURE_STORAGE_BLOB_ENDPOINT"
 $STORAGE_QUEUE_ENDPOINT = Get-AzdValue "AZURE_STORAGE_QUEUE_ENDPOINT"
 $SB_ENDPOINT = Get-AzdValue "AZURE_SERVICEBUS_ENDPOINT"
 $KEYVAULT_URI = Get-AzdValue "AZURE_KEYVAULT_URI"
+$APPINSIGHTS_CS = Get-AzdValue "AZURE_APPINSIGHTS_CONNECTION_STRING"
 
 # Validate required vars
 foreach ($var in @("INSTANCE_ID","AKS_CLUSTER","ACR_LOGIN_SERVER","ACR_NAME","COSMOS_ENDPOINT","IDENTITY_CLIENT_ID","RESOURCE_GROUP")) {
@@ -478,6 +479,12 @@ $helmArgs = @(
 if ($KEYVAULT_URI) {
     $helmArgs += @(
         "--set", "azure.keyVault.uri=$KEYVAULT_URI"
+    )
+}
+
+if ($APPINSIGHTS_CS) {
+    $helmArgs += @(
+        "--set", "azure.appInsights.connectionString=$APPINSIGHTS_CS"
     )
 }
 

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -88,6 +88,7 @@ STORAGE_QUEUE_ENDPOINT=$(get_azd_value "AZURE_STORAGE_QUEUE_ENDPOINT")
 SB_ENDPOINT=$(get_azd_value "AZURE_SERVICEBUS_ENDPOINT")
 KEYVAULT_URI=$(get_azd_value "AZURE_KEYVAULT_URI")
 APPINSIGHTS_CS=$(get_azd_value "AZURE_APPINSIGHTS_CONNECTION_STRING")
+LOG_ANALYTICS_WS=$(get_azd_value "AZURE_LOG_ANALYTICS_WORKSPACE_ID")
 
 # Validate required vars
 for var in INSTANCE_ID AKS_CLUSTER ACR_LOGIN_SERVER ACR_NAME COSMOS_ENDPOINT IDENTITY_CLIENT_ID RESOURCE_GROUP; do
@@ -570,6 +571,9 @@ run_helm_deploy() {
 
   if [ -n "$APPINSIGHTS_CS" ]; then
     set -- "$@" --set "azure.appInsights.connectionString=${APPINSIGHTS_CS}"
+  fi
+  if [ -n "$LOG_ANALYTICS_WS" ]; then
+    set -- "$@" --set "azure.appInsights.workspaceId=${LOG_ANALYTICS_WS}"
   fi
 
   if [ -n "$SB_ENDPOINT" ]; then

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -87,6 +87,7 @@ STORAGE_BLOB_ENDPOINT=$(get_azd_value "AZURE_STORAGE_BLOB_ENDPOINT")
 STORAGE_QUEUE_ENDPOINT=$(get_azd_value "AZURE_STORAGE_QUEUE_ENDPOINT")
 SB_ENDPOINT=$(get_azd_value "AZURE_SERVICEBUS_ENDPOINT")
 KEYVAULT_URI=$(get_azd_value "AZURE_KEYVAULT_URI")
+APPINSIGHTS_CS=$(get_azd_value "AZURE_APPINSIGHTS_CONNECTION_STRING")
 
 # Validate required vars
 for var in INSTANCE_ID AKS_CLUSTER ACR_LOGIN_SERVER ACR_NAME COSMOS_ENDPOINT IDENTITY_CLIENT_ID RESOURCE_GROUP; do
@@ -565,6 +566,10 @@ run_helm_deploy() {
 
   if [ -n "$KEYVAULT_URI" ]; then
     set -- "$@" --set "azure.keyVault.uri=${KEYVAULT_URI}"
+  fi
+
+  if [ -n "$APPINSIGHTS_CS" ]; then
+    set -- "$@" --set "azure.appInsights.connectionString=${APPINSIGHTS_CS}"
   fi
 
   if [ -n "$SB_ENDPOINT" ]; then

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -20,19 +20,17 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 read_input() {
   prompt="$1"
   _ri_val=""
-  if [ -t 0 ]; then
-    printf "%s" "$prompt"
-    read -r _ri_val || true
-  elif [ -w /dev/tty ] 2>/dev/null && printf "" > /dev/tty 2>/dev/null; then
+  # Always prefer /dev/tty — azd hooks have stdin piped from azd, so stdin
+  # may be consumed by child processes (az cli, etc.) causing hangs.
+  if [ -e /dev/tty ]; then
     printf "%s" "$prompt" > /dev/tty
     read -r _ri_val < /dev/tty || true
+  elif [ -t 0 ]; then
+    printf "%s" "$prompt"
+    read -r _ri_val || true
   else
-    # No TTY available — try reading from stdin directly
-    if read -r _ri_val 2>/dev/null; then
-      : # got input from redirected stdin
-    else
-      _ri_val=""
-    fi
+    # No TTY at all — return empty (caller uses default)
+    _ri_val=""
   fi
   echo "$_ri_val"
 }
@@ -58,7 +56,7 @@ get_azd_value() {
   val=$(printf '%s' "$val" | tr -d '\r')
   if [ -n "$val" ]; then echo "$val"; return 0; fi
   # Fallback: read from azd env store (use && to suppress stdout errors)
-  val=$(azd env get-value "$key" 2>/dev/null) && val=$(printf '%s' "$val" | tr -d '\r') || val=""
+  val=$(azd env get-value "$key" < /dev/null 2>/dev/null) && val=$(printf '%s' "$val" | tr -d '\r') || val=""
   if [ -n "$val" ]; then echo "$val"; return 0; fi
   echo ""
 }
@@ -126,7 +124,7 @@ GPU_CNT=$(get_azd_value "OMNIVEC_GPU_NODE_COUNT")
 META=$(get_azd_value "OMNIVEC_METADATA_STORE")
 BLOB=$(get_azd_value "OMNIVEC_ENABLE_BLOB_SOURCE")
 BUILD=$(get_azd_value "OMNIVEC_BUILD_MODE")
-_RG_ID=$(az group show --name "$RESOURCE_GROUP" --query "id" -o tsv 2>/dev/null)
+_RG_ID=$(az group show --name "$RESOURCE_GROUP" --query "id" -o tsv < /dev/null 2>/dev/null)
 az tag update --resource-id "$_RG_ID" --operation merge --tags \
     "omnivec-sys-sku=$SYS_VM" \
     "omnivec-sys-count=$SYS_CNT" \

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -60,22 +60,24 @@ acquire_lock
 
 # Helper: safely read an azd env value, returns empty string on failure
 azd_get() {
-  _val=$(azd env get-value "$1" 2>/dev/null) && printf '%s' "$_val" | tr -d '\r' || printf ''
+  _val=$(azd env get-value "$1" < /dev/null 2>/dev/null) && printf '%s' "$_val" | tr -d '\r' || printf ''
 }
 
 # Helper: read user input from TTY (works in hook context where stdin may be redirected)
 read_input() {
   _prompt=$1
   _input=""
-  if [ -t 0 ]; then
-    printf '%b' "$_prompt"
-    read -r _input || true
-  elif [ -w /dev/tty ] 2>/dev/null && printf "" > /dev/tty 2>/dev/null; then
+  # Always prefer /dev/tty — azd hooks have stdin piped from azd, so stdin
+  # may be consumed by child processes (az cli, etc.) causing hangs.
+  if [ -e /dev/tty ]; then
     printf '%b' "$_prompt" > /dev/tty
     read -r _input < /dev/tty || true
+  elif [ -t 0 ]; then
+    printf '%b' "$_prompt"
+    read -r _input || true
   else
-    # No TTY — try reading from stdin directly
-    read -r _input 2>/dev/null || _input=""
+    # No TTY at all — return empty (caller uses default)
+    _input=""
   fi
   printf '%s' "$_input"
 }
@@ -99,7 +101,7 @@ KUBECTL_DIR="${HOME}/.azure-kubectl"
 if ! command -v kubectl >/dev/null 2>&1; then
   printf "  ${YELLOW}kubectl not found — installing to ${KUBECTL_DIR}...${NC}\n"
   mkdir -p "$KUBECTL_DIR"
-  az aks install-cli --install-location "$KUBECTL_DIR/kubectl" --kubelogin-install-location "$KUBECTL_DIR/kubelogin" 2>/dev/null || true
+  az aks install-cli --install-location "$KUBECTL_DIR/kubectl" --kubelogin-install-location "$KUBECTL_DIR/kubelogin" < /dev/null 2>/dev/null || true
   chmod +x "$KUBECTL_DIR/kubectl" "$KUBECTL_DIR/kubelogin" 2>/dev/null || true
   export PATH="$KUBECTL_DIR:$PATH"
   if ! command -v kubectl >/dev/null 2>&1; then
@@ -139,18 +141,18 @@ fi
 # ── Validate Azure login ────────────────────────────────────────────────────
 
 printf "\n${YELLOW}Checking Azure login...${NC}\n"
-if ! az account show >/dev/null 2>&1; then
+if ! az account show < /dev/null >/dev/null 2>&1; then
   printf "${RED}Not logged into Azure. Run 'az login' first.${NC}\n"
   exit 1
 fi
 
-SUBSCRIPTION=$(az account show --query name -o tsv)
-SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+SUBSCRIPTION=$(az account show --query name -o tsv < /dev/null)
+SUBSCRIPTION_ID=$(az account show --query id -o tsv < /dev/null)
 printf "${GREEN}Logged in to subscription: ${SUBSCRIPTION} (${SUBSCRIPTION_ID})${NC}\n"
 
 # ── Check for existing deployment (RG exists + config present = update in-place) ─
 RG_NAME="rg-omnivec-${AZURE_ENV_NAME}"
-RG_EXISTS=$(az group exists --name "$RG_NAME" 2>/dev/null || echo "false")
+RG_EXISTS=$(az group exists --name "$RG_NAME" < /dev/null 2>/dev/null || echo "false")
 RG_EXISTS=$(printf '%s' "$RG_EXISTS" | tr -d '\r\n ')
 
 if [ "$RG_EXISTS" = "true" ]; then
@@ -165,10 +167,10 @@ if [ "$RG_EXISTS" = "true" ]; then
     "omnivec-build:OMNIVEC_BUILD_MODE"; do
     _tag=$(echo "$_pair" | cut -d: -f1)
     _env=$(echo "$_pair" | cut -d: -f2)
-    _val=$(az group show --name "$RG_NAME" --query "tags.\"$_tag\"" -o tsv 2>/dev/null || true)
+    _val=$(az group show --name "$RG_NAME" --query "tags.\"$_tag\"" -o tsv < /dev/null 2>/dev/null || true)
     _val=$(printf '%s' "$_val" | tr -d '\r\n')
     if [ -n "$_val" ]; then
-      azd env set "$_env" "$_val" 2>/dev/null
+      azd env set "$_env" "$_val" < /dev/null 2>/dev/null
       printf "  ${_env} = ${_val}\n"
     fi
   done
@@ -195,12 +197,12 @@ setup_mode=${setup_mode:-1}
 
 if [ "$setup_mode" = "1" ]; then
   printf "\n${GREEN}Applying recommended defaults:${NC}\n"
-  azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE "Standard_B4ms"
-  azd env set OMNIVEC_SYSTEM_NODE_COUNT   "2"
-  azd env set OMNIVEC_GPU_NODE_VM_SIZE    ""
-  azd env set OMNIVEC_GPU_NODE_COUNT      "0"
-  azd env set OMNIVEC_METADATA_STORE      "cosmosdb-serverless"
-  azd env set OMNIVEC_ENABLE_BLOB_SOURCE  "true"
+  azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE "Standard_B4ms" < /dev/null
+  azd env set OMNIVEC_SYSTEM_NODE_COUNT   "2" < /dev/null
+  azd env set OMNIVEC_GPU_NODE_VM_SIZE    "" < /dev/null
+  azd env set OMNIVEC_GPU_NODE_COUNT      "0" < /dev/null
+  azd env set OMNIVEC_METADATA_STORE      "cosmosdb-serverless" < /dev/null
+  azd env set OMNIVEC_ENABLE_BLOB_SOURCE  "true" < /dev/null
   echo "  OMNIVEC_SYSTEM_NODE_VM_SIZE = Standard_B4ms"
   echo "  OMNIVEC_SYSTEM_NODE_COUNT   = 2"
   echo "  OMNIVEC_GPU_NODE_VM_SIZE    = (none)"
@@ -232,11 +234,11 @@ else
   case "$meta_choice" in
     2)
       printf "${GREEN}Using CosmosDB Provisioned for metadata storage.${NC}\n"
-      azd env set OMNIVEC_METADATA_STORE "cosmosdb-provisioned"
+      azd env set OMNIVEC_METADATA_STORE "cosmosdb-provisioned" < /dev/null
       ;;
     *)
       printf "${GREEN}Using CosmosDB Serverless for metadata storage.${NC}\n"
-      azd env set OMNIVEC_METADATA_STORE "cosmosdb-serverless"
+      azd env set OMNIVEC_METADATA_STORE "cosmosdb-serverless" < /dev/null
       ;;
   esac
 fi
@@ -260,11 +262,11 @@ else
   case "$blob_choice" in
     1)
       printf "${GREEN}Blob source enabled.${NC}\n"
-      azd env set OMNIVEC_ENABLE_BLOB_SOURCE "true"
+      azd env set OMNIVEC_ENABLE_BLOB_SOURCE "true" < /dev/null
       ;;
     *)
       printf "${GREEN}Blob source disabled.${NC}\n"
-      azd env set OMNIVEC_ENABLE_BLOB_SOURCE "false"
+      azd env set OMNIVEC_ENABLE_BLOB_SOURCE "false" < /dev/null
       ;;
   esac
 fi
@@ -281,7 +283,7 @@ LOCATION="${AZURE_LOCATION:-centralus}"
 validate_sku() {
   _sku=$1
   _result=$(az vm list-skus --location "$LOCATION" --size "$_sku" --resource-type virtualMachines \
-    --query "[?name=='$_sku' && (restrictions==null || restrictions[0]==null)].name" -o tsv 2>/dev/null || true)
+    --query "[?name=='$_sku' && (restrictions==null || restrictions[0]==null)].name" -o tsv < /dev/null 2>/dev/null || true)
   _result=$(printf '%s' "$_result" | tr -d '\r\n ')
   [ -n "$_result" ] && [ "$_result" = "$_sku" ]
 }
@@ -404,10 +406,10 @@ if [ -z "$SYS_SKU" ]; then
 fi
 
 # Store in azd env for Bicep parameter substitution
-azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE "$SYS_SKU"
-azd env set OMNIVEC_SYSTEM_NODE_COUNT "$sys_count"
-azd env set OMNIVEC_GPU_NODE_VM_SIZE "$GPU_SKU"
-azd env set OMNIVEC_GPU_NODE_COUNT "$gpu_count"
+azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE "$SYS_SKU" < /dev/null
+azd env set OMNIVEC_SYSTEM_NODE_COUNT "$sys_count" < /dev/null
+azd env set OMNIVEC_GPU_NODE_VM_SIZE "$GPU_SKU" < /dev/null
+azd env set OMNIVEC_GPU_NODE_COUNT "$gpu_count" < /dev/null
 
 # ── Sanitize env values: strip BOM, tabs, carriage returns ──────────────────
 printf "\n${CYAN}Sanitizing environment values...${NC}\n"
@@ -416,7 +418,7 @@ for key in OMNIVEC_SYSTEM_NODE_VM_SIZE OMNIVEC_SYSTEM_NODE_COUNT OMNIVEC_GPU_NOD
   if [ -n "$raw" ]; then
     clean=$(printf '%s' "$raw" | tr -d '\r\t' | sed 's/^\xEF\xBB\xBF//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
     if [ "$raw" != "$clean" ]; then
-      azd env set "$key" "$clean"
+      azd env set "$key" "$clean" < /dev/null
       printf "  ${YELLOW}Cleaned ${key}: removed hidden characters${NC}\n"
     fi
   fi

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -355,9 +355,7 @@ if [ -n "$cur_gpu_count" ]; then
 else
   printf "${CYAN}GPU node pool (ML models — dse-qwen2, clip, bge, bge-small):${NC}\n"
   echo "  Enter 0 nodes to skip GPU pool (use external models only)."
-  printf "  GPU node count (0 = no GPU pool) [0]: " >/dev/tty 2>/dev/null || printf "  GPU node count (0 = no GPU pool) [0]: " >&2
-  gpu_count=""
-  if [ -t 0 ]; then read -r gpu_count || true; elif [ -e /dev/tty ]; then read -r gpu_count </dev/tty || true; fi
+  gpu_count=$(read_input "  GPU node count (0 = no GPU pool) [0]: ")
   gpu_count=$(printf '%s' "${gpu_count:-0}" | tr -d ' \r\n')
 
   if [ "$gpu_count" != "0" ]; then
@@ -369,9 +367,7 @@ else
     printf "    5) Standard_NC24ads_A100_v4 - 24 vCPU, 220 GB, 1x A100 80GB\n"
     printf "    6) Enter custom SKU\n"
     echo ""
-    printf "  GPU VM SKU [1]: " >/dev/tty 2>/dev/null || printf "  GPU VM SKU [1]: " >&2
-    gpu_pick=""
-    if [ -t 0 ]; then read -r gpu_pick || true; elif [ -e /dev/tty ]; then read -r gpu_pick </dev/tty || true; fi
+    gpu_pick=$(read_input "  GPU VM SKU [1]: ")
     gpu_pick=$(printf '%s' "${gpu_pick:-1}" | tr -d ' \r\n')
 
     case "$gpu_pick" in
@@ -382,9 +378,7 @@ else
       5) GPU_SKU="Standard_NC24ads_A100_v4" ;;
       6)
         def_gpu_manual=${cur_gpu_sku:-Standard_NC4as_T4_v3}
-        printf "  Enter SKU name [${def_gpu_manual}]: " >/dev/tty 2>/dev/null || printf "  Enter SKU name [${def_gpu_manual}]: " >&2
-        custom_gpu=""
-        if [ -t 0 ]; then read -r custom_gpu || true; elif [ -e /dev/tty ]; then read -r custom_gpu </dev/tty || true; fi
+        custom_gpu=$(read_input "  Enter SKU name [${def_gpu_manual}]: ")
         GPU_SKU=$(printf '%s' "${custom_gpu:-$def_gpu_manual}" | tr -d ' \r\n')
         ;;
       *) GPU_SKU="Standard_NC4as_T4_v3" ;;

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -135,7 +135,19 @@ module eventgrid 'modules/eventgrid.bicep' = if (enableBlobSource) {
   }
 }
 
-// 6. ACR (no dependencies)
+// 6. Application Insights (telemetry)
+module appinsights 'modules/appinsights.bicep' = {
+  name: 'appinsights'
+  scope: rg
+  params: {
+    workspaceName: '${prefix}-logs-${resourceToken}'
+    appInsightsName: '${prefix}-insights-${resourceToken}'
+    location: location
+    tags: tags
+  }
+}
+
+// 7. ACR (no dependencies)
 module acr 'modules/acr.bicep' = {
   name: 'acr'
   scope: rg
@@ -209,4 +221,5 @@ output AZURE_SERVICEBUS_NAMESPACE string = enableBlobSource ? servicebus!.output
 output AZURE_SERVICEBUS_ENDPOINT string = enableBlobSource ? servicebus!.outputs.endpoint : ''
 output AZURE_IDENTITY_CLIENT_ID string = identity.outputs.clientId
 output AZURE_KEYVAULT_URI string = keyvault.outputs.vaultUri
+output AZURE_APPINSIGHTS_CONNECTION_STRING string = appinsights.outputs.connectionString
 output AZURE_RESOURCE_GROUP string = rg.name

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -222,4 +222,5 @@ output AZURE_SERVICEBUS_ENDPOINT string = enableBlobSource ? servicebus!.outputs
 output AZURE_IDENTITY_CLIENT_ID string = identity.outputs.clientId
 output AZURE_KEYVAULT_URI string = keyvault.outputs.vaultUri
 output AZURE_APPINSIGHTS_CONNECTION_STRING string = appinsights.outputs.connectionString
+output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = appinsights.outputs.workspaceId
 output AZURE_RESOURCE_GROUP string = rg.name

--- a/infra/modules/appinsights.bicep
+++ b/infra/modules/appinsights.bicep
@@ -32,4 +32,4 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
 
 output connectionString string = appInsights.properties.ConnectionString
 output instrumentationKey string = appInsights.properties.InstrumentationKey
-output workspaceId string = workspace.id
+output workspaceId string = workspace.properties.customerId

--- a/infra/modules/appinsights.bicep
+++ b/infra/modules/appinsights.bicep
@@ -1,0 +1,35 @@
+// Application Insights + Log Analytics Workspace for OmniVec telemetry
+param workspaceName string
+param appInsightsName string
+param location string
+param tags object = {}
+
+resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: workspaceName
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  tags: tags
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: workspace.id
+    IngestionMode: 'LogAnalytics'
+    publicNetworkAccessForIngestion: 'Enabled'
+    publicNetworkAccessForQuery: 'Enabled'
+  }
+}
+
+output connectionString string = appInsights.properties.ConnectionString
+output instrumentationKey string = appInsights.properties.InstrumentationKey
+output workspaceId string = workspace.id

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -12,7 +12,7 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data:;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; img-src 'self' data:;" always;
 
     # Serve the UI at /ui
     location = /ui {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -6729,17 +6729,38 @@
                         <div id="model-health-result-${modelId}" style="margin-top: 12px;"></div>
                     </div>`;
 
-                // Update API Key section (only for external models with key auth)
-                if (isExternal && extModel && extModel.auth_type !== 'managed-identity') {
+                // Authentication section (for external models)
+                if (isExternal && extModel) {
+                    const curAuth = extModel.auth_type || 'key';
                     html += `
-                        <h4 style="margin: 0 0 16px 0; font-size: 16px;">Update API Key</h4>
+                        <h4 style="margin: 0 0 16px 0; font-size: 16px;">Authentication</h4>
                         <div style="background: var(--bg-tertiary); border-radius: var(--radius-md); padding: 16px;">
-                            <p style="font-size: 13px; color: var(--text-tertiary); margin: 0 0 12px 0;">If authentication is failing, update the API key and test again.</p>
-                            <div style="display: flex; gap: 8px; align-items: center;">
-                                <input type="password" class="form-input" id="model-update-key-${extModel.id}" placeholder="Enter new API key" style="flex: 1;">
-                                <button class="btn btn-primary" onclick="updateModelKey('${extModel.id}')">Update Key</button>
+                            <div style="display: flex; gap: 12px; margin-bottom: 16px;">
+                                <label style="display: flex; align-items: center; gap: 6px; cursor: pointer; padding: 8px 16px; border-radius: 8px; border: 2px solid ${curAuth === 'key' ? 'var(--accent-primary)' : 'var(--border)'}; background: ${curAuth === 'key' ? 'rgba(99,102,241,0.1)' : 'transparent'};">
+                                    <input type="radio" name="model-auth-type-${extModel.id}" value="key" ${curAuth === 'key' ? 'checked' : ''} onchange="toggleModelAuthFields('${extModel.id}', 'key')">
+                                    <span style="font-weight: 500;">API Key</span>
+                                </label>
+                                <label style="display: flex; align-items: center; gap: 6px; cursor: pointer; padding: 8px 16px; border-radius: 8px; border: 2px solid ${curAuth === 'managed-identity' ? 'var(--accent-primary)' : 'var(--border)'}; background: ${curAuth === 'managed-identity' ? 'rgba(34,197,94,0.1)' : 'transparent'};">
+                                    <input type="radio" name="model-auth-type-${extModel.id}" value="managed-identity" ${curAuth === 'managed-identity' ? 'checked' : ''} onchange="toggleModelAuthFields('${extModel.id}', 'managed-identity')">
+                                    <span style="font-weight: 500;">Managed Identity</span>
+                                </label>
                             </div>
-                            <div id="model-update-key-status-${extModel.id}" style="margin-top: 8px; font-size: 13px;"></div>
+                            <div id="model-auth-key-section-${extModel.id}" style="display: ${curAuth === 'key' ? 'block' : 'none'};">
+                                <p style="font-size: 13px; color: var(--text-tertiary); margin: 0 0 12px 0;">Update the API key for this model.</p>
+                                <div style="display: flex; gap: 8px; align-items: center;">
+                                    <input type="password" class="form-input" id="model-update-key-${extModel.id}" placeholder="Enter new API key" style="flex: 1;">
+                                    <button class="btn btn-primary" onclick="updateModelKey('${extModel.id}')">Update Key</button>
+                                </div>
+                                <div id="model-update-key-status-${extModel.id}" style="margin-top: 8px; font-size: 13px;"></div>
+                            </div>
+                            <div id="model-auth-mi-section-${extModel.id}" style="display: ${curAuth === 'managed-identity' ? 'block' : 'none'};">
+                                <p style="font-size: 13px; color: var(--text-tertiary); margin: 0 0 12px 0;">Uses Azure Workload Identity. Optionally specify a client ID.</p>
+                                <div style="display: flex; gap: 8px; align-items: center;">
+                                    <input type="text" class="form-input" id="model-update-clientid-${extModel.id}" placeholder="Client ID (optional — uses workload identity if empty)" value="${extModel.client_id || ''}" style="flex: 1;">
+                                    <button class="btn btn-primary" onclick="updateModelAuth('${extModel.id}', 'managed-identity')">Save</button>
+                                </div>
+                                <div id="model-update-mi-status-${extModel.id}" style="margin-top: 8px; font-size: 13px;"></div>
+                            </div>
                         </div>`;
                 }
 
@@ -6825,6 +6846,44 @@
             }
         }
 
+        function toggleModelAuthFields(modelId, authType) {
+            const keySection = document.getElementById(`model-auth-key-section-${modelId}`);
+            const miSection = document.getElementById(`model-auth-mi-section-${modelId}`);
+            if (keySection) keySection.style.display = authType === 'key' ? 'block' : 'none';
+            if (miSection) miSection.style.display = authType === 'managed-identity' ? 'block' : 'none';
+            // Update radio button styling
+            document.querySelectorAll(`input[name="model-auth-type-${modelId}"]`).forEach(r => {
+                const label = r.closest('label');
+                if (label) {
+                    const active = r.value === authType;
+                    label.style.borderColor = active ? 'var(--accent-primary)' : 'var(--border)';
+                    label.style.background = active ? (authType === 'key' ? 'rgba(99,102,241,0.1)' : 'rgba(34,197,94,0.1)') : 'transparent';
+                }
+            });
+        }
+
+        async function updateModelAuth(modelId, authType) {
+            const statusEl = document.getElementById(`model-update-mi-status-${modelId}`);
+            statusEl.innerHTML = '<span style="color:var(--text-tertiary);">Updating...</span>';
+            const clientId = document.getElementById(`model-update-clientid-${modelId}`)?.value?.trim() || '';
+            try {
+                const resp = await apiFetch(`/api/models/${encodeURIComponent(modelId)}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ auth_type: authType, client_id: clientId }),
+                });
+                if (resp.ok) {
+                    statusEl.innerHTML = '<span style="color:var(--success);">✓ Switched to managed identity. Run Test Connection to verify.</span>';
+                    loadDgModels();
+                } else {
+                    const err = await resp.json().catch(() => ({}));
+                    statusEl.innerHTML = `<span style="color:var(--error);">Failed: ${err.detail || resp.statusText}</span>`;
+                }
+            } catch (e) {
+                statusEl.innerHTML = `<span style="color:var(--error);">Error: ${e.message}</span>`;
+            }
+        }
+
         async function updateModelKey(modelId) {
             const input = document.getElementById(`model-update-key-${modelId}`);
             const status = document.getElementById(`model-update-key-status-${modelId}`);
@@ -6835,7 +6894,7 @@
                 const resp = await apiFetch(`/api/models/${encodeURIComponent(modelId)}`, {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ api_key: key }),
+                    body: JSON.stringify({ api_key: key, auth_type: 'key' }),
                 });
                 if (resp.ok) {
                     status.innerHTML = '<span style="color:var(--success);">✓ API key updated. Run Test Connection to verify.</span>';

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -982,8 +982,8 @@
                             <div class="stat-value" id="stat-throughput" style="color: var(--accent-primary);">--</div>
                             <div class="stat-trend" id="stat-throughput-label">docs/sec</div>
                         </div>
-                        <div class="stat-card" id="stat-insights-card" style="display:none;">
-                            <div class="stat-label">Telemetry</div>
+                        <div class="stat-card" id="stat-insights-card">
+                            <div class="stat-label">Avg Latency</div>
                             <div class="stat-value" id="stat-insights-status" style="font-size:1rem;">—</div>
                             <div class="stat-trend" id="stat-insights-link"></div>
                         </div>
@@ -2577,36 +2577,55 @@
                 document.getElementById('destinations-count').textContent = destinations.length;
                 document.getElementById('pipelines-count').textContent = pipelines.length;
 
-                // Update stats
+                // Update stats from in-memory metrics (no CosmosDB reads)
                 const metrics = metricsRes.ok ? await metricsRes.json() : {};
                 document.getElementById('stat-sources').textContent = sources.length;
                 document.getElementById('stat-destinations').textContent = destinations.length;
                 document.getElementById('stat-pipelines').textContent = pipelines.length;
-                // Aggregate embedded/total across active pipelines
-                let totalSourceDocs = 0, totalEmbedded = 0;
+
+                // Embedded count — prefer live metrics, fallback to pipeline stats
+                const liveEmbedded = metrics.events_processed || 0;
+                let totalSourceDocs = 0;
                 let hasSourceData = false;
                 pipelines.filter(p => p.status === 'active').forEach(p => {
                     if (p.stats?.source_doc_count != null) {
                         totalSourceDocs += p.stats.source_doc_count;
                         hasSourceData = true;
                     }
-                    totalEmbedded += p.stats?.embedded_count || 0;
                 });
-                const overallPct = hasSourceData && totalSourceDocs > 0 ? (totalEmbedded / totalSourceDocs * 100).toFixed(1) : null;
-                document.getElementById('stat-events').textContent = hasSourceData ? totalEmbedded.toLocaleString() + ' / ' + totalSourceDocs.toLocaleString() : '--';
+                const overallPct = hasSourceData && totalSourceDocs > 0 ? (liveEmbedded / totalSourceDocs * 100).toFixed(1) : null;
+                document.getElementById('stat-events').textContent = liveEmbedded > 0
+                    ? liveEmbedded.toLocaleString() + (hasSourceData ? ' / ' + totalSourceDocs.toLocaleString() : '')
+                    : '--';
                 document.getElementById('stat-events-today').textContent = overallPct != null ? overallPct + '% complete' : '';
-                document.getElementById('stat-failed').textContent = (metrics.events_failed || 0).toLocaleString();
-                document.getElementById('stat-failed-today').textContent = 'Today: ' + (metrics.today?.failed || 0);
 
-                // Aggregate throughput across active pipelines
-                let totalThroughput = 0;
-                let hasThroughput = false;
-                pipelines.filter(p => p.status === 'active').forEach(p => {
-                    const tp = p.stats?.throughput_docs_per_sec || p.stats?.recent_throughput_docs_per_sec;
-                    if (tp) { totalThroughput += tp; hasThroughput = true; }
-                });
-                document.getElementById('stat-throughput').textContent = hasThroughput ? totalThroughput.toFixed(1) : '--';
-                document.getElementById('stat-throughput-label').textContent = hasThroughput ? 'docs/sec (active pipelines)' : 'docs/sec';
+                // Failed — from live metrics
+                const totalFailed = metrics.events_failed || 0;
+                document.getElementById('stat-failed').textContent = totalFailed.toLocaleString();
+                const skipTotal = metrics.skipped?.total || 0;
+                document.getElementById('stat-failed-today').textContent = skipTotal > 0
+                    ? skipTotal.toLocaleString() + ' skipped'
+                    : '';
+
+                // Throughput — from live metrics (rolling 60s window)
+                const liveThroughput = metrics.throughput_docs_per_sec || 0;
+                document.getElementById('stat-throughput').textContent = liveThroughput > 0 ? liveThroughput.toFixed(1) : '--';
+                document.getElementById('stat-throughput-label').textContent = liveThroughput > 0 ? 'docs/sec (live)' : 'docs/sec';
+
+                // Latency card — show avg embedding latency
+                const avgLatency = metrics.latency?.embedding?.avg;
+                const latencyCard = document.getElementById('stat-insights-card');
+                if (latencyCard) {
+                    latencyCard.style.display = '';
+                    const p95 = metrics.latency?.embedding?.p95;
+                    document.getElementById('stat-insights-status').innerHTML = avgLatency != null
+                        ? '<span style="color:var(--accent-primary);">' + avgLatency + 'ms</span>'
+                        : '<span>—</span>';
+                    document.getElementById('stat-insights-link').innerHTML = p95 != null
+                        ? 'p95: ' + p95 + 'ms'
+                        + (metrics.tokens?.total ? ' · ' + metrics.tokens.total.toLocaleString() + ' tokens' : '')
+                        : (metrics.tokens?.total ? metrics.tokens.total.toLocaleString() + ' tokens' : 'No data yet');
+                }
 
                 // Render tables
                 renderSources();
@@ -2628,26 +2647,6 @@
                             navBadge.style.color = '#fff';
                         } else {
                             navBadge.style.display = 'none';
-                        }
-                    }
-                } catch (e) {}
-
-                // Fetch App Insights telemetry status
-                try {
-                    const insRes = await apiFetch('/api/metrics/insights');
-                    if (insRes.ok) {
-                        const ins = await insRes.json();
-                        const card = document.getElementById('stat-insights-card');
-                        if (ins.enabled) {
-                            card.style.display = '';
-                            document.getElementById('stat-insights-status').innerHTML =
-                                '<span style="color:var(--success);">● Active</span>';
-                            const tracked = Object.keys(ins.custom_metrics || {}).length;
-                            const linkEl = document.getElementById('stat-insights-link');
-                            linkEl.innerHTML = tracked + ' metrics tracked' +
-                                (ins.portal_url ? ' · <a href="' + ins.portal_url + '" target="_blank" style="color:var(--accent-primary);">Portal ↗</a>' : '');
-                        } else {
-                            card.style.display = 'none';
                         }
                     }
                 } catch (e) {}

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2142,17 +2142,127 @@
 
     <!-- DocGrok Add External Model Modal -->
     <div class="modal-overlay" id="dg-external-model-modal">
-        <div class="modal">
+        <div class="modal modal-full">
             <div class="modal-header">
-                <h3 class="modal-title">Add External Model</h3>
+                <h3 class="modal-title" style="display: flex; align-items: center; gap: 10px;">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="var(--accent-primary)" stroke-width="1.5" width="22" height="22"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/></svg>
+                    Add External Model
+                </h3>
                 <button class="modal-close" onclick="closeModal('dg-external-model-modal')">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="18" height="18">
                         <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
                     </svg>
                 </button>
             </div>
-            <div class="modal-body">
-                <form id="dg-external-model-form">
+            <div class="modal-body" style="padding: 0; flex: 1; max-height: none; overflow: hidden;">
+                <form id="dg-external-model-form" style="height: 100%;">
+                    <div style="display: grid; grid-template-columns: 1fr 1fr; height: 100%;">
+                        <!-- Left: Model Configuration -->
+                        <div style="padding: 24px; border-right: 1px solid var(--border-subtle); overflow-y: auto;">
+                            <div style="font-size: 12px; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 16px; font-weight: 600; letter-spacing: 0.5px;">Model Configuration</div>
+                            <div class="form-group">
+                                <label class="form-label">Model Name</label>
+                                <input type="text" class="form-input" name="name" placeholder="e.g., my-azure-openai">
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">Model Category</label>
+                                <select class="form-input" name="model_category" onchange="toggleEmbeddingDims(this.value)">
+                                    <option value="embedding">Embedding</option>
+                                    <option value="chat">Chat / LLM</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">Provider</label>
+                                <select class="form-input" name="type">
+                                    <option value="azure-openai">Azure OpenAI</option>
+                                    <option value="openai">OpenAI</option>
+                                    <option value="cohere">Cohere</option>
+                                    <option value="custom">Custom</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">Endpoint URL</label>
+                                <input type="text" class="form-input" name="endpoint" placeholder="https://your-resource.openai.azure.com">
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">Deployment Name</label>
+                                <input type="text" class="form-input" name="deployment" placeholder="e.g., text-embedding-3-small">
+                                <small style="color: var(--text-tertiary); font-size: 12px;">Must match the deployment name in Azure OpenAI exactly</small>
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">API Version (Azure only)</label>
+                                <input type="text" class="form-input" name="apiVersion" value="2024-06-01">
+                            </div>
+                            <div class="form-group" id="embedding-dims-group">
+                                <label class="form-label">Embedding Dimensions</label>
+                                <input type="number" class="form-input" name="dimensions" value="1536">
+                            </div>
+                        </div>
+
+                        <!-- Right: Authentication -->
+                        <div style="padding: 24px; background: var(--bg-tertiary); display: flex; flex-direction: column; overflow-y: auto;">
+                            <div style="font-size: 12px; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 16px; font-weight: 600; letter-spacing: 0.5px;">Authentication</div>
+
+                            <div class="form-group">
+                                <div style="display: flex; flex-direction: column; gap: 8px;">
+                                    <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; padding: 12px; background: var(--bg-secondary); border-radius: var(--radius-md); border: 2px solid var(--accent-primary);" id="model-add-auth-key-label">
+                                        <input type="radio" name="auth_type" value="key" checked onchange="toggleAuthFields(this.value)">
+                                        <div style="flex: 1;">
+                                            <div style="font-weight: 500;">API Key</div>
+                                            <div style="font-size: 12px; color: var(--text-tertiary); margin-top: 2px;">Authenticate with a subscription key</div>
+                                        </div>
+                                    </label>
+                                    <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; padding: 12px; background: var(--bg-secondary); border-radius: var(--radius-md); border: 2px solid transparent;" id="model-add-auth-mi-label">
+                                        <input type="radio" name="auth_type" value="managed-identity" onchange="toggleAuthFields(this.value)">
+                                        <div style="flex: 1;">
+                                            <div style="font-weight: 500; display: flex; align-items: center; gap: 8px;">
+                                                Managed Identity
+                                                <span class="badge badge-success" style="font-size: 10px;">Recommended</span>
+                                            </div>
+                                            <div style="font-size: 12px; color: var(--text-tertiary); margin-top: 2px;">Uses AKS Workload Identity — no keys needed</div>
+                                        </div>
+                                    </label>
+                                </div>
+                            </div>
+
+                            <div id="api-key-group">
+                                <div class="form-group">
+                                    <label class="form-label">API Key</label>
+                                    <input type="password" class="form-input" name="apiKey" placeholder="Paste your API key">
+                                </div>
+                            </div>
+
+                            <div id="client-id-group" style="display: none;">
+                                <input type="hidden" name="clientId" value="">
+                                <div style="background: var(--bg-secondary); border-radius: var(--radius-md); padding: 16px; font-size: 13px;">
+                                    <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px;">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="var(--success)" stroke-width="2" width="20" height="20"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                                        <span style="font-weight: 600; color: var(--success);">No key needed</span>
+                                    </div>
+                                    <p style="margin: 0 0 12px 0; color: var(--text-secondary);">Grant the AKS managed identity access to your Azure OpenAI resource:</p>
+                                    <p style="margin: 0 0 8px 0; font-weight: 500;">Azure Portal:</p>
+                                    <ol style="margin: 0 0 16px 0; padding-left: 20px; color: var(--text-secondary); line-height: 1.8;">
+                                        <li>Open your Azure OpenAI resource → <strong>Access Control (IAM)</strong></li>
+                                        <li>Click <strong>Add role assignment</strong></li>
+                                        <li>Select role: <strong>Cognitive Services OpenAI User</strong></li>
+                                        <li>Assign to: your AKS cluster's managed identity</li>
+                                    </ol>
+                                    <p style="margin: 0 0 4px 0; font-weight: 500;">Or via CLI:</p>
+                                    <div style="font-size: 11px; color: var(--text-tertiary); margin-bottom: 4px;">Bash:</div>
+                                    <div style="background: var(--bg-tertiary); padding: 10px; border-radius: 6px; margin-bottom: 8px; font-family: var(--font-mono), monospace; font-size: 11px; overflow-x: auto; white-space: pre-wrap;">az role assignment create \
+  --assignee &lt;aks-managed-identity-client-id&gt; \
+  --role "Cognitive Services OpenAI User" \
+  --scope &lt;azure-openai-resource-id&gt;</div>
+                                    <div style="font-size: 11px; color: var(--text-tertiary); margin-bottom: 4px;">PowerShell:</div>
+                                    <div style="background: var(--bg-tertiary); padding: 10px; border-radius: 6px; font-family: var(--font-mono), monospace; font-size: 11px; overflow-x: auto; white-space: pre-wrap;">az role assignment create `
+  --assignee &lt;aks-managed-identity-client-id&gt; `
+  --role "Cognitive Services OpenAI User" `
+  --scope &lt;azure-openai-resource-id&gt;</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </form>
                     <div class="form-group">
                         <label class="form-label">Model Name</label>
                         <input type="text" class="form-input" name="name" placeholder="e.g., my-azure-openai">
@@ -6599,8 +6709,8 @@
                             Overview
                         </button>
                         <button class="mdl-detail-tab" data-tab="health" onclick="switchModelDetailTab('health')" style="display: flex; align-items: center; gap: 10px; width: 100%; padding: 12px 16px; background: var(--bg-secondary); color: var(--text-primary); border: none; border-radius: 8px; cursor: pointer; font-size: 14px; text-align: left;">
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
-                            Health
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                            Auth &amp; Status
                             ${mh && mh.status !== 'healthy' ? '<span style="margin-left:auto;width:8px;height:8px;border-radius:50%;background:' + healthStatusColor(mh.status) + ';display:inline-block;"></span>' : ''}
                         </button>
                     </nav>
@@ -6974,13 +7084,22 @@
                     </div>`;
                 }
                 result.innerHTML = html;
-                // Update cached health data with fresh result and re-render the tab
+                // Update cached health data (but DON'T re-render tab — it would wipe this result)
                 if (healthData && healthData.models) {
                     const idx = healthData.models.findIndex(m => m.id === modelId);
                     if (idx >= 0) healthData.models[idx] = data;
                     else healthData.models.push(data);
                 }
-                renderModelDetailTab();
+                // Update the status banner inline if it exists
+                const banner = document.querySelector(`#dg-model-detail-body .health-status-banner-${modelId}`);
+                if (banner) {
+                    const sc = data.status === 'healthy' ? 'var(--success)' : data.status === 'warning' ? 'var(--warning)' : 'var(--error)';
+                    banner.style.background = sc + '15';
+                    banner.style.borderColor = sc + '33';
+                    banner.querySelector('.health-status-text').style.color = sc;
+                    banner.querySelector('.health-status-text').textContent = data.status;
+                    banner.querySelector('.health-status-dot').style.background = sc;
+                }
             } catch (e) {
                 result.innerHTML = `<span style="color:var(--error);">Error: ${e.message}</span>`;
             } finally {
@@ -7006,13 +7125,13 @@
             if (authType === 'managed-identity') {
                 if (keyGroup) keyGroup.style.display = 'none';
                 if (clientIdGroup) clientIdGroup.style.display = 'block';
-                if (keyLabel) { keyLabel.style.borderColor = 'var(--border)'; keyLabel.style.background = 'transparent'; }
-                if (miLabel) { miLabel.style.borderColor = 'var(--accent-primary)'; miLabel.style.background = 'rgba(34,197,94,0.1)'; }
+                if (keyLabel) { keyLabel.style.borderColor = 'transparent'; }
+                if (miLabel) { miLabel.style.borderColor = 'var(--accent-primary)'; }
             } else {
                 if (keyGroup) keyGroup.style.display = 'block';
                 if (clientIdGroup) clientIdGroup.style.display = 'none';
-                if (keyLabel) { keyLabel.style.borderColor = 'var(--accent-primary)'; keyLabel.style.background = 'rgba(99,102,241,0.1)'; }
-                if (miLabel) { miLabel.style.borderColor = 'var(--border)'; miLabel.style.background = 'transparent'; }
+                if (keyLabel) { keyLabel.style.borderColor = 'var(--accent-primary)'; }
+                if (miLabel) { miLabel.style.borderColor = 'transparent'; }
             }
         }
 

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -982,6 +982,11 @@
                             <div class="stat-value" id="stat-throughput" style="color: var(--accent-primary);">--</div>
                             <div class="stat-trend" id="stat-throughput-label">docs/sec</div>
                         </div>
+                        <div class="stat-card" id="stat-insights-card" style="display:none;">
+                            <div class="stat-label">Telemetry</div>
+                            <div class="stat-value" id="stat-insights-status" style="font-size:1rem;">—</div>
+                            <div class="stat-trend" id="stat-insights-link"></div>
+                        </div>
                     </div>
 
                     <div class="card">
@@ -2623,6 +2628,26 @@
                             navBadge.style.color = '#fff';
                         } else {
                             navBadge.style.display = 'none';
+                        }
+                    }
+                } catch (e) {}
+
+                // Fetch App Insights telemetry status
+                try {
+                    const insRes = await apiFetch('/api/metrics/insights');
+                    if (insRes.ok) {
+                        const ins = await insRes.json();
+                        const card = document.getElementById('stat-insights-card');
+                        if (ins.enabled) {
+                            card.style.display = '';
+                            document.getElementById('stat-insights-status').innerHTML =
+                                '<span style="color:var(--success);">● Active</span>';
+                            const tracked = Object.keys(ins.custom_metrics || {}).length;
+                            const linkEl = document.getElementById('stat-insights-link');
+                            linkEl.innerHTML = tracked + ' metrics tracked' +
+                                (ins.portal_url ? ' · <a href="' + ins.portal_url + '" target="_blank" style="color:var(--accent-primary);">Portal ↗</a>' : '');
+                        } else {
+                            card.style.display = 'none';
                         }
                     }
                 } catch (e) {}

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1308,12 +1308,6 @@
                 <header class="header">
                     <h2 class="header-title">Metrics</h2>
                     <div class="header-actions">
-                        <button class="btn btn-secondary" onclick="clearMetrics()">
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16">
-                                <path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
-                            </svg>
-                            Clear Metrics
-                        </button>
                         <button class="btn btn-ghost" onclick="loadMetricsSection()">
                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M21 12a9 9 0 1 1-6.219-8.56"/><polyline points="21 3 21 9 15 9"/></svg>
                             Refresh
@@ -3006,6 +3000,47 @@
                     `}
                 `;
             } else if (currentDetailTab === 'auth') {
+                if (source.type === 'postgresql' || source.type === 'mssql') {
+                    const isPg = source.type === 'postgresql';
+                    configPanel.innerHTML = `
+                        <h4 style="margin: 0 0 20px 0; font-size: 16px;">Authentication</h4>
+                        <div style="display: flex; align-items: center; gap: 16px; padding: 20px; background: var(--bg-tertiary); border-radius: 8px; margin-bottom: 24px;">
+                            <div style="width: 48px; height: 48px; background: rgba(59,130,246,0.1); border-radius: 12px; display: flex; align-items: center; justify-content: center;">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="var(--accent-primary)" stroke-width="2" width="24" height="24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                            </div>
+                            <div>
+                                <div style="font-weight: 600; font-size: 16px;">${isPg ? 'PostgreSQL' : 'SQL Server'} Credentials</div>
+                                <div style="font-size: 13px; color: var(--text-tertiary);">Username and password for database access</div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Username</label>
+                            <input type="text" class="form-input" id="detail-pg-user" value="${config.user || ''}" placeholder="${isPg ? 'postgres' : 'sa'}" oninput="markSourceDetailDirty()">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Password</label>
+                            <input type="password" class="form-input" id="detail-pg-password" value="${config.password || ''}" placeholder="Enter password" oninput="markSourceDetailDirty()">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">SSL Mode</label>
+                            <select class="form-input" id="detail-pg-ssl-mode" onchange="markSourceDetailDirty()">
+                                <option value="require" ${(config.ssl_mode || 'require') === 'require' ? 'selected' : ''}>Require (recommended)</option>
+                                <option value="verify-full" ${config.ssl_mode === 'verify-full' ? 'selected' : ''}>Verify Full</option>
+                                <option value="prefer" ${config.ssl_mode === 'prefer' ? 'selected' : ''}>Prefer</option>
+                                <option value="disable" ${config.ssl_mode === 'disable' ? 'selected' : ''}>Disable</option>
+                            </select>
+                        </div>
+                        <div style="background: var(--bg-tertiary); border-radius: 8px; padding: 16px; font-size: 13px; margin-top: 16px;">
+                            <p style="margin: 0 0 8px 0; font-weight: 500;">Troubleshooting</p>
+                            <ul style="margin: 0; padding-left: 16px; color: var(--text-secondary); line-height: 1.8;">
+                                <li>Verify the username has read access to the table</li>
+                                <li>Check that the database firewall allows connections from this service</li>
+                                ${isPg ? '<li>For Azure PostgreSQL: ensure "Allow access to Azure services" is enabled</li>' : ''}
+                                <li>If using SSL, ensure the server certificate is valid</li>
+                            </ul>
+                        </div>
+                    `;
+                } else {
                 const authLabel = authType === 'managed-identity' ? 'Managed Identity' : 'Connection String';
                 configPanel.innerHTML = `
                     <h4 style="margin: 0 0 20px 0; font-size: 16px;">Authentication</h4>
@@ -3061,6 +3096,7 @@
                         </div>
                     `}
                 `;
+                }
             } else if (currentDetailTab === 'health') {
                 const sh = getHealthFor('sources', source.id);
                 if (!sh) {
@@ -3144,13 +3180,21 @@
                 config.endpoint = editedSourceData.endpoint || source.config.endpoint;
                 config.database = editedSourceData.database || source.config.database;
                 config.container = editedSourceData.container || source.config.container;
+            } else if (source.type === 'postgresql' || source.type === 'mssql') {
+                config.host = editedSourceData.host || source.config?.host || '';
+                config.port = editedSourceData.port || source.config?.port || 5432;
+                config.database = editedSourceData.database || source.config?.database || '';
+                config.table = editedSourceData.table || source.config?.table || '';
+                config.user = editedSourceData.user || source.config?.user || '';
+                config.password = editedSourceData.password || source.config?.password || '';
+                config.ssl_mode = editedSourceData.ssl_mode || source.config?.ssl_mode || 'require';
             }
 
             try {
                 const res = await apiFetch('/api/sources/test-connection', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ type: source.type, config })
+                    body: JSON.stringify({ type: source.type, config, source_id: source.id })
                 });
                 const data = await res.json();
 
@@ -3199,6 +3243,25 @@
                 if (endpointEl) editedSourceData.endpoint = endpointEl.value;
                 if (dbEl) editedSourceData.database = dbEl.value;
                 if (containerEl) editedSourceData.container = containerEl.value;
+            } else if (source.type === 'postgresql' || source.type === 'mssql') {
+                const hostEl = document.getElementById('detail-pg-host');
+                const portEl = document.getElementById('detail-pg-port');
+                const dbEl = document.getElementById('detail-pg-database');
+                const tableEl = document.getElementById('detail-pg-table');
+                const idColEl = document.getElementById('detail-pg-id-column');
+                const tsColEl = document.getElementById('detail-pg-ts-column');
+                const userEl = document.getElementById('detail-pg-user');
+                const passEl = document.getElementById('detail-pg-password');
+                const sslEl = document.getElementById('detail-pg-ssl-mode');
+                if (hostEl) editedSourceData.host = hostEl.value;
+                if (portEl) editedSourceData.port = parseInt(portEl.value) || 5432;
+                if (dbEl) editedSourceData.database = dbEl.value;
+                if (tableEl) editedSourceData.table = tableEl.value;
+                if (idColEl) editedSourceData.id_column = idColEl.value;
+                if (tsColEl) editedSourceData.timestamp_column = tsColEl.value;
+                if (userEl) editedSourceData.user = userEl.value;
+                if (passEl) editedSourceData.password = passEl.value;
+                if (sslEl) editedSourceData.ssl_mode = sslEl.value;
             }
         }
 
@@ -3225,6 +3288,16 @@
                 config.endpoint = editedSourceData.endpoint || source.config?.endpoint || '';
                 config.database = editedSourceData.database || source.config?.database || '';
                 config.container = editedSourceData.container || source.config?.container || '';
+            } else if (source.type === 'postgresql' || source.type === 'mssql') {
+                config.host = editedSourceData.host || source.config?.host || '';
+                config.port = editedSourceData.port || source.config?.port || 5432;
+                config.database = editedSourceData.database || source.config?.database || '';
+                config.table = editedSourceData.table || source.config?.table || '';
+                config.id_column = editedSourceData.id_column || source.config?.id_column || 'id';
+                config.timestamp_column = editedSourceData.timestamp_column || source.config?.timestamp_column || 'updated_at';
+                config.user = editedSourceData.user || source.config?.user || '';
+                config.password = editedSourceData.password || source.config?.password || '';
+                config.ssl_mode = editedSourceData.ssl_mode || source.config?.ssl_mode || 'require';
             }
 
             try {
@@ -3489,6 +3562,51 @@
                     </div>
                 `;
             } else if (currentDestDetailTab === 'auth') {
+                if (dest.type === 'pgvector') {
+                    configPanel.innerHTML = `
+                        <h4 style="margin: 0 0 20px 0; font-size: 16px;">Authentication</h4>
+                        <div style="display: flex; align-items: center; gap: 16px; padding: 20px; background: var(--bg-tertiary); border-radius: 8px; margin-bottom: 24px;">
+                            <div style="width: 48px; height: 48px; background: rgba(59,130,246,0.1); border-radius: 12px; display: flex; align-items: center; justify-content: center;">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="var(--accent-primary)" stroke-width="2" width="24" height="24"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                            </div>
+                            <div>
+                                <div style="font-weight: 600; font-size: 16px;">PostgreSQL Credentials</div>
+                                <div style="font-size: 13px; color: var(--text-tertiary);">Username and password for database access</div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Username</label>
+                            <input type="text" class="form-input" id="dest-detail-pg-user" value="${config.user || ''}" placeholder="postgres" oninput="markDestDetailDirty()">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">Password</label>
+                            <input type="password" class="form-input" id="dest-detail-pg-password" value="${config.password || ''}" placeholder="Enter password" oninput="markDestDetailDirty()">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label">SSL Mode</label>
+                            <select class="form-input" id="dest-detail-pg-ssl-mode" onchange="markDestDetailDirty()">
+                                <option value="require" ${(config.ssl_mode || 'require') === 'require' ? 'selected' : ''}>Require (recommended)</option>
+                                <option value="verify-full" ${config.ssl_mode === 'verify-full' ? 'selected' : ''}>Verify Full</option>
+                                <option value="prefer" ${config.ssl_mode === 'prefer' ? 'selected' : ''}>Prefer</option>
+                                <option value="disable" ${config.ssl_mode === 'disable' ? 'selected' : ''}>Disable</option>
+                            </select>
+                        </div>
+                        <button type="button" class="btn btn-secondary" onclick="testDestDetailConnection()" id="dest-detail-test-btn" style="width: 100%; justify-content: center; padding: 12px; margin-top: 8px;">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+                            Test Connection
+                        </button>
+                        <div id="dest-detail-test-result" style="margin-top: 12px;"></div>
+                        <div style="background: var(--bg-tertiary); border-radius: 8px; padding: 16px; font-size: 13px; margin-top: 16px;">
+                            <p style="margin: 0 0 8px 0; font-weight: 500;">Troubleshooting</p>
+                            <ul style="margin: 0; padding-left: 16px; color: var(--text-secondary); line-height: 1.8;">
+                                <li>Verify the username has read/write access to the table</li>
+                                <li>Check that the database firewall allows connections from this service</li>
+                                <li>For Azure PostgreSQL: ensure "Allow access to Azure services" is enabled</li>
+                                <li>Ensure the pgvector extension is installed (<code>CREATE EXTENSION vector</code>)</li>
+                            </ul>
+                        </div>
+                    `;
+                } else {
                 const authLabel = authType === 'managed-identity' ? 'Managed Identity' : 'API Key';
                 configPanel.innerHTML = `
                     <h4 style="margin: 0 0 20px 0; font-size: 16px;">Authentication</h4>
@@ -3543,15 +3661,22 @@
                         </div>
                     `}
                 `;
+                } // end else (non-pgvector dest auth)
             } else if (currentDestDetailTab === 'vector') {
+                const isPgVector = dest.type === 'pgvector';
+                const vecTitle = isPgVector ? 'Vector Columns' : 'Vector Configuration';
+                const vecDesc = isPgVector
+                    ? 'Discover vector columns in your PostgreSQL table. Columns with the <code>vector</code> type will be listed.'
+                    : 'Vector index details are read from the destination when you test the connection.';
+                const btnLabel = isPgVector ? 'Discover Vector Columns' : 'Fetch Embedding Policies';
                 configPanel.innerHTML = `
-                    <h4 style="margin: 0 0 20px 0; font-size: 16px;">Vector Configuration</h4>
-                    <p style="font-size: 13px; color: var(--text-tertiary); margin-bottom: 20px;">Vector index details are read from the destination when you test the connection.</p>
+                    <h4 style="margin: 0 0 20px 0; font-size: 16px;">${vecTitle}</h4>
+                    <p style="font-size: 13px; color: var(--text-tertiary); margin-bottom: 20px;">${vecDesc}</p>
                     <button type="button" class="btn btn-secondary" onclick="testDestinationFromDetail()" style="width: 100%; justify-content: center; padding: 12px;">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18">
                             <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/>
                         </svg>
-                        Fetch Embedding Policies
+                        ${btnLabel}
                     </button>
                     <div id="dest-detail-vector-result" style="margin-top: 16px;"></div>
                 `;
@@ -3614,6 +3739,9 @@
                 const vecColEl = document.getElementById('dest-detail-pg-vector-col');
                 const contentColEl = document.getElementById('dest-detail-pg-content-col');
                 const dimsEl = document.getElementById('dest-detail-pg-dimensions');
+                const userEl = document.getElementById('dest-detail-pg-user');
+                const passEl = document.getElementById('dest-detail-pg-password');
+                const sslEl = document.getElementById('dest-detail-pg-ssl-mode');
                 if (hostEl) editedDestData.host = hostEl.value;
                 if (portEl) editedDestData.port = parseInt(portEl.value) || 5432;
                 if (dbEl) editedDestData.database = dbEl.value;
@@ -3621,6 +3749,9 @@
                 if (vecColEl) editedDestData.vector_column = vecColEl.value;
                 if (contentColEl) editedDestData.content_column = contentColEl.value;
                 if (dimsEl) editedDestData.vector_dimensions = parseInt(dimsEl.value) || 1536;
+                if (userEl) editedDestData.user = userEl.value;
+                if (passEl) editedDestData.password = passEl.value;
+                if (sslEl) editedDestData.ssl_mode = sslEl.value;
             }
         }
 
@@ -3647,17 +3778,20 @@
                 config.host = editedDestData.host || dest.config?.host || '';
                 config.port = editedDestData.port || dest.config?.port || 5432;
                 config.database = editedDestData.database || dest.config?.database || '';
+                config.table = editedDestData.table || dest.config?.table || 'vectors';
+                config.vector_column = editedDestData.vector_column || dest.config?.vector_column || 'embedding';
+                config.user = editedDestData.user || dest.config?.user || '';
+                config.password = editedDestData.password || dest.config?.password || '';
+                config.ssl_mode = editedDestData.ssl_mode || dest.config?.ssl_mode || 'require';
             }
 
             try {
                 const res = await apiFetch('/api/destinations/test-connection', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ type: dest.type, config })
+                    body: JSON.stringify({ type: dest.type, config, destination_id: dest.id })
                 });
                 const data = await res.json();
-
-                let html = '';
                 if (data.success) {
                     let details = '';
                     const vi = data.vector_indexes || data.result?.vector_indexes || [];
@@ -3706,18 +3840,32 @@
             if (resultDiv) resultDiv.innerHTML = '<div style="color: var(--text-secondary); font-size: 13px;">Testing connection...</div>';
 
             // Get current form values
-            const endpoint = document.getElementById('dest-detail-endpoint')?.value || dest.config?.endpoint || '';
-            const database = document.getElementById('dest-detail-database')?.value || dest.config?.database || '';
-            const container = document.getElementById('dest-detail-container')?.value || dest.config?.container || '';
-
             const authType = dest.config?.auth_type || 'managed-identity';
-            const config = { auth_type: authType, endpoint, database, container };
+            let config = { auth_type: authType };
+
+            if (dest.type === 'pgvector') {
+                captureDestTabData();
+                config.host = editedDestData.host || dest.config?.host || '';
+                config.port = editedDestData.port || dest.config?.port || 5432;
+                config.database = editedDestData.database || dest.config?.database || '';
+                config.table = editedDestData.table || dest.config?.table || 'vectors';
+                config.vector_column = editedDestData.vector_column || dest.config?.vector_column || 'embedding';
+                config.user = editedDestData.user || dest.config?.user || '';
+                config.password = editedDestData.password || dest.config?.password || '';
+                config.ssl_mode = editedDestData.ssl_mode || dest.config?.ssl_mode || 'require';
+            } else {
+                // CosmosDB and other types
+                const endpoint = document.getElementById('dest-detail-endpoint')?.value || dest.config?.endpoint || '';
+                const database = document.getElementById('dest-detail-database')?.value || dest.config?.database || '';
+                const container = document.getElementById('dest-detail-container')?.value || dest.config?.container || '';
+                config = { auth_type: authType, endpoint, database, container };
+            }
 
             try {
                 const res = await apiFetch('/api/destinations/test-connection', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ type: dest.type, config })
+                    body: JSON.stringify({ type: dest.type, config, destination_id: dest.id })
                 });
                 const data = await res.json();
                 if (data.success) {
@@ -3767,6 +3915,19 @@
                 config.endpoint = editedDestData.endpoint || dest.config?.endpoint || '';
                 config.database = editedDestData.database || dest.config?.database || '';
                 config.container = editedDestData.container || dest.config?.container || '';
+            } else if (dest.type === 'pgvector') {
+                config.host = editedDestData.host || dest.config?.host || '';
+                config.port = editedDestData.port || dest.config?.port || 5432;
+                config.database = editedDestData.database || dest.config?.database || '';
+                config.table = editedDestData.table || dest.config?.table || 'vectors';
+                config.vector_column = editedDestData.vector_column || dest.config?.vector_column || 'embedding';
+                config.content_column = editedDestData.content_column || dest.config?.content_column || 'content';
+                config.vector_dimensions = editedDestData.vector_dimensions || dest.config?.vector_dimensions || 1536;
+                config.user = editedDestData.user || dest.config?.user || '';
+                config.password = editedDestData.password || dest.config?.password || '';
+                config.ssl_mode = editedDestData.ssl_mode || dest.config?.ssl_mode || 'require';
+                // Preserve discovered vector_indexes
+                if (dest.config?.vector_indexes) config.vector_indexes = dest.config.vector_indexes;
             } else if (dest.type === 'pinecone') {
                 config.index = editedDestData.index || dest.config?.index || '';
                 config.environment = editedDestData.environment || dest.config?.environment || '';
@@ -4119,12 +4280,16 @@
                     </div>
 
                     <div class="form-group" style="margin-top: 16px;">
-                        <label class="form-label">Embedding Policy Path</label>
+                        <label class="form-label">${destType === 'pgvector' ? 'Vector Column' : 'Embedding Policy Path'}</label>
                         <div style="padding: 10px 12px; background: var(--bg-tertiary); border-radius: var(--radius-sm); font-family: monospace; font-size: 13px;">
-                            /${pipeline.vector_index_path || '<span style="color: var(--text-tertiary);">not set</span>'}
+                            ${destType === 'pgvector'
+                                ? (pipeline.vector_index_path || '<span style="color: var(--text-tertiary);">embedding</span>')
+                                : '/' + (pipeline.vector_index_path || '<span style="color: var(--text-tertiary);">not set</span>')}
                         </div>
                         <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
-                            The vector embedding path in the destination container. Cannot be changed after creation.
+                            ${destType === 'pgvector'
+                                ? 'The vector column in the destination table where embeddings are stored. Cannot be changed after creation.'
+                                : 'The vector embedding path in the destination container. Cannot be changed after creation.'}
                         </small>
                     </div>
                 `;
@@ -4883,8 +5048,16 @@
                 document.getElementById('pl-dest-vector-policy-group').style.display = 'none';
                 return;
             }
-            // Try to load from destination's stored config first
+            // Update label based on dest type
             const dest = destinations.find(d => d.id === destId);
+            const isPg = dest?.type === 'pgvector';
+            const labelEl = document.querySelector('#pl-dest-vector-policy-group .form-label');
+            if (labelEl) labelEl.textContent = isPg ? 'Vector Column' : 'Vector Embedding Policy';
+            const smallEl = document.querySelector('#pl-dest-vector-policy-group small');
+            if (smallEl) smallEl.textContent = isPg
+                ? 'Select which vector column to use for storing embeddings'
+                : 'Select which vector embedding field to use for this pipeline';
+
             const vi = dest?.config?.vector_indexes || [];
             if (vi.length > 0) {
                 populateVectorPolicyDropdown(vi);
@@ -5517,7 +5690,9 @@
                     vector_column: formData.get('vector_column') || 'embedding',
                     vector_dimensions: parseInt(formData.get('vector_dimensions')) || 1024,
                     index_type: formData.get('index_type') || 'ivfflat',
-                    ssl_mode: 'require'
+                    user: formData.get('user') || '',
+                    password: formData.get('password') || '',
+                    ssl_mode: formData.get('ssl_mode') || 'require'
                 };
             }
 
@@ -6009,6 +6184,14 @@
                 config.endpoint = formData.get('endpoint');
                 config.database = formData.get('database');
                 config.container = formData.get('container');
+            } else if (type === 'postgresql' || type === 'mssql') {
+                config.host = formData.get('host');
+                config.port = parseInt(formData.get('port')) || 5432;
+                config.database = formData.get('database');
+                config.table = formData.get('table');
+                config.user = formData.get('user') || '';
+                config.password = formData.get('password') || '';
+                config.ssl_mode = formData.get('ssl_mode') || 'require';
             }
 
             if (authType === 'connection-string') {
@@ -6311,6 +6494,25 @@
                             <option value="hnsw">HNSW (faster, more memory)</option>
                         </select>
                     </div>
+                    <hr style="border: 0; border-top: 1px solid var(--border-primary); margin: 16px 0;">
+                    <h5 style="margin: 0 0 12px 0; font-size: 14px;">Authentication</h5>
+                    <div class="form-group">
+                        <label class="form-label">Username</label>
+                        <input type="text" class="form-input" name="user" placeholder="postgres">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Password</label>
+                        <input type="password" class="form-input" name="password" placeholder="Enter password">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">SSL Mode</label>
+                        <select class="form-input" name="ssl_mode">
+                            <option value="require" selected>Require (recommended)</option>
+                            <option value="verify-full">Verify Full</option>
+                            <option value="prefer">Prefer</option>
+                            <option value="disable">Disable</option>
+                        </select>
+                    </div>
                 `;
             } else if (type === 'pinecone') {
                 container.innerHTML = `
@@ -6365,9 +6567,24 @@
                 config.endpoint = formData.get('endpoint');
                 config.database = formData.get('database');
                 config.container = formData.get('container');
-            }
-
-            if (!config.endpoint || !config.database || !config.container) {
+                if (!config.endpoint || !config.database || !config.container) {
+                    resultDiv.innerHTML = `<div style="background: var(--warning-muted); border: 1px solid var(--warning); padding: 12px; border-radius: var(--radius-md); color: var(--warning);">Please fill in all required fields</div>`;
+                    return;
+                }
+            } else if (type === 'pgvector') {
+                config.host = formData.get('host') || '';
+                config.port = parseInt(formData.get('port')) || 5432;
+                config.database = formData.get('database') || '';
+                config.table = formData.get('table') || 'vectors';
+                config.user = formData.get('user') || '';
+                config.password = formData.get('password') || '';
+                config.vector_column = formData.get('vector_column') || 'embedding';
+                config.ssl_mode = formData.get('ssl_mode') || 'require';
+                if (!config.host || !config.database) {
+                    resultDiv.innerHTML = `<div style="background: var(--warning-muted); border: 1px solid var(--warning); padding: 12px; border-radius: var(--radius-md); color: var(--warning);">Please fill in Host and Database</div>`;
+                    return;
+                }
+            } else {
                 resultDiv.innerHTML = `<div style="background: var(--warning-muted); border: 1px solid var(--warning); padding: 12px; border-radius: var(--radius-md); color: var(--warning);">Please fill in all required fields</div>`;
                 return;
             }
@@ -8256,17 +8473,6 @@
                 metricsEnd = ed.value + 'T' + (et && et.value ? et.value : '23:59') + ':00';
                 metricsRange = 'custom';
                 loadMetricsSection();
-            }
-        }
-
-        async function clearMetrics() {
-            if (!confirm('Clear all metrics? This cannot be undone.')) return;
-            try {
-                await apiFetch('/api/metrics', { method: 'DELETE' });
-                showNotification('Metrics cleared', 'success');
-                loadMetricsSection();
-            } catch (e) {
-                showNotification('Error: ' + e.message, 'error');
             }
         }
 

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2156,7 +2156,6 @@
                     <div class="form-group">
                         <label class="form-label">Model Name</label>
                         <input type="text" class="form-input" name="name" placeholder="e.g., my-azure-openai">
-                        <small style="color: var(--text-tertiary); font-size: 12px;">Unique identifier for this external model</small>
                     </div>
                     <div class="form-group">
                         <label class="form-label">Model Category</label>
@@ -2164,7 +2163,6 @@
                             <option value="embedding">Embedding</option>
                             <option value="chat">Chat / LLM</option>
                         </select>
-                        <small style="color: var(--text-tertiary); font-size: 12px;">Embedding models are used in pipelines</small>
                     </div>
                     <div class="form-group">
                         <label class="form-label">Provider</label>
@@ -2177,50 +2175,66 @@
                     </div>
                     <div class="form-group">
                         <label class="form-label">Endpoint URL</label>
-                        <input type="text" class="form-input" name="endpoint" placeholder="https://...">
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label">Authentication</label>
-                        <div style="display: flex; gap: 12px; margin-top: 4px;">
-                            <label style="display: flex; align-items: center; gap: 6px; cursor: pointer; padding: 10px 20px; border-radius: 8px; border: 2px solid var(--accent-primary); background: rgba(99,102,241,0.1); flex: 1; justify-content: center;" id="model-add-auth-key-label">
-                                <input type="radio" name="auth_type" value="key" checked onchange="toggleAuthFields(this.value)">
-                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
-                                <span style="font-weight: 500;">API Key</span>
-                            </label>
-                            <label style="display: flex; align-items: center; gap: 6px; cursor: pointer; padding: 10px 20px; border-radius: 8px; border: 2px solid var(--border); background: transparent; flex: 1; justify-content: center;" id="model-add-auth-mi-label">
-                                <input type="radio" name="auth_type" value="managed-identity" onchange="toggleAuthFields(this.value)">
-                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-                                <span style="font-weight: 500;">Managed Identity</span>
-                            </label>
-                        </div>
-                    </div>
-                    <div class="form-group" id="api-key-group">
-                        <label class="form-label">API Key</label>
-                        <input type="password" class="form-input" name="apiKey" placeholder="Enter API key">
-                    </div>
-                    <div class="form-group" id="client-id-group" style="display: none;">
-                        <label class="form-label">Client ID (optional)</label>
-                        <input type="text" class="form-input" name="clientId" placeholder="Managed identity client ID (uses workload identity if empty)">
-                        <div style="background: var(--bg-tertiary); border-radius: 8px; padding: 12px; margin-top: 8px; font-size: 12px;">
-                            <p style="margin: 0 0 8px 0; font-weight: 500; color: var(--text-secondary);">Grant access to your Azure OpenAI resource:</p>
-                            <div style="background: var(--bg-secondary); padding: 8px; border-radius: 4px; font-family: var(--font-mono), monospace; font-size: 11px; overflow-x: auto; white-space: pre-wrap;">az role assignment create \
-  --assignee &lt;managed-identity-client-id&gt; \
-  --role "Cognitive Services OpenAI User" \
-  --scope /subscriptions/.../Microsoft.CognitiveServices/accounts/&lt;name&gt;</div>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label">API Version (Azure only)</label>
-                        <input type="text" class="form-input" name="apiVersion" placeholder="e.g., 2024-06-01">
+                        <input type="text" class="form-input" name="endpoint" placeholder="https://your-resource.openai.azure.com">
                     </div>
                     <div class="form-group">
                         <label class="form-label">Deployment Name</label>
                         <input type="text" class="form-input" name="deployment" placeholder="e.g., text-embedding-3-small">
-                        <small style="color: var(--text-tertiary); font-size: 12px;">The exact deployment name in Azure OpenAI (must match exactly)</small>
+                        <small style="color: var(--text-tertiary); font-size: 12px;">Must match the deployment name in Azure OpenAI exactly</small>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">API Version (Azure only)</label>
+                        <input type="text" class="form-input" name="apiVersion" placeholder="e.g., 2024-06-01" value="2024-06-01">
                     </div>
                     <div class="form-group" id="embedding-dims-group">
                         <label class="form-label">Embedding Dimensions</label>
-                        <input type="number" class="form-input" name="dimensions" value="3072">
+                        <input type="number" class="form-input" name="dimensions" value="1536">
+                    </div>
+
+                    <hr style="border: none; border-top: 1px solid var(--border); margin: 24px 0;">
+
+                    <div class="form-group">
+                        <label class="form-label">Authentication</label>
+                        <div style="display: flex; gap: 12px; margin-top: 4px;">
+                            <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; padding: 12px 20px; border-radius: 8px; border: 2px solid var(--accent-primary); background: rgba(99,102,241,0.1); flex: 1; justify-content: center;" id="model-add-auth-key-label">
+                                <input type="radio" name="auth_type" value="key" checked onchange="toggleAuthFields(this.value)">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+                                <span style="font-weight: 600;">API Key</span>
+                            </label>
+                            <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; padding: 12px 20px; border-radius: 8px; border: 2px solid var(--border); background: transparent; flex: 1; justify-content: center;" id="model-add-auth-mi-label">
+                                <input type="radio" name="auth_type" value="managed-identity" onchange="toggleAuthFields(this.value)">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                                <span style="font-weight: 600;">Managed Identity</span>
+                            </label>
+                        </div>
+                    </div>
+                    <div id="api-key-group">
+                        <div class="form-group">
+                            <label class="form-label">API Key</label>
+                            <input type="password" class="form-input" name="apiKey" placeholder="Paste your API key">
+                        </div>
+                    </div>
+                    <div id="client-id-group" style="display: none;">
+                        <input type="hidden" name="clientId" value="">
+                        <div style="background: var(--bg-tertiary); border-radius: 8px; padding: 16px; font-size: 13px;">
+                            <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px;">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="var(--success)" stroke-width="2" width="20" height="20"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                                <span style="font-weight: 600; color: var(--success);">No key needed</span>
+                            </div>
+                            <p style="margin: 0 0 12px 0; color: var(--text-secondary);">OmniVec uses the AKS cluster's workload identity to authenticate with Azure OpenAI. Just grant access:</p>
+                            <p style="margin: 0 0 8px 0; font-weight: 500;">Azure Portal (easiest):</p>
+                            <ol style="margin: 0 0 16px 0; padding-left: 20px; color: var(--text-secondary); line-height: 1.8;">
+                                <li>Open your Azure OpenAI resource → <strong>Access Control (IAM)</strong></li>
+                                <li>Click <strong>Add role assignment</strong></li>
+                                <li>Select role: <strong>Cognitive Services OpenAI User</strong></li>
+                                <li>Assign to: your AKS cluster's managed identity</li>
+                            </ol>
+                            <p style="margin: 0 0 4px 0; font-weight: 500;">Or via CLI:</p>
+                            <div style="background: var(--bg-secondary); padding: 10px; border-radius: 6px; font-family: var(--font-mono), monospace; font-size: 11px; overflow-x: auto; white-space: pre-wrap;">az role assignment create \
+  --assignee &lt;aks-managed-identity-client-id&gt; \
+  --role "Cognitive Services OpenAI User" \
+  --scope &lt;azure-openai-resource-id&gt;</div>
+                        </div>
                     </div>
                 </form>
             </div>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -6873,8 +6873,13 @@
                     </div>`;
                 }
                 result.innerHTML = html;
-                // Also refresh health data globally
-                refreshData();
+                // Update cached health data with fresh result and re-render the tab
+                if (healthData && healthData.models) {
+                    const idx = healthData.models.findIndex(m => m.id === modelId);
+                    if (idx >= 0) healthData.models[idx] = data;
+                    else healthData.models.push(data);
+                }
+                renderModelDetailTab();
             } catch (e) {
                 result.innerHTML = `<span style="color:var(--error);">Error: ${e.message}</span>`;
             } finally {
@@ -8049,6 +8054,11 @@
             if (_metricsChartThroughput) { _metricsChartThroughput.destroy(); _metricsChartThroughput = null; }
             if (_metricsChartLatency) { _metricsChartLatency.destroy(); _metricsChartLatency = null; }
             if (!buckets.length) return;
+            if (typeof Chart === 'undefined') {
+                const el = document.getElementById('metrics-chart-throughput');
+                if (el) el.parentElement.innerHTML = '<div style="display:flex;align-items:center;justify-content:center;height:300px;color:var(--text-tertiary);">Chart.js not loaded (CDN may be blocked)</div>';
+                return;
+            }
 
             const labels = buckets.map(b => _fmtBucketLabel(b.t, granularity));
             const chartDefaults = {
@@ -8222,7 +8232,10 @@
             container.innerHTML = html;
 
             // Render charts after DOM is ready
-            setTimeout(() => _renderMetricsCharts(buckets, data.granularity), 0);
+            setTimeout(() => {
+                try { _renderMetricsCharts(buckets, data.granularity); }
+                catch(e) { console.error('Chart render error:', e); }
+            }, 100);
         }
 
         let _opsActiveTab = 'overview';

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -6683,6 +6683,24 @@
                                 <span class="mono">${extModel.embedding_dim || '-'}</span>
                             </div>
                         </div>
+
+                        <h4 style="margin: 0 0 16px 0; font-size: 16px;">Update API Key</h4>
+                        <div style="background: var(--bg-tertiary); border-radius: var(--radius-md); padding: 16px; margin-bottom: 24px;">
+                            <div style="display: flex; gap: 8px; align-items: center;">
+                                <input type="password" class="form-input" id="model-update-key-${extModel.id}" placeholder="Enter new API key" style="flex: 1;">
+                                <button class="btn btn-primary" onclick="updateModelKey('${extModel.id}')">Update Key</button>
+                            </div>
+                            <div id="model-update-key-status-${extModel.id}" style="margin-top: 8px; font-size: 13px;"></div>
+                        </div>
+
+                        <h4 style="margin: 0 0 16px 0; font-size: 16px;">Quick Health Check</h4>
+                        <div style="background: var(--bg-tertiary); border-radius: var(--radius-md); padding: 16px; margin-bottom: 16px;">
+                            <button class="btn btn-secondary" onclick="testModelHealth('${extModel.id}')" id="model-test-btn-${extModel.id}">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16" style="vertical-align: middle; margin-right: 6px;"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+                                Test Connection
+                            </button>
+                            <div id="model-health-result-${extModel.id}" style="margin-top: 12px;"></div>
+                        </div>
                     `;
                 }
             } else if (currentModelDetailTab === 'health') {
@@ -6791,6 +6809,63 @@
                 loadDgModels();
             } catch (err) {
                 alert('Error: ' + err.message);
+            }
+        }
+
+        async function updateModelKey(modelId) {
+            const input = document.getElementById(`model-update-key-${modelId}`);
+            const status = document.getElementById(`model-update-key-status-${modelId}`);
+            const key = input?.value?.trim();
+            if (!key) { status.innerHTML = '<span style="color:var(--error);">Please enter an API key</span>'; return; }
+            status.innerHTML = '<span style="color:var(--text-tertiary);">Updating...</span>';
+            try {
+                const resp = await apiFetch(`/api/models/${encodeURIComponent(modelId)}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ api_key: key }),
+                });
+                if (resp.ok) {
+                    status.innerHTML = '<span style="color:var(--success);">✓ API key updated. Run Test Connection to verify.</span>';
+                    input.value = '';
+                } else {
+                    const err = await resp.json().catch(() => ({}));
+                    status.innerHTML = `<span style="color:var(--error);">Failed: ${err.detail || resp.statusText}</span>`;
+                }
+            } catch (e) {
+                status.innerHTML = `<span style="color:var(--error);">Error: ${e.message}</span>`;
+            }
+        }
+
+        async function testModelHealth(modelId) {
+            const btn = document.getElementById(`model-test-btn-${modelId}`);
+            const result = document.getElementById(`model-health-result-${modelId}`);
+            if (btn) btn.disabled = true;
+            result.innerHTML = '<span style="color:var(--text-tertiary);">Testing connection...</span>';
+            try {
+                const resp = await apiFetch(`/api/models/${encodeURIComponent(modelId)}/test`, { method: 'POST' });
+                const data = await resp.json();
+                let html = '';
+                const statusColor = data.status === 'healthy' ? 'var(--success)' : data.status === 'warning' ? 'var(--warning)' : 'var(--error)';
+                html += `<div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+                    <span style="display:inline-block;width:10px;height:10px;border-radius:50%;background:${statusColor};"></span>
+                    <span style="font-weight:600;color:${statusColor};text-transform:uppercase;">${data.status}</span>
+                </div>`;
+                for (const chk of (data.checks || [])) {
+                    const icon = chk.status === 'pass' ? '✓' : chk.status === 'warn' ? '⚠' : '✗';
+                    const color = chk.status === 'pass' ? 'var(--success)' : chk.status === 'warn' ? 'var(--warning)' : 'var(--error)';
+                    html += `<div style="display: flex; align-items: center; gap: 8px; padding: 6px 0; font-size: 13px;">
+                        <span style="color:${color};font-weight:bold;width:16px;">${icon}</span>
+                        <span style="min-width:120px;font-weight:500;">${chk.check}</span>
+                        <span style="color:var(--text-tertiary);">${(chk.detail || '').substring(0, 200)}</span>
+                    </div>`;
+                }
+                result.innerHTML = html;
+                // Also refresh health data globally
+                refreshData();
+            } catch (e) {
+                result.innerHTML = `<span style="color:var(--error);">Error: ${e.message}</span>`;
+            } finally {
+                if (btn) btn.disabled = false;
             }
         }
 

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2181,11 +2181,18 @@
                     </div>
                     <div class="form-group">
                         <label class="form-label">Authentication</label>
-                        <select class="form-input" name="auth_type" onchange="toggleAuthFields(this.value)">
-                            <option value="key">API Key</option>
-                            <option value="managed-identity">Managed Identity</option>
-                        </select>
-                        <small style="color: var(--text-tertiary); font-size: 12px;">Use managed identity for keyless access via Azure workload identity</small>
+                        <div style="display: flex; gap: 12px; margin-top: 4px;">
+                            <label style="display: flex; align-items: center; gap: 6px; cursor: pointer; padding: 10px 20px; border-radius: 8px; border: 2px solid var(--accent-primary); background: rgba(99,102,241,0.1); flex: 1; justify-content: center;" id="model-add-auth-key-label">
+                                <input type="radio" name="auth_type" value="key" checked onchange="toggleAuthFields(this.value)">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+                                <span style="font-weight: 500;">API Key</span>
+                            </label>
+                            <label style="display: flex; align-items: center; gap: 6px; cursor: pointer; padding: 10px 20px; border-radius: 8px; border: 2px solid var(--border); background: transparent; flex: 1; justify-content: center;" id="model-add-auth-mi-label">
+                                <input type="radio" name="auth_type" value="managed-identity" onchange="toggleAuthFields(this.value)">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                                <span style="font-weight: 500;">Managed Identity</span>
+                            </label>
+                        </div>
                     </div>
                     <div class="form-group" id="api-key-group">
                         <label class="form-label">API Key</label>
@@ -2194,6 +2201,13 @@
                     <div class="form-group" id="client-id-group" style="display: none;">
                         <label class="form-label">Client ID (optional)</label>
                         <input type="text" class="form-input" name="clientId" placeholder="Managed identity client ID (uses workload identity if empty)">
+                        <div style="background: var(--bg-tertiary); border-radius: 8px; padding: 12px; margin-top: 8px; font-size: 12px;">
+                            <p style="margin: 0 0 8px 0; font-weight: 500; color: var(--text-secondary);">Grant access to your Azure OpenAI resource:</p>
+                            <div style="background: var(--bg-secondary); padding: 8px; border-radius: 4px; font-family: var(--font-mono), monospace; font-size: 11px; overflow-x: auto; white-space: pre-wrap;">az role assignment create \
+  --assignee &lt;managed-identity-client-id&gt; \
+  --role "Cognitive Services OpenAI User" \
+  --scope /subscriptions/.../Microsoft.CognitiveServices/accounts/&lt;name&gt;</div>
+                        </div>
                     </div>
                     <div class="form-group">
                         <label class="form-label">API Version (Azure only)</label>
@@ -6754,7 +6768,21 @@
                                 <div id="model-update-key-status-${extModel.id}" style="margin-top: 8px; font-size: 13px;"></div>
                             </div>
                             <div id="model-auth-mi-section-${extModel.id}" style="display: ${curAuth === 'managed-identity' ? 'block' : 'none'};">
-                                <p style="font-size: 13px; color: var(--text-tertiary); margin: 0 0 12px 0;">Uses Azure Workload Identity. Optionally specify a client ID.</p>
+                                <div style="background: var(--bg-secondary); border-radius: 8px; padding: 16px; margin-bottom: 12px; font-size: 13px;">
+                                    <p style="margin: 0 0 12px 0; font-weight: 500;">Uses Azure Workload Identity — no API key needed.</p>
+                                    <p style="margin: 0 0 12px 0; color: var(--text-secondary);">Grant the AKS managed identity access to your Azure OpenAI resource:</p>
+                                    <div style="font-size: 11px; color: var(--text-tertiary); margin-bottom: 4px;">Bash / Linux:</div>
+                                    <div style="background: var(--bg-tertiary); padding: 12px; border-radius: 6px; margin: 4px 0 8px 0; font-family: var(--font-mono), monospace; font-size: 11px; overflow-x: auto; white-space: pre-wrap;">az role assignment create \\
+  --assignee &lt;managed-identity-client-id&gt; \\
+  --role "Cognitive Services OpenAI User" \\
+  --scope /subscriptions/&lt;sub-id&gt;/resourceGroups/&lt;rg&gt;/providers/Microsoft.CognitiveServices/accounts/&lt;name&gt;</div>
+                                    <div style="font-size: 11px; color: var(--text-tertiary); margin-bottom: 4px;">PowerShell / Windows:</div>
+                                    <div style="background: var(--bg-tertiary); padding: 12px; border-radius: 6px; margin: 4px 0 12px 0; font-family: var(--font-mono), monospace; font-size: 11px; overflow-x: auto; white-space: pre-wrap;">az role assignment create \`
+  --assignee &lt;managed-identity-client-id&gt; \`
+  --role "Cognitive Services OpenAI User" \`
+  --scope /subscriptions/&lt;sub-id&gt;/resourceGroups/&lt;rg&gt;/providers/Microsoft.CognitiveServices/accounts/&lt;name&gt;</div>
+                                    <p style="margin: 0 0 8px 0; color: var(--text-secondary);"><strong>Azure Portal:</strong> Azure OpenAI resource → Access Control (IAM) → Add role assignment → "Cognitive Services OpenAI User" → Assign to your AKS managed identity</p>
+                                </div>
                                 <div style="display: flex; gap: 8px; align-items: center;">
                                     <input type="text" class="form-input" id="model-update-clientid-${extModel.id}" placeholder="Client ID (optional — uses workload identity if empty)" value="${extModel.client_id || ''}" style="flex: 1;">
                                     <button class="btn btn-primary" onclick="updateModelAuth('${extModel.id}', 'managed-identity')">Save</button>
@@ -6959,12 +6987,18 @@
         function toggleAuthFields(authType) {
             const keyGroup = document.getElementById('api-key-group');
             const clientIdGroup = document.getElementById('client-id-group');
+            const keyLabel = document.getElementById('model-add-auth-key-label');
+            const miLabel = document.getElementById('model-add-auth-mi-label');
             if (authType === 'managed-identity') {
                 if (keyGroup) keyGroup.style.display = 'none';
                 if (clientIdGroup) clientIdGroup.style.display = 'block';
+                if (keyLabel) { keyLabel.style.borderColor = 'var(--border)'; keyLabel.style.background = 'transparent'; }
+                if (miLabel) { miLabel.style.borderColor = 'var(--accent-primary)'; miLabel.style.background = 'rgba(34,197,94,0.1)'; }
             } else {
                 if (keyGroup) keyGroup.style.display = 'block';
                 if (clientIdGroup) clientIdGroup.style.display = 'none';
+                if (keyLabel) { keyLabel.style.borderColor = 'var(--accent-primary)'; keyLabel.style.background = 'rgba(99,102,241,0.1)'; }
+                if (miLabel) { miLabel.style.borderColor = 'var(--border)'; miLabel.style.background = 'transparent'; }
             }
         }
 

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2583,20 +2583,20 @@
                 document.getElementById('stat-destinations').textContent = destinations.length;
                 document.getElementById('stat-pipelines').textContent = pipelines.length;
 
-                // Embedded count — prefer live metrics, fallback to pipeline stats
-                const liveEmbedded = metrics.events_processed || 0;
-                let totalSourceDocs = 0;
+                // Embedded count — use pipeline stats for unique docs (not cumulative batch events)
+                let totalSourceDocs = 0, totalEmbedded = 0;
                 let hasSourceData = false;
                 pipelines.filter(p => p.status === 'active').forEach(p => {
                     if (p.stats?.source_doc_count != null) {
                         totalSourceDocs += p.stats.source_doc_count;
                         hasSourceData = true;
                     }
+                    totalEmbedded += p.stats?.embedded_count || 0;
                 });
-                const overallPct = hasSourceData && totalSourceDocs > 0 ? (liveEmbedded / totalSourceDocs * 100).toFixed(1) : null;
-                document.getElementById('stat-events').textContent = liveEmbedded > 0
-                    ? liveEmbedded.toLocaleString() + (hasSourceData ? ' / ' + totalSourceDocs.toLocaleString() : '')
-                    : '--';
+                const overallPct = hasSourceData && totalSourceDocs > 0 ? (totalEmbedded / totalSourceDocs * 100).toFixed(1) : null;
+                document.getElementById('stat-events').textContent = hasSourceData
+                    ? totalEmbedded.toLocaleString() + ' / ' + totalSourceDocs.toLocaleString()
+                    : totalEmbedded > 0 ? totalEmbedded.toLocaleString() : '--';
                 document.getElementById('stat-events-today').textContent = overallPct != null ? overallPct + '% complete' : '';
 
                 // Failed — from live metrics
@@ -6683,53 +6683,66 @@
                                 <span class="mono">${extModel.embedding_dim || '-'}</span>
                             </div>
                         </div>
+                    `;
+                }
+            } else if (currentModelDetailTab === 'health') {
+                const modelId = name;
+                const isExternal = type === 'external';
+                const extModel = isExternal ? dgModels.external[name] : null;
+                const mh = getHealthForModel(name);
 
+                let html = '';
+
+                // Health status banner
+                if (mh) {
+                    html += `
+                        <h4 style="margin: 0 0 20px 0; font-size: 16px;">Health Status</h4>
+                        <div style="background: ${healthStatusBg(mh.status)}; border: 1px solid ${healthStatusColor(mh.status)}33; border-radius: var(--radius-md); padding: 16px; margin-bottom: 24px; display: flex; align-items: center; gap: 12px;">
+                            <span style="display:inline-block;width:12px;height:12px;border-radius:50%;background:${healthStatusColor(mh.status)};"></span>
+                            <span style="font-weight: 600; color: ${healthStatusColor(mh.status)}; text-transform: uppercase;">${mh.status}</span>
+                        </div>
+                        <h4 style="margin: 0 0 16px 0; font-size: 16px;">Checks</h4>
+                        <div style="background: var(--bg-tertiary); border-radius: var(--radius-md); overflow: hidden; margin-bottom: 24px;">`;
+                    for (const chk of (mh.checks || [])) {
+                        html += `<div style="display: flex; align-items: center; gap: 12px; padding: 12px 16px; border-bottom: 1px solid var(--border-subtle);">
+                            ${checkIcon(chk.status)}
+                            <span style="font-weight: 500; min-width: 140px;">${chk.check}</span>
+                            <span style="color: var(--text-tertiary); font-size: 13px;">${chk.detail || ''}</span>
+                        </div>`;
+                    }
+                    html += '</div>';
+                } else {
+                    html += `<div style="text-align: center; padding: 40px; color: var(--text-tertiary); margin-bottom: 24px;">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="48" height="48" style="margin-bottom: 16px; opacity: 0.5;"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+                        <p>No health data yet. Click Test Connection below.</p>
+                    </div>`;
+                }
+
+                // Test Connection button (for all model types)
+                html += `
+                    <h4 style="margin: 0 0 16px 0; font-size: 16px;">Test Connection</h4>
+                    <div style="background: var(--bg-tertiary); border-radius: var(--radius-md); padding: 16px; margin-bottom: 24px;">
+                        <button class="btn btn-primary" onclick="testModelHealth('${modelId}')" id="model-test-btn-${modelId}">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16" style="vertical-align: middle; margin-right: 6px;"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+                            Test Connection
+                        </button>
+                        <div id="model-health-result-${modelId}" style="margin-top: 12px;"></div>
+                    </div>`;
+
+                // Update API Key section (only for external models with key auth)
+                if (isExternal && extModel && extModel.auth_type !== 'managed-identity') {
+                    html += `
                         <h4 style="margin: 0 0 16px 0; font-size: 16px;">Update API Key</h4>
-                        <div style="background: var(--bg-tertiary); border-radius: var(--radius-md); padding: 16px; margin-bottom: 24px;">
+                        <div style="background: var(--bg-tertiary); border-radius: var(--radius-md); padding: 16px;">
+                            <p style="font-size: 13px; color: var(--text-tertiary); margin: 0 0 12px 0;">If authentication is failing, update the API key and test again.</p>
                             <div style="display: flex; gap: 8px; align-items: center;">
                                 <input type="password" class="form-input" id="model-update-key-${extModel.id}" placeholder="Enter new API key" style="flex: 1;">
                                 <button class="btn btn-primary" onclick="updateModelKey('${extModel.id}')">Update Key</button>
                             </div>
                             <div id="model-update-key-status-${extModel.id}" style="margin-top: 8px; font-size: 13px;"></div>
-                        </div>
+                        </div>`;
+                }
 
-                        <h4 style="margin: 0 0 16px 0; font-size: 16px;">Quick Health Check</h4>
-                        <div style="background: var(--bg-tertiary); border-radius: var(--radius-md); padding: 16px; margin-bottom: 16px;">
-                            <button class="btn btn-secondary" onclick="testModelHealth('${extModel.id}')" id="model-test-btn-${extModel.id}">
-                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16" style="vertical-align: middle; margin-right: 6px;"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
-                                Test Connection
-                            </button>
-                            <div id="model-health-result-${extModel.id}" style="margin-top: 12px;"></div>
-                        </div>
-                    `;
-                }
-            } else if (currentModelDetailTab === 'health') {
-                const mh = getHealthForModel(name);
-                if (!mh) {
-                    body.innerHTML = `<div style="text-align: center; padding: 60px; color: var(--text-tertiary);">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="48" height="48" style="margin-bottom: 16px; opacity: 0.5;"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
-                        <p>No health data available for this model.</p>
-                        <p style="font-size: 12px; margin-top: 8px;">Run a health check from the Health tab to see results.</p>
-                    </div>`;
-                    return;
-                }
-                let html = `
-                    <h4 style="margin: 0 0 20px 0; font-size: 16px;">Health Status</h4>
-                    <div style="background: ${healthStatusBg(mh.status)}; border: 1px solid ${healthStatusColor(mh.status)}33; border-radius: var(--radius-md); padding: 16px; margin-bottom: 24px; display: flex; align-items: center; gap: 12px;">
-                        <span style="display:inline-block;width:12px;height:12px;border-radius:50%;background:${healthStatusColor(mh.status)};"></span>
-                        <span style="font-weight: 600; color: ${healthStatusColor(mh.status)}; text-transform: uppercase;">${mh.status}</span>
-                    </div>
-                    <h4 style="margin: 0 0 16px 0; font-size: 16px;">Checks</h4>
-                    <div style="background: var(--bg-tertiary); border-radius: var(--radius-md); overflow: hidden;">
-                `;
-                for (const chk of (mh.checks || [])) {
-                    html += `<div style="display: flex; align-items: center; gap: 12px; padding: 12px 16px; border-bottom: 1px solid var(--border-subtle);">
-                        ${checkIcon(chk.status)}
-                        <span style="font-weight: 500; min-width: 140px;">${chk.check}</span>
-                        <span style="color: var(--text-tertiary); font-size: 13px;">${chk.detail || ''}</span>
-                    </div>`;
-                }
-                html += '</div>';
                 body.innerHTML = html;
             } else if (currentModelDetailTab === 'logs') {
                 body.innerHTML = `<div style="text-align: center; padding: 40px; color: var(--text-tertiary);">Loading logs...</div>`;

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -7991,7 +7991,7 @@
             let url = `/api/metrics/timeseries?granularity=${metricsGranularity}&start=${start}&end=${end}`;
             if (metricsPipelineFilter) url += `&pipeline_id=${metricsPipelineFilter}`;
             try {
-                const resp = await fetch(url);
+                const resp = await apiFetch(url);
                 const data = await resp.json();
                 renderMetricsSection(data);
             } catch (e) {


### PR DESCRIPTION
## Problem
Unix/Linux users report that \zd up\ hangs after SKU selection completes and availability is displayed. The script appears to freeze with no further progress.

## Root Cause
When \zd\ runs hook scripts, stdin is piped from azd (not from the terminal). Child processes like \z vm list-skus\, \zd env set\, and \z account show\ inherit this piped stdin and can **consume buffered input**. After these commands run, subsequent \ead_input()\ calls find stdin depleted/EOF and hang indefinitely.

## Fix
Two changes applied to both \preprovision.sh\ and \postprovision.sh\:

1. **\ead_input()\ now always prefers \/dev/tty\** — bypasses piped stdin entirely. Previous logic checked \[ -t 0 ]\ first (always false in azd hooks), making it unreliable.

2. **All \z\/\zd\ CLI calls now use \< /dev/null\** — prevents them from consuming the piped stdin buffer. Covers: \z vm list-skus\, \z account show\, \z group show/exists\, \zd env get-value\, \zd env set\, \z aks install-cli\.

## Testing
- Verified script syntax with shellcheck patterns
- \ead_input()\ correctly reads from \/dev/tty\ when available (all Linux/macOS systems)
- Falls back gracefully when no TTY exists (CI/CD pipelines)