### PR TITLE
feat: import/export deployment data (sources, destinations, pipelines, models, assistants, checkpoints)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -4942,6 +4942,365 @@ async def update_settings(payload: dict):
 
 
 # =============================================================================
+# IMPORT / EXPORT (deployment bundles)
+# =============================================================================
+
+_EXPORT_VERSION = "1.0"
+
+# Resource types handled by export/import, with their CosmosDB doc_type
+_EXPORT_RESOURCE_TYPES = {
+    "sources": "source",
+    "destinations": "destination",
+    "pipelines": "pipeline",
+    "models": "docgrok_model",
+    "assistants": "assistant",
+}
+
+
+def _strip_internal(doc: dict) -> dict:
+    """Remove Cosmos internal fields (_rid, _etag, _self, ...) and doc_type."""
+    return {k: v for k, v in doc.items() if not k.startswith("_") and k != "doc_type"}
+
+
+def _redact_secrets_in_config(cfg: dict) -> dict:
+    """Replace sensitive values inside a config dict with '***'."""
+    if not isinstance(cfg, dict):
+        return cfg
+    out = {}
+    for k, v in cfg.items():
+        if any(s in k.lower() for s in _SENSITIVE_CONFIG_KEYS):
+            out[k] = "***" if v not in (None, "", 0) else v
+        else:
+            out[k] = v
+    return out
+
+
+def _redact_model_doc(doc: dict) -> dict:
+    """Redact sensitive fields from a docgrok_model doc."""
+    out = dict(doc)
+    for k in list(out.keys()):
+        if any(s in k.lower() for s in _SENSITIVE_CONFIG_KEYS):
+            if out[k] not in (None, "", 0):
+                out[k] = "***"
+    return out
+
+
+def _collect_pipeline_refs(pipelines: list[dict]) -> tuple[set, set, set]:
+    """Return (source_ids, destination_ids, model_refs) referenced by the given pipelines."""
+    src_ids, dst_ids, mdl_refs = set(), set(), set()
+    for p in pipelines:
+        for ps in p.get("sources", []) or []:
+            sid = ps.get("source_id") if isinstance(ps, dict) else None
+            if sid:
+                src_ids.add(sid)
+        if p.get("destination_id"):
+            dst_ids.add(p["destination_id"])
+        if p.get("docgrok_pipeline"):
+            mdl_refs.add(p["docgrok_pipeline"])
+    return src_ids, dst_ids, mdl_refs
+
+
+@app.get("/api/admin/export")
+def export_bundle(
+    include: str = "sources,destinations,pipelines,models,assistants",
+    include_secrets: bool = False,
+    include_checkpoints: bool = False,
+    pipeline_ids: str = "",
+    download: bool = False,
+):
+    """Export OmniVec deployment data as a JSON bundle.
+
+    Query params:
+      - include: csv of {sources,destinations,pipelines,models,assistants}
+      - include_secrets: if true, keep connection strings / api keys / passwords
+      - include_checkpoints: if true, append all (or pipeline-scoped) checkpoints
+      - pipeline_ids: csv; when set, only export these pipelines plus the sources,
+        destinations, models, and assistants they reference
+      - download: if true, send as attachment
+    """
+    store = get_store()
+    wanted = {t.strip() for t in include.split(",") if t.strip()}
+    unknown = wanted - set(_EXPORT_RESOURCE_TYPES.keys())
+    if unknown:
+        raise HTTPException(status_code=400, detail=f"Unknown resource type(s): {sorted(unknown)}")
+
+    pipeline_filter = {p.strip() for p in pipeline_ids.split(",") if p.strip()}
+
+    resources: dict[str, list[dict]] = {k: [] for k in _EXPORT_RESOURCE_TYPES}
+
+    # Load pipelines first because filter is pipeline-driven
+    all_pipelines = [_strip_internal(d) for d in store.list("pipeline")]
+    if pipeline_filter:
+        all_pipelines = [p for p in all_pipelines if p.get("id") in pipeline_filter]
+        missing = pipeline_filter - {p.get("id") for p in all_pipelines}
+        if missing:
+            raise HTTPException(status_code=404, detail=f"Pipeline(s) not found: {sorted(missing)}")
+    if "pipelines" in wanted:
+        resources["pipelines"] = all_pipelines
+
+    ref_src, ref_dst, ref_mdl = _collect_pipeline_refs(all_pipelines)
+
+    def _filter_by_ids(docs, allowed):
+        return [d for d in docs if not pipeline_filter or d.get("id") in allowed]
+
+    if "sources" in wanted:
+        docs = [_strip_internal(d) for d in store.list("source")]
+        docs = _filter_by_ids(docs, ref_src)
+        if not include_secrets:
+            for d in docs:
+                if isinstance(d.get("config"), dict):
+                    d["config"] = _redact_secrets_in_config(d["config"])
+        resources["sources"] = docs
+
+    if "destinations" in wanted:
+        docs = [_strip_internal(d) for d in store.list("destination")]
+        docs = _filter_by_ids(docs, ref_dst)
+        if not include_secrets:
+            for d in docs:
+                if isinstance(d.get("config"), dict):
+                    d["config"] = _redact_secrets_in_config(d["config"])
+        resources["destinations"] = docs
+
+    if "models" in wanted:
+        docs = [_strip_internal(d) for d in store.list("docgrok_model")]
+        if pipeline_filter:
+            docs = [d for d in docs if d.get("id") in ref_mdl or d.get("name") in ref_mdl]
+        if not include_secrets:
+            docs = [_redact_model_doc(d) for d in docs]
+        resources["models"] = docs
+
+    if "assistants" in wanted:
+        docs = [_strip_internal(d) for d in store.list("assistant")]
+        if pipeline_filter:
+            # Assistants referencing any exported destination / model
+            kept_dst = {d["id"] for d in resources.get("destinations", [])}
+            kept_mdl = {d["id"] for d in resources.get("models", [])}
+            docs = [
+                a for a in docs
+                if a.get("model_id") in kept_mdl
+                or any(did in kept_dst for did in a.get("destination_ids") or [])
+            ]
+        resources["assistants"] = docs
+
+    bundle: dict[str, Any] = {
+        "omnivec_export_version": _EXPORT_VERSION,
+        "exported_at": datetime.utcnow().isoformat() + "Z",
+        "includes_secrets": bool(include_secrets),
+        "includes_checkpoints": bool(include_checkpoints),
+        "filter": {"pipeline_ids": sorted(pipeline_filter)} if pipeline_filter else None,
+        "resources": resources,
+    }
+
+    if include_checkpoints:
+        cp_docs = [_strip_internal(d) for d in store.list("checkpoint")]
+        if pipeline_filter:
+            # Scope checkpoints to the sources referenced by the filtered pipelines
+            cp_docs = [c for c in cp_docs if c.get("source_id") in ref_src]
+        bundle["checkpoints"] = cp_docs
+    else:
+        bundle["checkpoints"] = []
+
+    headers = {}
+    if download:
+        fname = "omnivec-export-" + datetime.utcnow().strftime("%Y%m%d-%H%M%S") + ".json"
+        headers["Content-Disposition"] = f'attachment; filename="{fname}"'
+    return JSONResponse(content=bundle, headers=headers)
+
+
+def _rewrite_ids(bundle_resources: dict, id_map: dict[str, str]) -> None:
+    """In-place rewrite of cross-references in a bundle's resources using id_map.
+
+    id_map maps OLD id -> NEW id (for sources, destinations, models, assistants,
+    pipelines). Callers populate it only for renamed resources.
+    """
+    if not id_map:
+        return
+    for p in bundle_resources.get("pipelines", []):
+        for ps in p.get("sources", []) or []:
+            if isinstance(ps, dict) and ps.get("source_id") in id_map:
+                ps["source_id"] = id_map[ps["source_id"]]
+        if p.get("destination_id") in id_map:
+            p["destination_id"] = id_map[p["destination_id"]]
+        if p.get("docgrok_pipeline") in id_map:
+            p["docgrok_pipeline"] = id_map[p["docgrok_pipeline"]]
+    for a in bundle_resources.get("assistants", []):
+        if a.get("model_id") in id_map:
+            a["model_id"] = id_map[a["model_id"]]
+        a["destination_ids"] = [id_map.get(d, d) for d in (a.get("destination_ids") or [])]
+
+
+def _new_suffixed_id(old_id: str) -> str:
+    """Generate a new id from an old one by appending -copy-<rand4>."""
+    suffix = secrets.token_hex(2)
+    if old_id:
+        return f"{old_id}-copy-{suffix}"
+    return f"copy-{suffix}"
+
+
+@app.post("/api/admin/import")
+def import_bundle(
+    payload: dict,
+    on_conflict: str = "skip",
+    dry_run: bool = False,
+):
+    """Import an OmniVec deployment bundle.
+
+    Query params:
+      - on_conflict: skip | overwrite | rename (default skip)
+      - dry_run: if true, no writes; response describes what would happen
+    """
+    if on_conflict not in ("skip", "overwrite", "rename"):
+        raise HTTPException(status_code=400, detail="on_conflict must be one of: skip, overwrite, rename")
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="Bundle must be a JSON object")
+
+    version = payload.get("omnivec_export_version")
+    if version and str(version).split(".")[0] != _EXPORT_VERSION.split(".")[0]:
+        raise HTTPException(status_code=400, detail=f"Unsupported bundle version: {version}")
+
+    resources = dict(payload.get("resources") or {})
+    # Deep-copy so we can safely rewrite ids without mutating caller's payload
+    import copy
+    resources = copy.deepcopy(resources)
+    checkpoints = payload.get("checkpoints") or []
+
+    store = get_store()
+
+    # Pre-load existing IDs per type to detect conflicts
+    existing: dict[str, set] = {}
+    for rtype, doc_type in _EXPORT_RESOURCE_TYPES.items():
+        try:
+            existing[rtype] = {d["id"] for d in store.list(doc_type) if d.get("id")}
+        except Exception:
+            existing[rtype] = set()
+
+    summary: dict[str, dict] = {rtype: {"created": 0, "overwritten": 0, "skipped": 0, "renamed": 0, "errors": []}
+                                for rtype in _EXPORT_RESOURCE_TYPES}
+    summary["checkpoints"] = {"created": 0, "overwritten": 0, "skipped": 0, "renamed": 0, "errors": []}
+    warnings: list[str] = []
+    id_map: dict[str, str] = {}  # old -> new (for rename mode)
+    to_write: list[tuple[str, dict]] = []  # (doc_type, doc)
+
+    # Stable order: sources/destinations/models first (referenced), then pipelines, then assistants
+    order = ["sources", "destinations", "models", "assistants", "pipelines"]
+    for rtype in order:
+        doc_type = _EXPORT_RESOURCE_TYPES[rtype]
+        items = resources.get(rtype) or []
+        for item in items:
+            if not isinstance(item, dict):
+                summary[rtype]["errors"].append("item is not an object")
+                continue
+            item_id = item.get("id")
+            if not item_id:
+                summary[rtype]["errors"].append("item missing id")
+                continue
+
+            # Redacted secret detection
+            if isinstance(item.get("config"), dict):
+                for k, v in item["config"].items():
+                    if v == "***":
+                        warnings.append(f"{rtype}/{item_id}: field '{k}' is redacted ('***'); resource may not function until updated")
+
+            conflict = item_id in existing.get(rtype, set())
+            if conflict:
+                if on_conflict == "skip":
+                    summary[rtype]["skipped"] += 1
+                    continue
+                elif on_conflict == "overwrite":
+                    summary[rtype]["overwritten"] += 1
+                elif on_conflict == "rename":
+                    new_id = _new_suffixed_id(item_id)
+                    # Ensure new_id doesn't also collide
+                    while new_id in existing.get(rtype, set()):
+                        new_id = _new_suffixed_id(item_id)
+                    id_map[item_id] = new_id
+                    item["id"] = new_id
+                    # Also rename to avoid unique-name constraint in most resources
+                    if item.get("name"):
+                        item["name"] = f"{item['name']}-copy-{new_id[-4:]}"
+                    summary[rtype]["renamed"] += 1
+                    existing[rtype].add(new_id)
+            else:
+                summary[rtype]["created"] += 1
+                existing[rtype].add(item_id)
+
+            # Pipelines: force paused on import so we never auto-start ingestion
+            if rtype == "pipelines":
+                item["status"] = "paused"
+
+            to_write.append((doc_type, item))
+
+    # Rewrite cross references after we know the id_map
+    if id_map:
+        _rewrite_ids(resources, id_map)
+        # Because to_write holds references into resources (same dicts), rewrites propagate
+
+    # Checkpoints
+    if checkpoints:
+        # Pre-load existing checkpoint IDs
+        try:
+            cp_existing = {d["id"] for d in store.list("checkpoint") if d.get("id")}
+        except Exception:
+            cp_existing = set()
+        cp_to_write = []
+        for cp in checkpoints:
+            if not isinstance(cp, dict) or not cp.get("id"):
+                summary["checkpoints"]["errors"].append("checkpoint missing id")
+                continue
+            # Rewrite source_id if its source was renamed
+            if cp.get("source_id") in id_map:
+                cp["source_id"] = id_map[cp["source_id"]]
+            cp_id = cp["id"]
+            conflict = cp_id in cp_existing
+            if conflict and on_conflict == "skip":
+                summary["checkpoints"]["skipped"] += 1
+                continue
+            if conflict and on_conflict == "overwrite":
+                summary["checkpoints"]["overwritten"] += 1
+            elif not conflict:
+                summary["checkpoints"]["created"] += 1
+            # rename for checkpoints: keep id (they're regenerated via source_id anyway)
+            cp["doc_type"] = "checkpoint"
+            cp_to_write.append(cp)
+    else:
+        cp_to_write = []
+
+    if dry_run:
+        return {
+            "success": True,
+            "dry_run": True,
+            "on_conflict": on_conflict,
+            "summary": summary,
+            "warnings": warnings,
+            "id_map": id_map,
+        }
+
+    # Apply writes
+    for doc_type, item in to_write:
+        try:
+            doc = {**item, "doc_type": doc_type}
+            store.upsert(doc)
+        except Exception as e:
+            rtype = next((k for k, v in _EXPORT_RESOURCE_TYPES.items() if v == doc_type), doc_type)
+            summary.setdefault(rtype, {}).setdefault("errors", []).append(f"{item.get('id')}: {e}")
+
+    for cp in cp_to_write:
+        try:
+            store.upsert(cp)
+        except Exception as e:
+            summary["checkpoints"]["errors"].append(f"{cp.get('id')}: {e}")
+
+    return {
+        "success": True,
+        "dry_run": False,
+        "on_conflict": on_conflict,
+        "summary": summary,
+        "warnings": warnings,
+        "id_map": id_map,
+    }
+
+
+# =============================================================================
 # MAIN
 # =============================================================================
 

--- a/cli/cmd_admin.go
+++ b/cli/cmd_admin.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func newAdminCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "admin",
+		Short: "Administrative operations (export/import deployment data)",
+	}
+	cmd.AddCommand(newExportCmd(), newImportCmd())
+	return cmd
+}
+
+func newExportCmd() *cobra.Command {
+	var (
+		outFile            string
+		include            string
+		includeSecrets     bool
+		includeCheckpoints bool
+		pipelines          string
+	)
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export sources, destinations, pipelines, models, assistants (and optionally checkpoints) as a JSON bundle",
+		Long: `Export an OmniVec deployment to a JSON bundle for backup or migration.
+
+By default, secrets (connection strings, API keys, passwords) are redacted ("***").
+Use --include-secrets to include real values.
+
+Examples:
+  omnivec admin export --output omnivec.json
+  omnivec admin export --output pips.json --pipelines pip-123,pip-456 --include-checkpoints
+  omnivec admin export --include-secrets --output full-backup.json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c := getClient()
+			params := map[string]string{
+				"include":             include,
+				"include_secrets":     boolStr(includeSecrets),
+				"include_checkpoints": boolStr(includeCheckpoints),
+			}
+			if pipelines != "" {
+				params["pipeline_ids"] = pipelines
+			}
+			data, err := c.Get("/api/admin/export", params)
+			if err != nil {
+				exitErr("%v", err)
+			}
+
+			// Pretty-print the bundle
+			var obj any
+			if err := json.Unmarshal(data, &obj); err == nil {
+				pretty, _ := json.MarshalIndent(obj, "", "  ")
+				data = pretty
+			}
+
+			if outFile == "" || outFile == "-" {
+				fmt.Println(string(data))
+			} else {
+				if err := os.WriteFile(outFile, data, 0o600); err != nil {
+					exitErr("Write %s: %v", outFile, err)
+				}
+				// Summary to stderr so redirection still works cleanly
+				summarizeExport(data)
+				fmt.Fprintf(os.Stderr, "%s Wrote %s (%d bytes)\n", green("OK:"), outFile, len(data))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&outFile, "output-file", "f", "", "Write bundle to this path (default: stdout)")
+	cmd.Flags().StringVar(&include, "include", "sources,destinations,pipelines,models,assistants",
+		"Comma-separated resource types to include")
+	cmd.Flags().BoolVar(&includeSecrets, "include-secrets", false,
+		"Include real secrets instead of redacting them")
+	cmd.Flags().BoolVar(&includeCheckpoints, "include-checkpoints", false,
+		"Include pipeline/source checkpoints so runs can be resumed after import")
+	cmd.Flags().StringVar(&pipelines, "pipelines", "",
+		"Only export these pipeline IDs (csv) and their dependencies")
+	return cmd
+}
+
+func newImportCmd() *cobra.Command {
+	var (
+		onConflict string
+		dryRun     bool
+	)
+	cmd := &cobra.Command{
+		Use:   "import <file>",
+		Short: "Import a JSON bundle produced by 'omnivec admin export'",
+		Long: `Import OmniVec deployment data from a JSON bundle.
+
+Conflict handling (--on-conflict):
+  skip      - leave existing resources untouched (default, safest)
+  overwrite - replace existing resources with the imported version
+  rename    - create new copies with suffixed IDs & names (cross-refs rewritten)
+
+Imported pipelines are always created in the 'paused' state; resume them
+explicitly after import.
+
+Examples:
+  omnivec admin import omnivec.json --dry-run
+  omnivec admin import omnivec.json --on-conflict overwrite
+  omnivec admin import pips.json    --on-conflict rename`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path := args[0]
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				exitErr("Read %s: %v", path, err)
+			}
+			var bundle any
+			if err := json.Unmarshal(raw, &bundle); err != nil {
+				exitErr("Parse %s: %v", path, err)
+			}
+
+			c := getClient()
+			qs := fmt.Sprintf("?on_conflict=%s&dry_run=%s", onConflict, boolStr(dryRun))
+			data, err := c.Post("/api/admin/import"+qs, bundle)
+			if err != nil {
+				exitErr("%v", err)
+			}
+
+			if flagOutput == "json" {
+				printJSON(json.RawMessage(data))
+				return nil
+			}
+			printImportSummary(data, dryRun)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&onConflict, "on-conflict", "skip",
+		"Conflict mode: skip | overwrite | rename")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"Don't write anything; just report what would happen")
+	return cmd
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// summarizeExport prints a short per-type count summary to stderr.
+func summarizeExport(data []byte) {
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return
+	}
+	res, _ := obj["resources"].(map[string]any)
+	var parts []string
+	for _, k := range []string{"sources", "destinations", "pipelines", "models", "assistants"} {
+		if arr, ok := res[k].([]any); ok {
+			parts = append(parts, fmt.Sprintf("%s=%d", k, len(arr)))
+		}
+	}
+	if cps, ok := obj["checkpoints"].([]any); ok && len(cps) > 0 {
+		parts = append(parts, fmt.Sprintf("checkpoints=%d", len(cps)))
+	}
+	if redacted, _ := obj["includes_secrets"].(bool); !redacted {
+		parts = append(parts, "secrets=redacted")
+	} else {
+		parts = append(parts, "secrets=included")
+	}
+	fmt.Fprintf(os.Stderr, "%s %s\n", dim("bundle:"), strings.Join(parts, " "))
+}
+
+func printImportSummary(data json.RawMessage, dryRun bool) {
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		fmt.Println(string(data))
+		return
+	}
+	if dryRun {
+		fmt.Println(bold("Dry run — no changes applied."))
+	}
+	mode, _ := obj["on_conflict"].(string)
+	fmt.Printf("Conflict mode: %s\n\n", bold(mode))
+
+	summary, _ := obj["summary"].(map[string]any)
+	order := []string{"sources", "destinations", "models", "assistants", "pipelines", "checkpoints"}
+	fmt.Printf("%-14s %8s %12s %8s %8s\n", bold("Resource"), bold("Created"), bold("Overwritten"), bold("Skipped"), bold("Renamed"))
+	for _, k := range order {
+		s, ok := summary[k].(map[string]any)
+		if !ok {
+			continue
+		}
+		fmt.Printf("%-14s %8v %12v %8v %8v\n", k,
+			intish(s["created"]), intish(s["overwritten"]),
+			intish(s["skipped"]), intish(s["renamed"]))
+	}
+
+	if warns, _ := obj["warnings"].([]any); len(warns) > 0 {
+		fmt.Printf("\n%s\n", yellow(fmt.Sprintf("Warnings (%d):", len(warns))))
+		for _, w := range warns {
+			fmt.Printf("  - %v\n", w)
+		}
+	}
+	// Errors
+	for _, k := range order {
+		s, ok := summary[k].(map[string]any)
+		if !ok {
+			continue
+		}
+		if errs, _ := s["errors"].([]any); len(errs) > 0 {
+			fmt.Printf("\n%s in %s:\n", red("Errors"), k)
+			for _, e := range errs {
+				fmt.Printf("  - %v\n", e)
+			}
+		}
+	}
+	if idMap, _ := obj["id_map"].(map[string]any); len(idMap) > 0 {
+		fmt.Printf("\n%s\n", bold("Renamed IDs:"))
+		for k, v := range idMap {
+			fmt.Printf("  %s -> %v\n", k, v)
+		}
+	}
+}
+
+func intish(v any) any {
+	if v == nil {
+		return 0
+	}
+	return v
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -40,6 +40,7 @@ func main() {
 		newStatusCmd(),
 		newSettingsCmd(),
 		newConfigCmd(),
+		newAdminCmd(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1131,6 +1131,14 @@
                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>
                             Refresh
                         </button>
+                        <button class="btn btn-secondary" onclick="showExportModal()" title="Export sources, destinations, pipelines, models & assistants as JSON">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                            Export
+                        </button>
+                        <button class="btn btn-secondary" onclick="showImportModal()" title="Import a JSON bundle">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                            Import
+                        </button>
                         <button class="btn btn-primary" onclick="showAddPipelineModal()">
                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M12 5v14"/><path d="M5 12h14"/>
@@ -1491,6 +1499,91 @@
                     </button>
                     <button class="btn btn-primary" onclick="saveSourceFromDetail()">Save Changes</button>
                 </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Export / Import Modals -->
+    <div class="modal-overlay" id="export-modal">
+        <div class="modal">
+            <div class="modal-header">
+                <h3 class="modal-title">Export Deployment</h3>
+                <button class="modal-close" onclick="closeModal('export-modal')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="18" height="18"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p style="color: var(--text-secondary); margin-bottom: 16px;">
+                    Download a JSON bundle that you can re-import later or on another deployment.
+                </p>
+                <div class="form-group">
+                    <label>Resources to include</label>
+                    <div style="display: flex; flex-wrap: wrap; gap: 10px 16px; padding: 8px 0;">
+                        <label><input type="checkbox" class="exp-rtype" value="sources" checked> Sources</label>
+                        <label><input type="checkbox" class="exp-rtype" value="destinations" checked> Destinations</label>
+                        <label><input type="checkbox" class="exp-rtype" value="pipelines" checked> Pipelines</label>
+                        <label><input type="checkbox" class="exp-rtype" value="models" checked> Models</label>
+                        <label><input type="checkbox" class="exp-rtype" value="assistants" checked> Assistants</label>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label style="display: flex; align-items: center; gap: 8px;">
+                        <input type="checkbox" id="exp-checkpoints">
+                        <span>Include pipeline/source <b>checkpoints</b> (needed to resume in-progress runs)</span>
+                    </label>
+                </div>
+                <div class="form-group">
+                    <label style="display: flex; align-items: center; gap: 8px;">
+                        <input type="checkbox" id="exp-secrets">
+                        <span>Include <b>secrets</b> (connection strings, API keys, passwords)</span>
+                    </label>
+                    <small style="color: var(--text-tertiary); display: block; margin-top: 4px;">
+                        Secrets are redacted as <code>"***"</code> when unchecked.
+                    </small>
+                </div>
+                <div class="form-group">
+                    <label>Filter by pipeline (optional)</label>
+                    <input type="text" id="exp-pipelines" placeholder="pip-123,pip-456 — leave blank for all" class="form-input">
+                    <small style="color: var(--text-tertiary);">Only exports the listed pipelines and their referenced sources, destinations, models &amp; assistants.</small>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-secondary" onclick="closeModal('export-modal')">Cancel</button>
+                <button class="btn btn-primary" id="export-run-btn" onclick="runExport()">Download bundle</button>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal-overlay" id="import-modal">
+        <div class="modal">
+            <div class="modal-header">
+                <h3 class="modal-title">Import Deployment</h3>
+                <button class="modal-close" onclick="closeModal('import-modal')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="18" height="18"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label>Bundle file</label>
+                    <input type="file" id="imp-file" accept="application/json,.json" class="form-input">
+                </div>
+                <div class="form-group">
+                    <label>On conflict</label>
+                    <select id="imp-on-conflict" class="form-input">
+                        <option value="skip" selected>skip — keep existing resources (safest)</option>
+                        <option value="overwrite">overwrite — replace existing resources</option>
+                        <option value="rename">rename — create copies with new IDs</option>
+                    </select>
+                </div>
+                <p style="color: var(--text-tertiary); font-size: 0.9em;">
+                    Imported pipelines are always created in the <b>paused</b> state; resume them explicitly after import.
+                </p>
+                <div id="imp-result" style="display:none; margin-top: 12px; padding: 12px; background: var(--bg-tertiary); border-radius: 6px; white-space: pre-wrap; font-family: var(--font-mono); font-size: 0.85em; max-height: 260px; overflow:auto;"></div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-secondary" onclick="closeModal('import-modal')">Cancel</button>
+                <button class="btn btn-secondary" onclick="runImport(true)">Dry run</button>
+                <button class="btn btn-primary" onclick="runImport(false)">Apply import</button>
             </div>
         </div>
     </div>
@@ -2656,6 +2749,140 @@
         function showAddDestinationModal() {
             document.getElementById('destination-form').reset();
             showModal('destination-modal');
+        }
+
+        // -------- Export / Import --------
+        function showExportModal() {
+            document.querySelectorAll('.exp-rtype').forEach(cb => cb.checked = true);
+            document.getElementById('exp-checkpoints').checked = false;
+            document.getElementById('exp-secrets').checked = false;
+            document.getElementById('exp-pipelines').value = '';
+            showModal('export-modal');
+        }
+
+        async function runExport() {
+            const include = Array.from(document.querySelectorAll('.exp-rtype:checked')).map(cb => cb.value).join(',');
+            if (!include) { alert('Select at least one resource type.'); return; }
+            const params = new URLSearchParams({
+                include,
+                include_secrets: document.getElementById('exp-secrets').checked ? 'true' : 'false',
+                include_checkpoints: document.getElementById('exp-checkpoints').checked ? 'true' : 'false',
+            });
+            const pids = document.getElementById('exp-pipelines').value.trim();
+            if (pids) params.set('pipeline_ids', pids);
+
+            const btn = document.getElementById('export-run-btn');
+            btn.disabled = true; btn.textContent = 'Exporting...';
+            try {
+                const res = await apiFetch('/api/admin/export?' + params.toString());
+                if (!res.ok) {
+                    const err = await res.text();
+                    throw new Error(err || ('HTTP ' + res.status));
+                }
+                const bundle = await res.json();
+                const blob = new Blob([JSON.stringify(bundle, null, 2)], { type: 'application/json' });
+                const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+                const a = document.createElement('a');
+                a.href = URL.createObjectURL(blob);
+                a.download = `omnivec-export-${ts}.json`;
+                document.body.appendChild(a); a.click(); a.remove();
+                URL.revokeObjectURL(a.href);
+                closeModal('export-modal');
+            } catch (e) {
+                alert('Export failed: ' + e.message);
+            } finally {
+                btn.disabled = false; btn.textContent = 'Download bundle';
+            }
+        }
+
+        function showImportModal() {
+            document.getElementById('imp-file').value = '';
+            document.getElementById('imp-on-conflict').value = 'skip';
+            const res = document.getElementById('imp-result');
+            res.style.display = 'none';
+            res.textContent = '';
+            showModal('import-modal');
+        }
+
+        async function runImport(dryRun) {
+            const fileInput = document.getElementById('imp-file');
+            if (!fileInput.files || !fileInput.files[0]) {
+                alert('Pick a bundle file first.');
+                return;
+            }
+            let bundle;
+            try {
+                const text = await fileInput.files[0].text();
+                bundle = JSON.parse(text);
+            } catch (e) {
+                alert('Invalid JSON file: ' + e.message);
+                return;
+            }
+            const onConflict = document.getElementById('imp-on-conflict').value;
+            const resEl = document.getElementById('imp-result');
+            resEl.style.display = 'block';
+            resEl.textContent = (dryRun ? 'Dry run' : 'Importing') + '...';
+            try {
+                const qs = new URLSearchParams({ on_conflict: onConflict, dry_run: dryRun ? 'true' : 'false' });
+                const res = await apiFetch('/api/admin/import?' + qs.toString(), {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(bundle),
+                });
+                const body = await res.json();
+                if (!res.ok) {
+                    throw new Error(body.detail || ('HTTP ' + res.status));
+                }
+                resEl.textContent = formatImportSummary(body, dryRun);
+                if (!dryRun) {
+                    // Refresh the main pipelines view after a real import
+                    if (typeof refreshData === 'function') { try { refreshData(); } catch(_) {} }
+                }
+            } catch (e) {
+                resEl.textContent = 'Import failed: ' + e.message;
+            }
+        }
+
+        function formatImportSummary(body, dryRun) {
+            const lines = [];
+            lines.push((dryRun ? 'DRY RUN' : 'IMPORTED') + '  on_conflict=' + (body.on_conflict || '?'));
+            lines.push('');
+            const order = ['sources','destinations','models','assistants','pipelines','checkpoints'];
+            const s = body.summary || {};
+            lines.push('Resource       Created  Overwritten  Skipped  Renamed');
+            for (const k of order) {
+                const r = s[k];
+                if (!r) continue;
+                lines.push(
+                    k.padEnd(14) +
+                    String(r.created || 0).padStart(9) +
+                    String(r.overwritten || 0).padStart(13) +
+                    String(r.skipped || 0).padStart(9) +
+                    String(r.renamed || 0).padStart(9)
+                );
+            }
+            const warns = body.warnings || [];
+            if (warns.length) {
+                lines.push('');
+                lines.push('Warnings (' + warns.length + '):');
+                for (const w of warns) lines.push('  - ' + w);
+            }
+            for (const k of order) {
+                const r = s[k];
+                if (r && r.errors && r.errors.length) {
+                    lines.push('');
+                    lines.push('Errors in ' + k + ':');
+                    for (const e of r.errors) lines.push('  - ' + e);
+                }
+            }
+            const idMap = body.id_map || {};
+            const keys = Object.keys(idMap);
+            if (keys.length) {
+                lines.push('');
+                lines.push('Renamed IDs:');
+                for (const k of keys) lines.push('  ' + k + ' -> ' + idMap[k]);
+            }
+            return lines.join('\n');
         }
 
         async function showAddPipelineModal() {


### PR DESCRIPTION
## Summary
Adds full import/export of OmniVec deployment data so an environment can be snapshotted, migrated, or resumed at a later point.

### Backend (`api/api.py`)
- `GET /api/admin/export` — returns a JSON bundle of `sources`, `destinations`, `pipelines`, `models`, `assistants`.
  - `include_secrets` (default **false**) — secrets redacted as `"***"` otherwise.
  - `include_checkpoints` (default **false**) — attaches `checkpoint` docs so a run can be resumed after restore.
  - `pipeline_ids=<csv>` — scopes the bundle to the listed pipelines and their referenced sources/destinations/models/assistants (and their checkpoints).
  - `download=1` — returns `Content-Disposition: attachment`.
- `POST /api/admin/import` — accepts a bundle.
  - `on_conflict={skip,overwrite,rename}` — rename creates fresh IDs and rewrites cross-references (`pipeline.source_id`/`destination_id`/`docgrok_pipeline` and `assistant.model_id`/`destination_ids`).
  - `dry_run=true` — plans without writing.
  - Imported pipelines are always forced to `status=paused` for safety.

### CLI (`cli/cmd_admin.go`, wired from `cli/main.go`)
```
omnivec admin export [-f file.json] [--include csv] [--include-secrets]
                     [--include-checkpoints] [--pipelines id,id]
omnivec admin import <file> [--on-conflict skip|overwrite|rename] [--dry-run]
```
Prints a per-resource summary (created / overwritten / skipped / renamed), warnings, errors and old→new id map.

### UI (`web/static/index.html`)
- **Export** and **Import** buttons in the Pipelines header.
- Export modal — resource checkboxes, include-checkpoints, include-secrets, optional pipeline filter; downloads the JSON bundle directly.
- Import modal — file picker, on-conflict selector, **Dry run** and **Apply import**; shows a formatted in-place summary.

### Safety
- Secrets redacted by default.
- Imported pipelines land paused; operator must explicitly resume.
- Rename mode rewrites all cross-refs so renamed resources wire back correctly.

### Verification
- `python -m ast` parse clean on `api/api.py`.
- `go build` clean on `cli/`.
- Images rebuilt and pushed to `omnivecregistry.azurecr.io` (`omnivec-api:latest` & `omnivec-web:latest`).
