### PR TITLE
test: mock harness for hooks/preprovision.sh (poor-man's LocalStack-for-Azure)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,11 @@
 *.sh            text eol=lf
 hooks/lib/*     text eol=lf
 tests/**/*.sh   text eol=lf
+# Extensionless shell stubs that live in $PATH (mock CLIs for tests).
+tests/hooks/mocks/azd     text eol=lf
+tests/hooks/mocks/az      text eol=lf
+tests/hooks/mocks/kubectl text eol=lf
+tests/hooks/mocks/helm    text eol=lf
 scripts/*.sh    text eol=lf
 Dockerfile*     text eol=lf
 *.yaml          text eol=lf

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -458,13 +458,13 @@ export KUBE_CONTEXT
 # Some azd/heartbeat wrappers reset $KUBECONFIG between hook phases, so we cannot
 # rely solely on the env var.
 kubectl_omnivec() {
-  kubectl --kubeconfig "$OMNIVEC_KUBECONFIG" --context "$KUBE_CONTEXT" "$@"
+  kubectl --kubeconfig "$OMNIVEC_KUBECONFIG" --context "$KUBE_CONTEXT" "$@"  # stdin-ok: callers supply </dev/null
 }
 
 # Sanity check before first kubectl call — surface config issues clearly.
-if ! kubectl --kubeconfig "$OMNIVEC_KUBECONFIG" config get-contexts "$KUBE_CONTEXT" >/dev/null 2>&1; then
+if ! kubectl --kubeconfig "$OMNIVEC_KUBECONFIG" config get-contexts "$KUBE_CONTEXT" </dev/null >/dev/null 2>&1; then
   printf "${RED}Context '%s' not found in %s. Kubeconfig contents:${NC}\n" "$KUBE_CONTEXT" "$OMNIVEC_KUBECONFIG"
-  kubectl --kubeconfig "$OMNIVEC_KUBECONFIG" config get-contexts 2>&1 || true
+  kubectl --kubeconfig "$OMNIVEC_KUBECONFIG" config get-contexts </dev/null 2>&1 || true
   ls -la "$OMNIVEC_KUBECONFIG" "$HOME/.kube/config" 2>&1 || true
   exit 1
 fi

--- a/tests/hooks/mocks/README.md
+++ b/tests/hooks/mocks/README.md
@@ -1,0 +1,46 @@
+# Recording mocks for cloud CLIs
+
+Drop-in POSIX shell stubs for `azd`, `az`, `kubectl`, `helm` that let us
+run the real `hooks/preprovision.sh` and `hooks/postprovision.sh`
+end-to-end **without** a real Azure subscription.
+
+## How it works
+
+Every invocation of the stubs (e.g. `azd env set FOO bar`) appends a
+single line to the file named by `$OMNIVEC_MOCK_LOG`:
+
+```
+azd env set FOO bar
+az provider show --namespace Microsoft.ContainerService --query registrationState -o tsv
+kubectl get pods -n omnivec
+```
+
+The stubs return canned output that is "good enough" for the hook to
+progress (e.g. `az account show` returns a fake subscription id, every
+provider is `Registered`, `azd env get-value` returns what was most
+recently `azd env set`).
+
+## Usage (POSIX test)
+
+```sh
+export OMNIVEC_MOCK_LOG="$(mktemp)"
+export PATH="$REPO_ROOT/tests/hooks/mocks:$PATH"
+export AZURE_ENV_NAME=mock-env
+export OMNIVEC_NONINTERACTIVE=1
+export OMNIVEC_FORCE_NO_TTY=1
+
+sh hooks/preprovision.sh </dev/null
+
+grep 'azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE' "$OMNIVEC_MOCK_LOG"
+```
+
+## Why no LocalStack-for-Azure?
+
+There is no production-quality emulator for ARM + AKS + Cosmos + Key
+Vault + Workload Identity. Azurite/Cosmos emulator/Service Bus emulator
+only cover data planes. This harness tests the *hook logic* — that we
+call the right azd/az/kubectl/helm commands in the right order with the
+right args — which is where most `azd up` regressions actually live.
+
+For what-if validation against real ARM, see `tests/infra/what-if.sh`
+(follow-up).

--- a/tests/hooks/mocks/_record.sh
+++ b/tests/hooks/mocks/_record.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Shared helper - append "<tool> <args...>" to $OMNIVEC_MOCK_LOG.
+# Sourced by every mock stub in this directory.
+_mock_record() {
+    _mr_tool="$1"; shift
+    if [ -n "${OMNIVEC_MOCK_LOG:-}" ]; then
+        printf '%s' "$_mr_tool" >> "$OMNIVEC_MOCK_LOG"
+        for _mr_a in "$@"; do
+            # Quote args containing whitespace so the log is parseable.
+            case "$_mr_a" in
+                *' '*|*'	'*) printf ' "%s"' "$_mr_a" >> "$OMNIVEC_MOCK_LOG" ;;
+                *)               printf ' %s'   "$_mr_a" >> "$OMNIVEC_MOCK_LOG" ;;
+            esac
+        done
+        printf '\n' >> "$OMNIVEC_MOCK_LOG"
+    fi
+}
+
+_mock_env_store() {
+    # Simple key=value store backed by $OMNIVEC_MOCK_AZD_ENV.
+    if [ -z "${OMNIVEC_MOCK_AZD_ENV:-}" ]; then
+        OMNIVEC_MOCK_AZD_ENV="${TMPDIR:-/tmp}/mock-azd-env.$$"
+        export OMNIVEC_MOCK_AZD_ENV
+    fi
+    [ -f "$OMNIVEC_MOCK_AZD_ENV" ] || : > "$OMNIVEC_MOCK_AZD_ENV"
+}
+
+_mock_env_set() {
+    _mock_env_store
+    _k="$1"; _v="$2"
+    # Remove any prior line for $_k, then append the new value.
+    grep -v "^${_k}=" "$OMNIVEC_MOCK_AZD_ENV" > "${OMNIVEC_MOCK_AZD_ENV}.tmp" 2>/dev/null || true
+    printf '%s=%s\n' "$_k" "$_v" >> "${OMNIVEC_MOCK_AZD_ENV}.tmp"
+    mv "${OMNIVEC_MOCK_AZD_ENV}.tmp" "$OMNIVEC_MOCK_AZD_ENV"
+}
+
+_mock_env_get() {
+    _mock_env_store
+    _k="$1"
+    # Preset values (read-only): OMNIVEC_* starting state from caller env.
+    # Then look up the recorded store.
+    grep "^${_k}=" "$OMNIVEC_MOCK_AZD_ENV" 2>/dev/null | tail -1 | sed "s/^${_k}=//"
+}

--- a/tests/hooks/mocks/az
+++ b/tests/hooks/mocks/az
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Mock `az` CLI - canned responses for the subset hooks actually use.
+_DIR=$(cd "$(dirname "$0")" && pwd)
+. "$_DIR/_record.sh"
+_mock_record az "$@"
+
+# Find --query and -o/--output if present.
+_q=""; _out=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --query) _q="$2"; shift 2 ;;
+        -o|--output) _out="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+_cmd="${OMNIVEC_AZ_FIRST_TWO:-}"
+# Recover sub-command from full original argv via recorded log.
+_line=$(tail -1 "${OMNIVEC_MOCK_LOG:-/dev/null}" 2>/dev/null)
+
+case "$_line" in
+    *' account show '*)
+        printf '{"id":"00000000-0000-0000-0000-000000000000","name":"mock-sub","tenantId":"00000000-0000-0000-0000-000000000001","user":{"name":"mock@example.com"}}\n'
+        exit 0
+        ;;
+    *' provider show '*)
+        # preflight_require_providers checks registrationState
+        printf 'Registered\n'
+        exit 0
+        ;;
+    *' provider register '*)
+        exit 0
+        ;;
+    *' vm list-sizes '*)
+        # preflight_sku_vcpus needs vCPUs for a SKU
+        printf '[{"name":"Standard_B4ms","numberOfCores":4,"memoryInMb":16384}]\n'
+        exit 0
+        ;;
+    *' vm list-usage '*)
+        # quota check - pretend plenty of headroom
+        printf '[{"name":{"value":"standardBsFamily"},"limit":100,"currentValue":10}]\n'
+        exit 0
+        ;;
+    *' group exists '*)
+        printf 'false\n'
+        exit 0
+        ;;
+    *' group show '*)
+        printf '{"name":"rg-mock","location":"centralus"}\n'
+        exit 0
+        ;;
+    *' storage account check-name '*)
+        printf '{"nameAvailable":true}\n'
+        exit 0
+        ;;
+    *' cosmosdb check-name-exists '*|*' cognitiveservices account list '*|*' keyvault check-name '*)
+        printf 'false\n'
+        exit 0
+        ;;
+    *' deployment group list '*)
+        printf '[]\n'
+        exit 0
+        ;;
+    *' aks install-cli '*)
+        exit 0
+        ;;
+    *' aks get-credentials '*)
+        exit 0
+        ;;
+    *' acr '*)
+        # ACR token/login - just succeed.
+        exit 0
+        ;;
+    *' --version'*|*'version'*)
+        printf 'azure-cli 2.66.0 (mock)\n'
+        exit 0
+        ;;
+esac
+
+# Default: succeed quietly with empty output.
+exit 0

--- a/tests/hooks/mocks/azd
+++ b/tests/hooks/mocks/azd
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Mock `azd` - records invocation, emulates env set/get-value semantics.
+_DIR=$(cd "$(dirname "$0")" && pwd)
+. "$_DIR/_record.sh"
+_mock_record azd "$@"
+
+case "${1:-}" in
+    env)
+        case "${2:-}" in
+            set)
+                _mock_env_set "$3" "${4:-}"
+                exit 0
+                ;;
+            get-value)
+                _mock_env_get "$3"
+                exit 0
+                ;;
+            get-values)
+                _mock_env_store
+                cat "$OMNIVEC_MOCK_AZD_ENV" 2>/dev/null || true
+                exit 0
+                ;;
+            list)
+                # Emit a single env so hooks that inspect list can proceed.
+                printf 'NAME            DEFAULT  LOCAL\n'
+                printf '%s  true     true\n' "${AZURE_ENV_NAME:-mock-env}"
+                exit 0
+                ;;
+            new|select|refresh)
+                exit 0
+                ;;
+        esac
+        ;;
+    version)
+        printf 'azd version 1.24.1 (commit mock-harness) (mock)\n'
+        exit 0
+        ;;
+    auth)
+        # az auth login/token - never reach the internet in tests.
+        exit 0
+        ;;
+esac
+exit 0

--- a/tests/hooks/mocks/helm
+++ b/tests/hooks/mocks/helm
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Mock `helm`.
+_DIR=$(cd "$(dirname "$0")" && pwd)
+. "$_DIR/_record.sh"
+_mock_record helm "$@"
+
+case "${1:-}" in
+    version)
+        printf 'v3.16.2 (mock)\n'
+        exit 0
+        ;;
+    list)
+        printf 'NAME\tNAMESPACE\tREVISION\tSTATUS\n'
+        exit 0
+        ;;
+esac
+exit 0

--- a/tests/hooks/mocks/kubectl
+++ b/tests/hooks/mocks/kubectl
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Mock `kubectl`.
+_DIR=$(cd "$(dirname "$0")" && pwd)
+. "$_DIR/_record.sh"
+_mock_record kubectl "$@"
+
+case "${1:-}" in
+    version)
+        printf 'Client Version: v1.30.0 (mock)\n'
+        exit 0
+        ;;
+    get)
+        # Return empty lists by default (hook uses this for existence checks).
+        printf 'No resources found.\n'
+        exit 0
+        ;;
+esac
+exit 0

--- a/tests/hooks/test-mock-harness.sh
+++ b/tests/hooks/test-mock-harness.sh
@@ -1,0 +1,225 @@
+#!/bin/sh
+# End-to-end mock harness test for hooks/preprovision.sh.
+#
+# Runs the REAL preprovision.sh against recording mocks of azd/az/kubectl/helm.
+# This catches regressions like "we forgot to set OMNIVEC_GPU_NODE_COUNT" or
+# "we accidentally removed the `</dev/null` guard and now blocks on stdin".
+#
+# Tests cover:
+#   1. NONINTERACTIVE early-exit path (most common CI case): six OMNIVEC_*
+#      defaults must be azd-env-set, no cloud calls made, exit 0.
+#   2. Fast-fail when no TTY and no NONINTERACTIVE flag.
+#   3. Lock file is created and released on exit.
+#
+# Works under dash, bash, sh.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+MOCKS_DIR="$SCRIPT_DIR/mocks"
+PREPROVISION="$REPO_ROOT/hooks/preprovision.sh"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS+1)); printf '  PASS  %s\n' "$1"; }
+fail() { FAIL=$((FAIL+1)); printf '  FAIL  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; }
+
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t omnivec-mock)
+trap 'rm -rf "$TMP"' EXIT
+
+printf '\n=== Mock harness: hooks/preprovision.sh end-to-end ===\n'
+
+# Ensure mock stubs are executable (git may not preserve +x on Windows checkouts).
+chmod +x "$MOCKS_DIR"/azd "$MOCKS_DIR"/az "$MOCKS_DIR"/kubectl "$MOCKS_DIR"/helm 2>/dev/null || true
+
+# --- Case 1: NONINTERACTIVE path ---
+(
+    LOG="$TMP/case1.log"
+    AZDENV="$TMP/case1.env"
+    : > "$LOG"
+    : > "$AZDENV"
+
+    # Isolate HOME so the lock file can't collide with a real run.
+    HOME="$TMP/home-case1"
+    mkdir -p "$HOME"
+
+    export OMNIVEC_MOCK_LOG="$LOG"
+    export OMNIVEC_MOCK_AZD_ENV="$AZDENV"
+    export PATH="$MOCKS_DIR:$PATH"
+    export HOME
+    export AZURE_ENV_NAME="mock-case1"
+    export AZURE_LOCATION="centralus"
+    export OMNIVEC_NONINTERACTIVE=1
+    export OMNIVEC_FORCE_NO_TTY=1
+    # Keep heartbeat quiet so test output is readable.
+    export OMNIVEC_HEARTBEAT_QUIET=1
+
+    # Run the REAL hook. It should hit require_tty_or_preset, apply defaults,
+    # print the success banner, and exit 0 without reaching the big prompt block.
+    sh "$PREPROVISION" </dev/null >"$TMP/case1.out" 2>&1
+    rc=$?
+
+    [ "$rc" -eq 0 ] || { printf 'rc=%s\nout=\n%s\n' "$rc" "$(cat "$TMP/case1.out")" >&2; exit 1; }
+
+    # Verify the six defaults were recorded. Accept the values either quoted or
+    # unquoted (our recorder quotes whitespace-containing args only).
+    for kv in \
+        'OMNIVEC_SYSTEM_NODE_VM_SIZE=Standard_B4ms' \
+        'OMNIVEC_SYSTEM_NODE_COUNT=2' \
+        'OMNIVEC_GPU_NODE_COUNT=0' \
+        'OMNIVEC_METADATA_STORE=cosmosdb-serverless' \
+        'OMNIVEC_ENABLE_BLOB_SOURCE=true'; do
+        if ! grep -q "^${kv}\$" "$AZDENV"; then
+            printf 'missing %s\n--- env store ---\n%s\n--- mock log ---\n%s\n' \
+                "$kv" "$(cat "$AZDENV")" "$(cat "$LOG")" >&2
+            exit 1
+        fi
+    done
+
+    # GPU SKU may be empty - check the key exists even if value is ''.
+    grep -q '^OMNIVEC_GPU_NODE_VM_SIZE=' "$AZDENV" || {
+        printf 'missing OMNIVEC_GPU_NODE_VM_SIZE key\n' >&2; exit 1
+    }
+
+    # No mutating cloud calls should happen on this fast path - read-only
+    # preflight (az account show / az group exists) is fine, but no create/
+    # update/delete/apply, no helm install, no kubectl apply.
+    if grep -Eq '^(kubectl (apply|create|delete|patch)|helm (install|upgrade|uninstall)|az [a-z-]+ (create|update|delete|set))' "$LOG"; then
+        printf 'unexpected mutating cloud calls on fast path:\n%s\n' "$(cat "$LOG")" >&2
+        exit 1
+    fi
+
+    # Success banner must show up.
+    grep -q 'non-interactive' "$TMP/case1.out" || {
+        printf 'banner missing:\n%s\n' "$(cat "$TMP/case1.out")" >&2; exit 1
+    }
+
+    exit 0
+) && pass "NONINTERACTIVE path: six OMNIVEC_* defaults set, no mutating cloud calls" \
+  || fail "NONINTERACTIVE path"
+
+# --- Case 2: No TTY + no flag -> fast fail with helpful message ---
+(
+    LOG="$TMP/case2.log"
+    AZDENV="$TMP/case2.env"
+    : > "$LOG"
+    : > "$AZDENV"
+    HOME="$TMP/home-case2"
+    mkdir -p "$HOME"
+
+    export OMNIVEC_MOCK_LOG="$LOG"
+    export OMNIVEC_MOCK_AZD_ENV="$AZDENV"
+    export PATH="$MOCKS_DIR:$PATH"
+    export HOME
+    export AZURE_ENV_NAME="mock-case2"
+    export OMNIVEC_FORCE_NO_TTY=1
+    export OMNIVEC_HEARTBEAT_QUIET=1
+    # Explicitly unset every non-interactive signal.
+    unset OMNIVEC_NONINTERACTIVE AZD_NONINTERACTIVE CI GITHUB_ACTIONS
+
+    sh "$PREPROVISION" </dev/null >"$TMP/case2.out" 2>&1
+    rc=$?
+
+    [ "$rc" -ne 0 ] || { printf 'expected non-zero rc, got %s\n' "$rc" >&2; exit 1; }
+
+    # Must mention actionable fix options.
+    grep -q 'OMNIVEC_NONINTERACTIVE' "$TMP/case2.out" \
+        && grep -q 'azd env set' "$TMP/case2.out" \
+        || { printf 'error message missing guidance:\n%s\n' "$(cat "$TMP/case2.out")" >&2; exit 1; }
+
+    exit 0
+) && pass "no-TTY + no flag: exits non-zero with actionable message" \
+  || fail "no-TTY fast-fail"
+
+# --- Case 3: Lock file is created and released ---
+(
+    LOG="$TMP/case3.log"
+    AZDENV="$TMP/case3.env"
+    : > "$LOG"; : > "$AZDENV"
+    HOME="$TMP/home-case3"
+    mkdir -p "$HOME"
+
+    export OMNIVEC_MOCK_LOG="$LOG"
+    export OMNIVEC_MOCK_AZD_ENV="$AZDENV"
+    export PATH="$MOCKS_DIR:$PATH"
+    export HOME
+    export AZURE_ENV_NAME="mock-case3"
+    export AZURE_LOCATION="centralus"
+    export OMNIVEC_NONINTERACTIVE=1
+    export OMNIVEC_FORCE_NO_TTY=1
+    export OMNIVEC_HEARTBEAT_QUIET=1
+
+    sh "$PREPROVISION" </dev/null >/dev/null 2>&1
+    rc=$?
+    [ "$rc" -eq 0 ] || { printf 'rc=%s\n' "$rc" >&2; exit 1; }
+
+    # Lock file should NOT remain after successful exit.
+    if [ -f "$HOME/.omnivec/locks/${AZURE_ENV_NAME}.lock" ]; then
+        printf 'lock file leaked: %s\n' "$HOME/.omnivec/locks/${AZURE_ENV_NAME}.lock" >&2
+        exit 1
+    fi
+    # But the locks dir should exist (acquire_lock mkdir -p).
+    [ -d "$HOME/.omnivec/locks" ] || { printf 'locks dir not created\n' >&2; exit 1; }
+
+    exit 0
+) && pass "lock file created and released on clean exit" \
+  || fail "lock file lifecycle"
+
+# --- Case 4: Stale lock (dead PID) is cleaned up ---
+(
+    LOG="$TMP/case4.log"
+    AZDENV="$TMP/case4.env"
+    : > "$LOG"; : > "$AZDENV"
+    HOME="$TMP/home-case4"
+    LOCK_DIR="$HOME/.omnivec/locks"
+    mkdir -p "$LOCK_DIR"
+    # Seed with a lock for a PID that cannot exist (PID 1 is init and kill -0
+    # would succeed; use a high unused pid for portability).
+    printf '999999\nsomehost\n' > "$LOCK_DIR/mock-case4.lock"
+
+    export OMNIVEC_MOCK_LOG="$LOG"
+    export OMNIVEC_MOCK_AZD_ENV="$AZDENV"
+    export PATH="$MOCKS_DIR:$PATH"
+    export HOME
+    export AZURE_ENV_NAME="mock-case4"
+    export AZURE_LOCATION="centralus"
+    export OMNIVEC_NONINTERACTIVE=1
+    export OMNIVEC_FORCE_NO_TTY=1
+    export OMNIVEC_HEARTBEAT_QUIET=1
+
+    sh "$PREPROVISION" </dev/null >"$TMP/case4.out" 2>&1
+    rc=$?
+    [ "$rc" -eq 0 ] || { printf 'rc=%s\nout=%s\n' "$rc" "$(cat "$TMP/case4.out")" >&2; exit 1; }
+    # Stale lock message should show up.
+    grep -qi 'stale lock' "$TMP/case4.out" || {
+        printf 'expected "Stale lock" notice:\n%s\n' "$(cat "$TMP/case4.out")" >&2
+        exit 1
+    }
+    exit 0
+) && pass "stale lock (dead PID) is auto-cleaned" \
+  || fail "stale lock recovery"
+
+# --- Case 5: Mocks themselves record correctly ---
+(
+    LOG="$TMP/case5.log"
+    AZDENV="$TMP/case5.env"
+    : > "$LOG"; : > "$AZDENV"
+    export OMNIVEC_MOCK_LOG="$LOG"
+    export OMNIVEC_MOCK_AZD_ENV="$AZDENV"
+    export PATH="$MOCKS_DIR:$PATH"
+    azd env set FOO bar </dev/null
+    azd env set WITH_SPACE "hello world" </dev/null
+    val=$(azd env get-value FOO </dev/null)
+    [ "$val" = "bar" ] || { printf 'expected bar, got %s\n' "$val" >&2; exit 1; }
+    val2=$(azd env get-value WITH_SPACE </dev/null)
+    [ "$val2" = "hello world" ] || { printf 'expected hello world, got %s\n' "$val2" >&2; exit 1; }
+    # Log must have both calls.
+    grep -q '^azd env set FOO bar$' "$LOG" || { printf 'missing FOO line\n'; cat "$LOG"; exit 1; } >&2
+    grep -q 'WITH_SPACE "hello world"' "$LOG" || { printf 'missing quoted arg\n'; cat "$LOG"; exit 1; } >&2
+    exit 0
+) && pass "mock recorder: set/get round-trip, whitespace-safe logging" \
+  || fail "mock recorder self-test"
+
+printf '\n=== %d passed, %d failed ===\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Why

`azd up` keeps biting us because most of the hook logic is never exercised without a real Azure subscription. You asked about a LocalStack-for-Azure - there isn't one. Azurite, the Cosmos emulator, and the Service Bus emulator cover data planes only; nothing emulates ARM + AKS + Workload Identity + RBAC together.

This PR adds the next-best thing: a **recording mock** of the CLIs our hooks shell out to (`azd`, `az`, `kubectl`, `helm`), so we can run the **real** `hooks/preprovision.sh` end-to-end in CI and assert on the sequence of cloud calls it makes. This catches regressions like "we forgot to set OMNIVEC_GPU_NODE_COUNT" or "we accidentally dropped a `</dev/null` guard and now block on stdin" - which is the failure mode we've hit repeatedly.

## What's in here

**Mocks** (`tests/hooks/mocks/`):
- `_record.sh` - shared recorder and a tiny k=v store that simulates `azd env set` / `azd env get-value` round-trips.
- `azd` / `az` / `kubectl` / `helm` - POSIX stubs that append `<tool> <args>` to `\` and return canned output that's just realistic enough for the hook to progress.

**Test driver** (`tests/hooks/test-mock-harness.sh`):
Runs the real `preprovision.sh` against the mocks. Five assertions:
1. NONINTERACTIVE path sets the six OMNIVEC_* defaults and makes zero *mutating* cloud calls (read-only preflight like `az account show` is allowed).
2. No-TTY + no flag exits non-zero with an actionable error message.
3. Lock file is created and released on clean exit.
4. Stale lock (dead PID) is auto-cleaned.
5. Mock recorder round-trips correctly and safely quotes whitespace.

Verified green under **dash, bash, and sh**. Auto-picked up by `tests/run.sh`.

## Side-fix caught by the static analyzer

While running the full suite, `tests/hooks/test-stdin-guards.sh` flagged two new bare `kubectl` calls that landed via PRs #65/#66 (the kubeconfig pinning work). They're in `hooks/postprovision.sh` at lines 461 and 467. If either ran inside a pipeline it could swallow the outer stdin and hang. Fixed with `</dev/null` on the `config get-contexts` call and a `# stdin-ok` marker on the helper (callers already pass `</dev/null`).

## .gitattributes

Pinned the four extensionless mock stubs to LF. They live on `\` during tests and must run under `sh` on Linux/macOS. They're also marked `100755` in the git index so fresh Linux checkouts have `+x`.

## Follow-up: real what-if in CI

The other half of what I proposed - `azd provision --preview` against an Azure sandbox subscription in a nightly workflow - needs a long-lived `AZURE_CREDENTIALS_WHATIF` secret and a sandbox sub. I didn't ship it here because the sub/secret setup needs your decision. Happy to add in a follow-up PR once you point me at a subscription.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>