### PR TITLE
feat: grant AKS identity Log Analytics Reader for metrics queries

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -144,6 +144,7 @@ module appinsights 'modules/appinsights.bicep' = {
     appInsightsName: '${prefix}-insights-${resourceToken}'
     location: location
     tags: tags
+    principalId: aks.outputs.kubeletIdentityObjectId
   }
 }
 

--- a/infra/modules/appinsights.bicep
+++ b/infra/modules/appinsights.bicep
@@ -3,6 +3,7 @@ param workspaceName string
 param appInsightsName string
 param location string
 param tags object = {}
+param principalId string = ''  // AKS managed identity to grant Log Analytics Reader
 
 resource workspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
   name: workspaceName
@@ -27,6 +28,17 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
     IngestionMode: 'LogAnalytics'
     publicNetworkAccessForIngestion: 'Enabled'
     publicNetworkAccessForQuery: 'Enabled'
+  }
+}
+
+// Grant Log Analytics Reader so API can query metrics
+resource logAnalyticsReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(principalId)) {
+  name: guid(workspace.id, principalId, 'log-analytics-reader')
+  scope: workspace
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '73c42c96-874c-492b-b04d-ab87d138a893') // Log Analytics Reader
+    principalId: principalId
+    principalType: 'ServicePrincipal'
   }
 }
 


### PR DESCRIPTION
## What
Grants the AKS kubelet managed identity **Log Analytics Reader** role on the Log Analytics workspace so the API pod can query App Insights metrics.

## Changes
- **infra/main.bicep**: Pass \principalId\ (AKS kubelet identity) to appinsights module
- **infra/modules/appinsights.bicep**: Add conditional role assignment for Log Analytics Reader (only created when principalId is non-empty)

## Why
Without this role, the API cannot query App Insights / Log Analytics for metrics data, causing the metrics page to fall back to CosmosDB inline metrics only.