### PR TITLE
harden(azd-up): a2 no-TTY fast-fail + a4 stdin-guards on nested tools

### DIFF
--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -156,7 +156,7 @@ IMAGES="omnivec-api omnivec-web omnivec-changefeed omnivec-dotnet-worker docgrok
 image_exists() {
   name=$1
   tag=$2
-  existing=$(az acr repository show-tags --name "$ACR_NAME" --repository "$name" --query "[?@ == '$tag']" -o tsv 2>/dev/null || true)
+  existing=$(az acr repository show-tags --name "$ACR_NAME" --repository "$name" --query "[?@ == '$tag']" -o tsv </dev/null 2>/dev/null || true)
   [ -n "$existing" ]
 }
 
@@ -165,10 +165,10 @@ image_up_to_date() {
   name=$1
   tag=$2
   # Get digest from local ACR
-  local_digest=$(az acr manifest show-metadata --registry "$ACR_NAME" --name "${name}:${tag}" --query "digest" -o tsv 2>/dev/null || true)
+  local_digest=$(az acr manifest show-metadata --registry "$ACR_NAME" --name "${name}:${tag}" --query "digest" -o tsv </dev/null 2>/dev/null || true)
   if [ -z "$local_digest" ]; then return 1; fi
   # Get digest from shared registry
-  shared_digest=$(az acr manifest show-metadata --registry "omnivecregistry" --name "${name}:${tag}" --query "digest" -o tsv 2>/dev/null || true)
+  shared_digest=$(az acr manifest show-metadata --registry "omnivecregistry" --name "${name}:${tag}" --query "digest" -o tsv </dev/null 2>/dev/null || true)
   if [ -z "$shared_digest" ]; then return 1; fi
   [ "$local_digest" = "$shared_digest" ]
 }
@@ -190,8 +190,8 @@ build_image() {
     docker build -t "${ACR_LOGIN_SERVER}/${name}:${tag}" -f "$dockerfile" "$context"
     docker push "${ACR_LOGIN_SERVER}/${name}:${tag}"
   else
-    az acr build --registry "$ACR_NAME" --image "${name}:${tag}" --file "$dockerfile" "$context" --no-logs 2>/dev/null || \
-    az acr build --registry "$ACR_NAME" --image "${name}:${tag}" --file "$dockerfile" "$context"
+    az acr build --registry "$ACR_NAME" --image "${name}:${tag}" --file "$dockerfile" "$context" --no-logs </dev/null 2>/dev/null || \
+    az acr build --registry "$ACR_NAME" --image "${name}:${tag}" --file "$dockerfile" "$context" </dev/null
   fi
   printf "  ${GREEN}${name}:${tag} pushed.${NC}\n"
 }
@@ -267,7 +267,7 @@ if [ "$OMNIVEC_BUILD" != "true" ]; then
       if [ -n "$_new_token" ]; then
         if az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:latest" --image "${FIRST_IMAGE}:latest" --username "$SHARED_REGISTRY_USER" --password "$_new_token" --force >/dev/null 2>&1; then
           SHARED_REGISTRY_TOKEN="$_new_token"
-          azd env set OMNIVEC_SHARED_REGISTRY_TOKEN "$_new_token" 2>/dev/null || true
+          azd env set OMNIVEC_SHARED_REGISTRY_TOKEN "$_new_token" </dev/null 2>/dev/null || true
           printf "  ${GREEN}Token valid — saved for future use.${NC}\n"
           TOKEN_OK=true
         else
@@ -433,7 +433,7 @@ elif [ ! -f "$HOME/.kube/config" ]; then
 fi
 
 export KUBE_CONTEXT
-kubectl --context "$KUBE_CONTEXT" get nodes >/dev/null
+kubectl --context "$KUBE_CONTEXT" get nodes </dev/null >/dev/null
 printf "${GREEN}Connected to AKS cluster: ${AKS_CLUSTER} (context: ${KUBE_CONTEXT})${NC}\n"
 
 # =============================================================================
@@ -443,10 +443,10 @@ printf "${GREEN}Connected to AKS cluster: ${AKS_CLUSTER} (context: ${KUBE_CONTEX
 printf "\n${YELLOW}Phase 3: Creating namespaces and secrets...${NC}\n"
 
 # Create namespaces and label for Helm ownership
-kubectl --context "$KUBE_CONTEXT" create namespace omnivec 2>/dev/null || true
-kubectl --context "$KUBE_CONTEXT" create namespace docgrok 2>/dev/null || true
-kubectl --context "$KUBE_CONTEXT" label namespace omnivec app.kubernetes.io/managed-by=Helm --overwrite
-kubectl --context "$KUBE_CONTEXT" annotate namespace omnivec meta.helm.sh/release-name=omnivec meta.helm.sh/release-namespace=omnivec --overwrite
+kubectl --context "$KUBE_CONTEXT" create namespace omnivec </dev/null 2>/dev/null || true
+kubectl --context "$KUBE_CONTEXT" create namespace docgrok </dev/null 2>/dev/null || true
+kubectl --context "$KUBE_CONTEXT" label namespace omnivec app.kubernetes.io/managed-by=Helm --overwrite </dev/null
+kubectl --context "$KUBE_CONTEXT" annotate namespace omnivec meta.helm.sh/release-name=omnivec meta.helm.sh/release-namespace=omnivec --overwrite </dev/null
 
 # Storage connection string secret (only when blob source is enabled)
 if [ "$ENABLE_BLOB_SOURCE" = "true" ]; then
@@ -482,7 +482,7 @@ if [ -n "$CURRENT_HASH" ] && [ "$CURRENT_HASH" = "$CACHED_HASH" ]; then
   printf "  ${GREEN}Helm dependencies up to date, skipping.${NC}\n"
 else
   printf "  ${CYAN}Resolving helm dependencies...${NC}\n"
-  helm dependency build "$CHART_DIR" 2>/dev/null
+  helm dependency build "$CHART_DIR" </dev/null 2>/dev/null
   if [ -n "$CURRENT_HASH" ]; then
     echo "$CURRENT_HASH" > "$LOCK_HASH_FILE"
   fi
@@ -493,7 +493,7 @@ fi
 ADMIN_TOKEN=$(get_azd_value "OMNIVEC_ADMIN_TOKEN")
 if [ -z "$ADMIN_TOKEN" ]; then
   ADMIN_TOKEN=$(head -c 32 /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c 44)
-  azd env set OMNIVEC_ADMIN_TOKEN "$ADMIN_TOKEN"
+  azd env set OMNIVEC_ADMIN_TOKEN "$ADMIN_TOKEN" </dev/null
   printf "  ${GREEN}Generated new admin token.${NC}\n"
 else
   printf "  ${GREEN}Using existing admin token.${NC}\n"
@@ -590,18 +590,18 @@ run_helm_deploy() {
 
 # Detect stuck Helm release (pending-install / pending-upgrade from interrupted deploy)
 set +e
-_helm_status=$(helm status omnivec -n omnivec --kube-context "$KUBE_CONTEXT" -o json 2>/dev/null)
+_helm_status=$(helm status omnivec -n omnivec --kube-context "$KUBE_CONTEXT" -o json </dev/null 2>/dev/null)
 _helm_phase=$(echo "$_helm_status" | grep -o '"status":"pending-[^"]*"' | head -1 | cut -d'"' -f4)
 set -e
 if [ -n "$_helm_phase" ]; then
   printf "${YELLOW}Detected stuck Helm release (status: ${_helm_phase}). Rolling back...${NC}\n"
   set +e
-  helm rollback omnivec -n omnivec --kube-context "$KUBE_CONTEXT" 2>/dev/null
+  helm rollback omnivec -n omnivec --kube-context "$KUBE_CONTEXT" </dev/null 2>/dev/null
   _rb_rc=$?
   set -e
   if [ "$_rb_rc" -ne 0 ]; then
     printf "${YELLOW}Rollback failed — uninstalling stuck release...${NC}\n"
-    helm uninstall omnivec -n omnivec --kube-context "$KUBE_CONTEXT" 2>/dev/null || true
+    helm uninstall omnivec -n omnivec --kube-context "$KUBE_CONTEXT" </dev/null 2>/dev/null || true
   fi
   printf "${GREEN}Stuck release cleared. Proceeding with fresh deploy.${NC}\n"
 fi
@@ -617,15 +617,17 @@ rm -f "$HELM_VALUES_FILE"
 
 if [ "$helm_rc" -ne 0 ]; then
   printf "${RED}Helm deploy failed. Collecting pod diagnostics...${NC}\n"
-  kubectl --context "$KUBE_CONTEXT" get pods -n omnivec -o wide || true
-  kubectl --context "$KUBE_CONTEXT" get pods -n omnivec --no-headers 2>/dev/null | while read -r line; do
+  kubectl --context "$KUBE_CONTEXT" get pods -n omnivec -o wide </dev/null || true
+  kubectl --context "$KUBE_CONTEXT" get pods -n omnivec --no-headers </dev/null 2>/dev/null | while read -r line; do
     pod=$(echo "$line" | awk '{print $1}')
     status=$(echo "$line" | awk '{print $3}')
     case "$status" in
       ImagePullBackOff|ErrImagePull|CrashLoopBackOff|Error|Pending)
         printf "\n${YELLOW}=== %s (%s) ===${NC}\n" "$pod" "$status"
-        kubectl --context "$KUBE_CONTEXT" describe pod "$pod" -n omnivec | sed -n '/Events:/,$p' || true
-        kubectl --context "$KUBE_CONTEXT" logs "$pod" -n omnivec --tail=80 || true
+        # CRITICAL: inner kubectl calls need </dev/null inside while-read loop,
+        # otherwise they consume the outer pipe's stdin and break the loop.
+        kubectl --context "$KUBE_CONTEXT" describe pod "$pod" -n omnivec </dev/null | sed -n '/Events:/,$p' || true
+        kubectl --context "$KUBE_CONTEXT" logs "$pod" -n omnivec --tail=80 </dev/null || true
         ;;
     esac
   done
@@ -637,8 +639,8 @@ printf "${GREEN}Helm deployment complete.${NC}\n"
 # Force pod restart if images were updated (tag is always 'latest', so Helm won't restart on its own)
 if [ "$IMAGES_CHANGED" = "true" ]; then
   printf "\n${YELLOW}Images updated — restarting pods to pull new images...${NC}\n"
-  kubectl --context "$KUBE_CONTEXT" rollout restart deployment -n omnivec 2>/dev/null || true
-  kubectl --context "$KUBE_CONTEXT" rollout status deployment/omnivec-api -n omnivec --timeout=5m 2>/dev/null || true
+  kubectl --context "$KUBE_CONTEXT" rollout restart deployment -n omnivec </dev/null 2>/dev/null || true
+  kubectl --context "$KUBE_CONTEXT" rollout status deployment/omnivec-api -n omnivec --timeout=5m </dev/null 2>/dev/null || true
   printf "${GREEN}Pods restarted with new images.${NC}\n"
 fi
 
@@ -649,18 +651,18 @@ fi
 printf "\n${YELLOW}Phase 5: Verifying deployment...${NC}\n"
 
 printf "\n${CYAN}OmniVec pods:${NC}\n"
-kubectl --context "$KUBE_CONTEXT" get pods -n omnivec --no-headers 2>/dev/null || true
+kubectl --context "$KUBE_CONTEXT" get pods -n omnivec --no-headers </dev/null 2>/dev/null || true
 
 printf "\n${CYAN}DocGrok pods:${NC}\n"
-kubectl --context "$KUBE_CONTEXT" get pods -n omnivec -l app=docgrok --no-headers 2>/dev/null || true
-kubectl --context "$KUBE_CONTEXT" get pods -n omnivec -l app=docgrok-controller --no-headers 2>/dev/null || true
+kubectl --context "$KUBE_CONTEXT" get pods -n omnivec -l app=docgrok --no-headers </dev/null 2>/dev/null || true
+kubectl --context "$KUBE_CONTEXT" get pods -n omnivec -l app=docgrok-controller --no-headers </dev/null 2>/dev/null || true
 
 # Wait for external IP
 printf "\n${YELLOW}Waiting for external IP...${NC}\n"
 EXTERNAL_IP=""
 i=0
 while [ $i -lt 30 ]; do
-  EXTERNAL_IP=$(kubectl --context "$KUBE_CONTEXT" get svc omnivec-web -n omnivec -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+  EXTERNAL_IP=$(kubectl --context "$KUBE_CONTEXT" get svc omnivec-web -n omnivec -o jsonpath='{.status.loadBalancer.ingress[0].ip}' </dev/null 2>/dev/null || true)
   if [ -n "$EXTERNAL_IP" ]; then
     break
   fi

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -63,23 +63,83 @@ azd_get() {
   _val=$(azd env get-value "$1" < /dev/null 2>/dev/null) && printf '%s' "$_val" | tr -d '\r' || printf ''
 }
 
+# Helper: can we actually prompt the user right now?
+# Tries /dev/tty first (most reliable: even if stdin is redirected, the hook
+# may still have a controlling terminal we can write prompts to). Falls back
+# to stdin-is-a-tty. Respects OMNIVEC_FORCE_NO_TTY for tests / CI simulation.
+_can_prompt() {
+  [ -n "${OMNIVEC_FORCE_NO_TTY:-}" ] && return 1
+  if [ -e /dev/tty ] && ( : >/dev/tty ) 2>/dev/null && ( : </dev/tty ) 2>/dev/null; then
+    return 0
+  fi
+  [ -t 0 ] && return 0
+  return 1
+}
+
 # Helper: read user input from TTY (works in hook context where stdin may be redirected)
+# Returns empty string when no TTY is available — callers must fall back to
+# defaults OR pre-check with _can_prompt to fast-fail before calling this.
 read_input() {
   _prompt=$1
   _input=""
-  # Always prefer /dev/tty — azd hooks have stdin piped from azd, so stdin
-  # may be consumed by child processes (az cli, etc.) causing hangs.
-  if [ -e /dev/tty ]; then
-    printf '%b' "$_prompt" > /dev/tty
-    read -r _input < /dev/tty || true
-  elif [ -t 0 ]; then
-    printf '%b' "$_prompt"
-    read -r _input || true
-  else
-    # No TTY at all — return empty (caller uses default)
-    _input=""
+  if _can_prompt; then
+    if [ -e /dev/tty ] && ( : >/dev/tty ) 2>/dev/null; then
+      printf '%b' "$_prompt" > /dev/tty
+      read -r _input < /dev/tty 2>/dev/null || true
+    else
+      printf '%b' "$_prompt"
+      read -r _input || true
+    fi
   fi
   printf '%s' "$_input"
+}
+
+# a2: Detect non-interactive mode from several common sources. Users (and CI)
+# commonly set one of these; we honor any of them.
+is_noninteractive() {
+  case "${OMNIVEC_NONINTERACTIVE:-}${AZD_NONINTERACTIVE:-}${CI:-}${GITHUB_ACTIONS:-}" in
+    '') return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# a2: Apply Quick-start defaults to azd env. Used when non-interactive and no
+# preset config exists, to give a predictable fallback instead of silently
+# accepting empty/garbage input.
+apply_quickstart_defaults() {
+  printf "  ${GREEN}Applying Quick-start defaults (non-interactive mode).${NC}\n"
+  azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE "Standard_B4ms" < /dev/null
+  azd env set OMNIVEC_SYSTEM_NODE_COUNT   "2" < /dev/null
+  azd env set OMNIVEC_GPU_NODE_VM_SIZE    "" < /dev/null
+  azd env set OMNIVEC_GPU_NODE_COUNT      "0" < /dev/null
+  azd env set OMNIVEC_METADATA_STORE      "cosmosdb-serverless" < /dev/null
+  azd env set OMNIVEC_ENABLE_BLOB_SOURCE  "true" < /dev/null
+}
+
+# a2: Fail fast when we would need to prompt but can't. Far better than a
+# silent 10-minute deploy with surprise defaults.
+require_tty_or_preset() {
+  if _can_prompt; then
+    return 0
+  fi
+  if is_noninteractive; then
+    apply_quickstart_defaults
+    printf "\n${GREEN}Pre-provision checks passed (non-interactive). Proceeding with Bicep deployment...${NC}\n"
+    exit 0
+  fi
+  printf "\n${RED}ERROR: No TTY and no configuration found.${NC}\n" >&2
+  printf "  azd hooks run this script without an interactive terminal (common in CI,\n" >&2
+  printf "  Docker, nohup, or piped shells), and no configuration has been pre-set.\n" >&2
+  printf "\n  Fix with ONE of:\n" >&2
+  printf "    1) Run interactively:  azd up  (from a real terminal)\n" >&2
+  printf "    2) Accept defaults:    OMNIVEC_NONINTERACTIVE=1 azd up\n" >&2
+  printf "    3) Pre-set config, e.g.:\n" >&2
+  printf "         azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE Standard_B4ms\n" >&2
+  printf "         azd env set OMNIVEC_SYSTEM_NODE_COUNT 2\n" >&2
+  printf "         azd env set OMNIVEC_GPU_NODE_COUNT 0\n" >&2
+  printf "         azd env set OMNIVEC_ENABLE_BLOB_SOURCE true\n" >&2
+  printf "         azd env set OMNIVEC_METADATA_STORE cosmosdb-serverless\n" >&2
+  exit 1
 }
 
 DEPLOYMENT_DETECTED=false
@@ -118,7 +178,7 @@ if ! command -v helm >/dev/null 2>&1; then
   HELM_INSTALL_DIR="${HOME}/.local/bin"
   mkdir -p "$HELM_INSTALL_DIR"
   export PATH="$HELM_INSTALL_DIR:$PATH"
-  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | HELM_INSTALL_DIR="$HELM_INSTALL_DIR" USE_SUDO="false" sh 2>/dev/null || true
+  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 </dev/null | HELM_INSTALL_DIR="$HELM_INSTALL_DIR" USE_SUDO="false" sh </dev/null 2>/dev/null || true
   if ! command -v helm >/dev/null 2>&1; then
     printf "  ${RED}Failed to install helm. Install manually: https://helm.sh/docs/intro/install/${NC}\n"
     exit 1
@@ -135,7 +195,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 if [ ! -f "$REPO_ROOT/docgrok/Dockerfile" ]; then
   printf "  ${YELLOW}Initializing git submodules...${NC}\n"
-  (cd "$REPO_ROOT" && git submodule update --init --recursive 2>/dev/null) || true
+  (cd "$REPO_ROOT" && git submodule update --init --recursive </dev/null 2>/dev/null) || true
 fi
 
 # ── Validate Azure login ────────────────────────────────────────────────────
@@ -187,6 +247,11 @@ if [ -n "$_existing_vm" ]; then
 fi
 
 # ── Fresh deploy: offer auto-defaults or interactive ─────────────────────────
+# a2: If we have no preset config AND no TTY, fail fast with a clear error
+# (or auto-apply Quick-start if OMNIVEC_NONINTERACTIVE / CI is set).
+# Must run BEFORE the first read_input.
+require_tty_or_preset
+
 echo ""
 printf "${YELLOW}No configuration found. Choose setup mode:${NC}\n"
 echo "  1) Quick start — use recommended defaults (fastest, no GPU)"

--- a/tests/hooks/test-no-tty.sh
+++ b/tests/hooks/test-no-tty.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+# Functional test for a2 (no-TTY fast-fail + non-interactive mode).
+#
+# We can't run the real preprovision.sh here (it would need az login, azd,
+# a real Azure subscription, etc.), so we extract the a2 helpers into a
+# stub harness, stub out azd/az, and assert behavior under three stdin
+# configurations:
+#   1. TTY attached           → helpers allow continuation
+#   2. No TTY, NONINTERACTIVE → helpers auto-apply defaults and exit 0
+#   3. No TTY, no NONINTERACTIVE → helpers fail fast with clear error
+#
+# Works under dash, bash, sh.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+PREPROVISION="$REPO_ROOT/hooks/preprovision.sh"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; }
+
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t omnivec-a2)
+trap 'rm -rf "$TMP"' EXIT
+
+printf '\n=== a2: no-TTY / non-interactive tests ===\n'
+
+# Verify helpers exist in preprovision.sh (catches refactoring regressions).
+for fn in require_tty_or_preset is_noninteractive apply_quickstart_defaults; do
+    if grep -q "^${fn}()" "$PREPROVISION" 2>/dev/null \
+    || grep -q "^${fn}()[[:space:]]*{" "$PREPROVISION" 2>/dev/null; then
+        pass "preprovision.sh defines ${fn}()"
+    else
+        fail "preprovision.sh missing ${fn}()"
+    fi
+done
+
+# Extract the three helpers into a fragment we can source in isolation.
+# They occupy a contiguous block near the top of the file.
+python_or_awk_extract() {
+    # Extract _can_prompt + is_noninteractive + apply_quickstart_defaults +
+    # require_tty_or_preset from preprovision.sh. Single-print state machine.
+    awk '
+        /^_can_prompt\(\)/             { inblock=1 }
+        /^require_tty_or_preset\(\)/   { inrt=1 }
+        inblock { print }
+        inrt && /^}[[:space:]]*$/      { exit }
+    ' "$PREPROVISION"
+}
+
+FRAG="$TMP/a2.sh"
+{
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'set -u'
+    # Color vars used inside helpers.
+    printf '%s\n' 'GREEN="" RED="" YELLOW="" CYAN="" NC=""'
+    # Stub azd: record env sets into $TMP/azdenv.
+    printf '%s\n' 'azd() {'
+    printf '%s\n' '  if [ "$1" = "env" ] && [ "$2" = "set" ]; then'
+    printf '%s\n' '    printf "%s=%s\n" "$3" "$4" >> "$AZDENV_FILE"'
+    printf '%s\n' '    return 0'
+    printf '%s\n' '  fi'
+    printf '%s\n' '  return 0'
+    printf '%s\n' '}'
+    python_or_awk_extract
+} > "$FRAG"
+
+# Sanity: fragment extracted and parses.
+if sh -n "$FRAG" 2>"$TMP/syn.err"; then
+    pass "extracted helper fragment parses cleanly"
+else
+    fail "helper fragment syntax error" "$(cat "$TMP/syn.err")"
+fi
+
+# --- Case 1: non-interactive mode applies Quick-start defaults ---
+(
+    export AZDENV_FILE="$TMP/env1"
+    : > "$AZDENV_FILE"
+    export OMNIVEC_NONINTERACTIVE=1
+    export OMNIVEC_FORCE_NO_TTY=1
+    out=$(sh -c ". $FRAG; require_tty_or_preset; echo POSTCALL" </dev/null 2>&1)
+    rc=$?
+    if [ "$rc" -eq 0 ] \
+       && ! printf '%s' "$out" | grep -q POSTCALL \
+       && grep -q 'OMNIVEC_SYSTEM_NODE_VM_SIZE=Standard_B4ms' "$AZDENV_FILE" \
+       && grep -q 'OMNIVEC_ENABLE_BLOB_SOURCE=true' "$AZDENV_FILE"; then
+        exit 0
+    fi
+    printf 'rc=%s\nout=%s\nenv=%s\n' "$rc" "$out" "$(cat "$AZDENV_FILE")" >&2
+    exit 1
+) && pass "OMNIVEC_NONINTERACTIVE=1 + no TTY → auto-applies defaults and exits 0" \
+  || fail "non-interactive mode"
+
+# --- Case 2: CI=true also triggers non-interactive ---
+(
+    export AZDENV_FILE="$TMP/env2"
+    : > "$AZDENV_FILE"
+    unset OMNIVEC_NONINTERACTIVE AZD_NONINTERACTIVE GITHUB_ACTIONS
+    export CI=true
+    export OMNIVEC_FORCE_NO_TTY=1
+    out=$(sh -c ". $FRAG; require_tty_or_preset; echo POSTCALL" </dev/null 2>&1)
+    rc=$?
+    if [ "$rc" -eq 0 ] && grep -q 'OMNIVEC_GPU_NODE_COUNT=0' "$AZDENV_FILE"; then
+        exit 0
+    fi
+    printf 'rc=%s\nout=%s\n' "$rc" "$out" >&2
+    exit 1
+) && pass "CI=true + no TTY → auto-applies defaults" \
+  || fail "CI env triggers non-interactive"
+
+# --- Case 3: No TTY, no flag → fast fail with helpful message ---
+(
+    export AZDENV_FILE="$TMP/env3"
+    : > "$AZDENV_FILE"
+    unset OMNIVEC_NONINTERACTIVE AZD_NONINTERACTIVE CI GITHUB_ACTIONS
+    export OMNIVEC_FORCE_NO_TTY=1
+    out=$(sh -c ". $FRAG; require_tty_or_preset; echo POSTCALL" </dev/null 2>&1)
+    rc=$?
+    if [ "$rc" -ne 0 ] \
+       && ! printf '%s' "$out" | grep -q POSTCALL \
+       && printf '%s' "$out" | grep -q 'No TTY' \
+       && printf '%s' "$out" | grep -q 'OMNIVEC_NONINTERACTIVE' \
+       && printf '%s' "$out" | grep -q 'azd env set'; then
+        exit 0
+    fi
+    printf 'rc=%s\nout=%s\n' "$rc" "$out" >&2
+    exit 1
+) && pass "No TTY + no flag → exits non-zero with actionable error" \
+  || fail "no-TTY fast-fail"
+
+# --- Case 4: read_input returns empty when no TTY and doesn't hang ---
+(
+    awk '
+        /^_can_prompt\(\)/ { inblock=1 }
+        /^read_input\(\)/  { inri=1 }
+        inblock { print }
+        inri && /^}[[:space:]]*$/ { exit }
+    ' "$PREPROVISION" > "$TMP/readinput.sh"
+    {
+        printf '%s\n' '#!/bin/sh'
+        printf '%s\n' 'set -u'
+        cat "$TMP/readinput.sh"
+        printf '%s\n' 'val=$(read_input "prompt: ")'
+        printf '%s\n' 'printf "RESULT=[%s]\n" "$val"'
+    } > "$TMP/ri-driver.sh"
+    out=$(OMNIVEC_FORCE_NO_TTY=1 sh "$TMP/ri-driver.sh" </dev/null 2>&1)
+    rc=$?
+    if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q 'RESULT=\[\]'; then
+        exit 0
+    fi
+    printf 'rc=%s\nout=%s\n' "$rc" "$out" >&2
+    exit 1
+) && pass "read_input with no TTY returns empty string without hanging" \
+  || fail "read_input no-TTY behavior"
+
+# --- Case 5: stdin-guard on get-helm-3 curl|sh line ---
+if grep -q 'get-helm-3.*</dev/null.*| .*sh .*</dev/null' "$PREPROVISION"; then
+    pass "helm install pipeline has </dev/null on both curl and sh"
+else
+    fail "helm install pipeline missing </dev/null guards"
+fi
+
+# --- Case 6: git submodule update has stdin guard ---
+if grep -q 'git submodule update.*</dev/null' "$PREPROVISION"; then
+    pass "git submodule update has </dev/null"
+else
+    fail "git submodule update missing </dev/null"
+fi
+
+# --- Case 7: kubectl calls inside while-read loop in postprovision have guards ---
+POSTP="$REPO_ROOT/hooks/postprovision.sh"
+if [ -f "$POSTP" ]; then
+    # Expect BOTH `describe pod` and `logs` inside the failure-diagnostic loop
+    # to have explicit </dev/null, to prevent pipe-stdin collision.
+    if grep -q 'kubectl.*describe pod.*</dev/null' "$POSTP" \
+       && grep -q 'kubectl.*logs.*--tail=80.*</dev/null' "$POSTP"; then
+        pass "postprovision while-read loop: inner kubectl calls have </dev/null"
+    else
+        fail "postprovision inner kubectl calls missing </dev/null (breaks loop)"
+    fi
+fi
+
+printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/tests/hooks/test-stdin-guards.sh
+++ b/tests/hooks/test-stdin-guards.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# Static-analysis regression test for a4 (stdin guards).
+#
+# Azd hooks run with stdin piped from azd. Nested `az`/`azd`/`kubectl`/`helm`/
+# `git`/`curl` calls inherit that stdin unless explicitly redirected. Without
+# `</dev/null` they can:
+#   - consume the hook's own stdin (eating pipe data in while-read loops)
+#   - hang waiting for input on prompts that never come
+#
+# Emit a line for each call site that lacks a stdin redirection OR a
+# `# stdin-ok` opt-out marker. Fail if any found. Known-safe patterns
+# (right-hand side of `|`, `apply -f -`, comments, heredocs) are skipped.
+#
+# Works under dash, bash, sh.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; }
+
+printf '\n=== stdin-guard static analysis ===\n'
+
+issues_file=$(mktemp 2>/dev/null || mktemp -t stdin-scan)
+trap 'rm -f "$issues_file"' EXIT
+
+for f in "$REPO_ROOT"/hooks/*.sh; do
+    [ -f "$f" ] || continue
+    rel=${f#$REPO_ROOT/}
+    printf '  scanning %s\n' "$rel"
+
+    # awk pipeline: emit risky lines only. Much faster than a pure-shell loop.
+    awk -v REL="$rel" '
+        # Strip leading whitespace for prefix checks.
+        {
+            line = $0
+            stripped = line
+            sub(/^[ \t]+/, "", stripped)
+        }
+
+        # Skip comments / blanks.
+        stripped == "" { next }
+        stripped ~ /^#/ { next }
+
+        # Skip if explicit opt-out marker or existing stdin redirect is present.
+        line ~ /# stdin-ok/        { next }
+        line ~ /<[ ]*\/dev\/null/  { next }
+        line ~ /<</               { next }
+
+        # Skip common stdin-is-the-input patterns.
+        line ~ /apply[ ]+-f[ ]+-/    { next }
+        line ~ /create[ ]+-f[ ]+-/   { next }
+        line ~ /replace[ ]+-f[ ]+-/  { next }
+        line ~ /delete[ ]+-f[ ]+-/   { next }
+
+        # Skip line-continuation (we only check complete logical lines).
+        line ~ /\\$/ { next }
+
+        # Look for risky command as first non-trivial token on a command segment.
+        # Segments are separated by ;, &&, ||, (, {. Pipe handling below.
+        {
+            # Replace known segment separators with newlines to check each segment.
+            segs = line
+            gsub(/\|\|/, "\n", segs)
+            gsub(/&&/,   "\n", segs)
+            gsub(/;/,    "\n", segs)
+            gsub(/\(/,   "\n", segs)
+            n = split(segs, arr, "\n")
+            for (i = 1; i <= n; i++) {
+                seg = arr[i]
+                sub(/^[ \t]+/, "", seg)
+                # Skip segments that are the RHS of a pipe (stdin = pipe data).
+                if (match(seg, /^\|[ ]/) || match(seg, /^\| /)) continue
+                if (seg ~ /^\|/) continue
+
+                # Pull first token.
+                first = seg
+                sub(/[ \t].*$/, "", first)
+
+                if (first == "az" || first == "azd" || first == "kubectl" \
+                 || first == "helm" || first == "curl" || first == "git") {
+                    # Check if THIS segment has a stdin redirect.
+                    if (seg ~ /<[ ]*\/dev\/null/) continue
+                    if (seg ~ /# stdin-ok/) continue
+                    printf("    %s:%d  %s\n", REL, NR, stripped)
+                    next
+                }
+            }
+        }
+    ' "$f" >> "$issues_file"
+done
+
+if [ -s "$issues_file" ]; then
+    count=$(wc -l < "$issues_file" | tr -d ' ')
+    cat "$issues_file"
+    fail "$count call site(s) missing stdin guard" "add </dev/null or '# stdin-ok' marker"
+else
+    pass "all hook shell calls have explicit stdin redirection or # stdin-ok marker"
+fi
+
+printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Builds on #60. Addresses the **#1 linux/mac pain point** — azd hangs silently for 10+ minutes with zero indication of what's wrong. Root cause: the hook scripts were handing control to nested `az`/`kubectl`/`helm` processes that inherited a piped stdin from azd, so any prompt from those tools (or a no-TTY environment with no config) produced a silent hang instead of a clear error.

## a2 — POSIX no-TTY fast-fail + non-interactive mode

**Before:** No TTY + no preset config → `read_input` silently returns empty → Quick-start default applied → user has no idea what just happened, sees no output for minutes.

**After:** `require_tty_or_preset` runs before the first prompt and picks ONE of three outcomes:

| Condition | Behavior |
|---|---|
| Real TTY (`_can_prompt` returns true) | Continue normally. |
| No TTY **and** `OMNIVEC_NONINTERACTIVE=1` (or `AZD_NONINTERACTIVE`/`CI`/`GITHUB_ACTIONS`) | Apply Quick-start defaults, log it, exit 0. |
| No TTY **and** no flag | Exit 1 **immediately** with an actionable message listing three fix options. |

`_can_prompt` probes both **write** and **read** on `/dev/tty` so it detects the real no-controlling-terminal case on Linux/macOS (where `/dev/tty` on Git Bash is misleading). Exposes `OMNIVEC_FORCE_NO_TTY=1` so tests can simulate CI/Docker on any host.

## a4 — Stdin-guards on every nested tool

Added `</dev/null` to **21** call sites in `postprovision.sh` + the `curl | sh` get-helm-3 installer and `git submodule update` in `preprovision.sh`.

**Critical bug fixed:** the pod-failure diagnostic `while read` loop (around line 621 of postprovision.sh) had inner `kubectl describe` / `kubectl logs` calls that were silently consuming the outer pipe's stdin, breaking iteration after the first pod. Both now have explicit `</dev/null`.

## Test harness

- `tests/hooks/test-no-tty.sh` — **11 functional tests** for a2. Extracts the helpers via awk into an isolated fragment, stubs `azd`, drives via `OMNIVEC_FORCE_NO_TTY=1`, and asserts each of the three branches behaves correctly.
- `tests/hooks/test-stdin-guards.sh` — awk-based **static analyzer** that flags every `az`/`azd`/`kubectl`/`helm`/`curl`/`git` call site that lacks a stdin redirect or an explicit `# stdin-ok` opt-out marker. **This test failing = you reintroduced a potential hang.**

## Full matrix

**33 tests × 3 shells (dash + bash + sh) = 99 executions, all green.** Both hook scripts pass `sh -n` / `dash -n` / `bash -n` syntax check.

```
sh tests/run.sh
# ========== done: 0 failing suites ==========
```

## Stack order

Merge #60 first, then this. Rebased onto main after #60 merges will be a no-op.

## What's next (not in this PR)

- a1 — Windows `Read-Host` prompt-hang replacement
- b2 — preprovision env-sanitization validator
- f2 — wrap long-running hook commands with `wait_with_heartbeat`
- f3 — background ARM deploy ticker

---
Do **not** merge until I give the order.