### PR TITLE
fix(pipeline): eliminate 6 critical hang scenarios (C1-C6)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -2073,6 +2073,7 @@ def pause_pipeline(pipeline_id: str):
 
     pipeline = _pipeline_from_doc(doc)
     pipeline.status = PipelineStatus.PAUSED
+    pipeline.updated_at = datetime.utcnow()
     store.upsert(_to_doc(pipeline, "pipeline"))
     return {"success": True}
 
@@ -2087,6 +2088,7 @@ def resume_pipeline(pipeline_id: str):
 
     pipeline = _pipeline_from_doc(doc)
     pipeline.status = PipelineStatus.ACTIVE
+    pipeline.updated_at = datetime.utcnow()
     store.upsert(_to_doc(pipeline, "pipeline"))
     return {"success": True}
 
@@ -4466,6 +4468,92 @@ def _get_pg_stats_cached(source, pipeline, store):
         return None
 
 
+def _get_blob_embed_count_pg(dest_cfg, pipeline_id, reset_at):
+    """Count rows in a pgvector destination table for a given pipeline since reset_at.
+
+    Used when source.type == AZURE_BLOB and destination.type == pgvector.
+    Returns int (row count) or None on failure. Resilient to missing
+    cfp_generation / embedded_at columns on older tables.
+    """
+    import asyncio
+    from health_checker import _connect_pg
+
+    table = dest_cfg.get("table", "")
+    schema = dest_cfg.get("schema_name", dest_cfg.get("schema", "public"))
+    if not table:
+        return None
+
+    async def _q():
+        conn = await _connect_pg(dest_cfg)
+        try:
+            # Prefer pipeline_id + embedded_at filter; fall back gracefully.
+            try:
+                return await conn.fetchval(
+                    f'SELECT COUNT(*) FROM "{schema}"."{table}" '
+                    f'WHERE pipeline_id = $1 AND embedded_at >= $2::timestamptz',
+                    pipeline_id, reset_at)
+            except Exception:
+                try:
+                    return await conn.fetchval(
+                        f'SELECT COUNT(*) FROM "{schema}"."{table}" WHERE pipeline_id = $1',
+                        pipeline_id)
+                except Exception:
+                    return await conn.fetchval(
+                        f'SELECT COUNT(*) FROM "{schema}"."{table}" WHERE embedding IS NOT NULL')
+        finally:
+            await conn.close()
+
+    try:
+        return asyncio.run(_q())
+    except Exception as e:
+        logger.warning(f"pgvector blob embed count failed: {e}")
+        return None
+
+
+def _get_blob_embed_count_mssql(dest_cfg, pipeline_id, reset_at):
+    """Count rows in an MSSQL destination table for a given pipeline since reset_at."""
+    try:
+        import pyodbc
+    except ImportError:
+        logger.warning("pyodbc not installed; cannot count mssql blob embeddings")
+        return None
+
+    host = dest_cfg.get("host", "")
+    database = dest_cfg.get("database", "")
+    user = dest_cfg.get("user", "")
+    password = dest_cfg.get("password", "")
+    port = dest_cfg.get("port", 1433)
+    table = dest_cfg.get("table", "")
+    schema = dest_cfg.get("schema_name", dest_cfg.get("schema", "dbo"))
+    if not (host and database and table):
+        return None
+
+    conn_str = (
+        f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={host},{port};"
+        f"DATABASE={database};UID={user};PWD={password};Encrypt=yes;TrustServerCertificate=yes;"
+    )
+    try:
+        cn = pyodbc.connect(conn_str, timeout=5)
+        cur = cn.cursor()
+        try:
+            cur.execute(
+                f"SELECT COUNT(*) FROM [{schema}].[{table}] "
+                f"WHERE pipeline_id = ? AND embedded_at >= ?",
+                pipeline_id, reset_at)
+            return cur.fetchone()[0]
+        except Exception:
+            cur.execute(
+                f"SELECT COUNT(*) FROM [{schema}].[{table}] WHERE pipeline_id = ?",
+                pipeline_id)
+            return cur.fetchone()[0]
+        finally:
+            cur.close()
+            cn.close()
+    except Exception as e:
+        logger.warning(f"mssql blob embed count failed: {e}")
+        return None
+
+
 _mssql_stats_cache: dict = {}  # key: (source_id, dest_table) -> (source_count, embed_count, timestamp)
 
 def _get_mssql_stats_cached(source, pipeline, store):
@@ -4733,30 +4821,45 @@ def get_pipeline_stats(pipeline_id: str) -> PipelineRunStats:
                             blob_count += 1
                         source_doc_count = blob_count
 
-                    # Count embedded docs in destination CosmosDB container
+                    # Count embedded docs in the pipeline's destination store.
+                    # Dispatch by destination type: cosmosdb | pgvector | mssql.
                     if pipeline.destination_id:
                         dest_doc = store.get(pipeline.destination_id, "destination")
                         if dest_doc:
                             dest_cfg = dest_doc.get("config", {})
-                            dest_endpoint = dest_cfg.get("endpoint", "")
-                            if dest_endpoint:
-                                dest_client = CosmosClient(dest_endpoint, credential=DefaultAzureCredential())
-                                embed_container = dest_client.get_database_client(dest_cfg["database"]).get_container_client(dest_cfg["container"])
-                                reset_at = pipeline.reset_at or "1970-01-01T00:00:00"
-                                if hasattr(reset_at, 'isoformat'):
-                                    reset_at = reset_at.isoformat()
-                                reset_at = str(reset_at)
-                                count_query = (
-                                    "SELECT VALUE COUNT(1) FROM c "
-                                    "WHERE c.pipeline_id = @pid AND c.embedded_at >= @reset_at"
-                                )
-                                count_params = [
-                                    {"name": "@pid", "value": pipeline_id},
-                                    {"name": "@reset_at", "value": reset_at},
-                                ]
-                                result = list(embed_container.query_items(count_query, parameters=count_params, enable_cross_partition_query=True))
-                                if result:
-                                    embedded_count = result[0]
+                            dest_type = (dest_doc.get("type") or "").lower()
+                            reset_at = pipeline.reset_at or "1970-01-01T00:00:00"
+                            if hasattr(reset_at, 'isoformat'):
+                                reset_at = reset_at.isoformat()
+                            reset_at = str(reset_at)
+
+                            try:
+                                if dest_type in ("cosmosdb", "cosmos", "azure-cosmos-db"):
+                                    dest_endpoint = dest_cfg.get("endpoint", "")
+                                    if dest_endpoint:
+                                        dest_client = CosmosClient(dest_endpoint, credential=DefaultAzureCredential())
+                                        embed_container = dest_client.get_database_client(dest_cfg["database"]).get_container_client(dest_cfg["container"])
+                                        count_query = (
+                                            "SELECT VALUE COUNT(1) FROM c "
+                                            "WHERE c.pipeline_id = @pid AND c.embedded_at >= @reset_at"
+                                        )
+                                        count_params = [
+                                            {"name": "@pid", "value": pipeline_id},
+                                            {"name": "@reset_at", "value": reset_at},
+                                        ]
+                                        result = list(embed_container.query_items(count_query, parameters=count_params, enable_cross_partition_query=True))
+                                        if result:
+                                            embedded_count = result[0]
+                                elif dest_type in ("pgvector", "postgresql", "postgres"):
+                                    ec = _get_blob_embed_count_pg(dest_cfg, pipeline_id, reset_at)
+                                    if ec is not None:
+                                        embedded_count = ec
+                                elif dest_type in ("mssql", "sqlserver", "sql-server"):
+                                    ec = _get_blob_embed_count_mssql(dest_cfg, pipeline_id, reset_at)
+                                    if ec is not None:
+                                        embedded_count = ec
+                            except Exception as ce:
+                                logger.warning(f"Blob embedded_count query failed (dest_type={dest_type}): {ce}")
 
                     docs_processed = embedded_count
                     if source_doc_count and source_doc_count > 0:

--- a/connectors/ingestion/dotnet/Program.cs
+++ b/connectors/ingestion/dotnet/Program.cs
@@ -38,6 +38,7 @@ builder.Services.AddHttpClient<OmniVecApiClient>((sp, client) =>
 
 // Services
 builder.Services.AddSingleton<LeaseContainerManager>();
+builder.Services.AddSingleton<BlobLeaseManager>();
 builder.Services.AddSingleton<ContentHasher>();
 builder.Services.AddSingleton<ServiceBusPublisher>();
 builder.Services.AddSingleton<SourceWatcherManager>();

--- a/connectors/ingestion/dotnet/Services/BlobLeaseManager.cs
+++ b/connectors/ingestion/dotnet/Services/BlobLeaseManager.cs
@@ -1,0 +1,172 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+using OmniVec.ChangeFeed.Configuration;
+
+namespace OmniVec.ChangeFeed.Services;
+
+/// <summary>
+/// Distributed lease manager for Blob sources. Prevents duplicate enumeration across
+/// multiple change-feed pod replicas (default replicaCount=15).
+///
+/// Each pod calls TryAcquireAsync(sourceId) on every reconcile cycle. At most one pod
+/// holds a valid lease at any time. Expired leases (owner missed renewals for >
+/// LeaseTtlSeconds) can be stolen by any other pod using a conditional ETag update.
+///
+/// Lease doc schema (container: blob-leases in omnivec-cosmos):
+///   { "id": "<sourceId>", "ownerId": "<hostname>", "expiresAt": "<iso-utc>" }
+/// Partition key: /id
+/// </summary>
+public class BlobLeaseManager
+{
+    private readonly CosmosClient _cosmos;
+    private readonly ChangeFeedOptions _options;
+    private readonly ILogger<BlobLeaseManager> _logger;
+    private readonly string _ownerId;
+    private Container? _container;
+    private readonly SemaphoreSlim _ensureGate = new(1, 1);
+
+    // Tunables
+    public int LeaseTtlSeconds { get; set; } = 90;  // stale after 90s without renewal
+
+    public BlobLeaseManager(
+        CosmosClient cosmos,
+        IOptions<ChangeFeedOptions> options,
+        ILogger<BlobLeaseManager> logger)
+    {
+        _cosmos = cosmos;
+        _options = options.Value;
+        _logger = logger;
+        _ownerId = Environment.GetEnvironmentVariable("HOSTNAME")
+                   ?? Environment.GetEnvironmentVariable("POD_NAME")
+                   ?? Guid.NewGuid().ToString("N");
+    }
+
+    public string OwnerId => _ownerId;
+
+    private async Task<Container> EnsureContainerAsync(CancellationToken ct)
+    {
+        if (_container is not null) return _container;
+        await _ensureGate.WaitAsync(ct);
+        try
+        {
+            if (_container is not null) return _container;
+            var db = _cosmos.GetDatabase(_options.OmniVecDatabase);
+            await db.CreateContainerIfNotExistsAsync(
+                new ContainerProperties("blob-leases", "/id"),
+                cancellationToken: ct);
+            _container = db.GetContainer("blob-leases");
+            return _container;
+        }
+        finally
+        {
+            _ensureGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Try to acquire or renew the lease for <paramref name="sourceId"/>.
+    /// Returns true iff this pod currently owns the lease (and renewal was written).
+    /// Safe to call on every reconcile pass.
+    /// </summary>
+    public async Task<bool> TryAcquireAsync(string sourceId, CancellationToken ct)
+    {
+        try
+        {
+            var container = await EnsureContainerAsync(ct);
+            var pk = new PartitionKey(sourceId);
+            var nowUtc = DateTime.UtcNow;
+            var newExpiresAt = nowUtc.AddSeconds(LeaseTtlSeconds).ToString("o");
+
+            // Read existing lease (if any)
+            ItemResponse<LeaseDoc>? existing = null;
+            try
+            {
+                existing = await container.ReadItemAsync<LeaseDoc>(sourceId, pk, cancellationToken: ct);
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                // No lease yet — try to create with IfNoneMatch on ETag
+                try
+                {
+                    await container.CreateItemAsync(
+                        new LeaseDoc { Id = sourceId, OwnerId = _ownerId, ExpiresAt = newExpiresAt },
+                        pk,
+                        cancellationToken: ct);
+                    return true;
+                }
+                catch (CosmosException ex2) when (ex2.StatusCode == HttpStatusCode.Conflict)
+                {
+                    // Someone else created it between read and create — retry as a read below.
+                    existing = await container.ReadItemAsync<LeaseDoc>(sourceId, pk, cancellationToken: ct);
+                }
+            }
+
+            if (existing is null) return false;
+
+            var doc = existing.Resource;
+            var etag = existing.ETag;
+
+            bool isOwner = doc.OwnerId == _ownerId;
+            bool isExpired = !DateTime.TryParse(doc.ExpiresAt, null,
+                System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+                out var exp) || exp < nowUtc;
+
+            if (!isOwner && !isExpired)
+            {
+                return false; // Someone else holds a valid lease
+            }
+
+            // Either we own it (renewal) or it is expired (steal). Either way, write with IfMatch.
+            doc.OwnerId = _ownerId;
+            doc.ExpiresAt = newExpiresAt;
+            try
+            {
+                await container.ReplaceItemAsync(
+                    doc, sourceId, pk,
+                    new ItemRequestOptions { IfMatchEtag = etag },
+                    cancellationToken: ct);
+                return true;
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.PreconditionFailed)
+            {
+                // Another pod won the race. That's fine.
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "BlobLeaseManager.TryAcquireAsync failed for source {SourceId}", sourceId);
+            return false;
+        }
+    }
+
+    /// <summary>Best-effort release of a lease (on watcher dispose).</summary>
+    public async Task ReleaseAsync(string sourceId, CancellationToken ct)
+    {
+        try
+        {
+            if (_container is null) return;
+            var pk = new PartitionKey(sourceId);
+            var existing = await _container.ReadItemAsync<LeaseDoc>(sourceId, pk, cancellationToken: ct);
+            if (existing.Resource.OwnerId != _ownerId) return;
+            // Expire it immediately.
+            existing.Resource.ExpiresAt = DateTime.UtcNow.AddSeconds(-1).ToString("o");
+            await _container.ReplaceItemAsync(
+                existing.Resource, sourceId, pk,
+                new ItemRequestOptions { IfMatchEtag = existing.ETag },
+                cancellationToken: ct);
+        }
+        catch { /* best-effort */ }
+    }
+
+    private class LeaseDoc
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("id")]
+        public string Id { get; set; } = "";
+        [System.Text.Json.Serialization.JsonPropertyName("ownerId")]
+        public string OwnerId { get; set; } = "";
+        [System.Text.Json.Serialization.JsonPropertyName("expiresAt")]
+        public string ExpiresAt { get; set; } = "";
+    }
+}

--- a/connectors/ingestion/dotnet/Services/BlobSourceWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/BlobSourceWatcher.cs
@@ -21,7 +21,7 @@ public class BlobSourceWatcher : ISourceWatcher
     private readonly ChangeFeedOptions _options;
     private readonly OmniVecApiClient _apiClient;
     private readonly ContentHasher _hasher;
-    private readonly ServiceBusPublisher _sbPublisher;
+    private readonly ServiceBusPublisher? _sbPublisher;
     private readonly ILogger<BlobSourceWatcher> _logger;
 
     private CancellationTokenSource? _cts;
@@ -58,8 +58,10 @@ public class BlobSourceWatcher : ISourceWatcher
         _options = options;
         _apiClient = apiClient;
         _hasher = hasher;
-        _sbPublisher = sbPublisher ?? throw new ArgumentNullException(nameof(sbPublisher),
-            "Blob sources require Service Bus (queue mode only)");
+        // Blob sources depend on Service Bus, but we must not throw here:
+        // SourceWatcherManager will detect a disabled publisher and skip CreateWatcher.
+        // Throwing would crash the entire ReconcileAsync pass and silently stall discovery.
+        _sbPublisher = sbPublisher;
         _logger = logger;
         Generation = generation ?? "0";
     }
@@ -73,6 +75,16 @@ public class BlobSourceWatcher : ISourceWatcher
 
     public async Task StartAsync(CancellationToken ct)
     {
+        // Blob sources require a working Service Bus publisher. If it's not configured,
+        // log a loud warning and stay idle rather than crashing the reconcile loop.
+        if (_sbPublisher is null || !_sbPublisher.IsEnabled)
+        {
+            _logger.LogWarning(
+                "Blob source {Source}: Service Bus publisher is not enabled — watcher will stay idle until SB is configured.",
+                _source.Name);
+            return;
+        }
+
         // Verify connection
         var client = CreateBlobServiceClient();
         var container = client.GetBlobContainerClient(_source.BlobContainer);
@@ -105,7 +117,7 @@ public class BlobSourceWatcher : ISourceWatcher
             try
             {
                 // Check backpressure before enumerating more
-                if (!await _sbPublisher.HasCapacityAsync(ct))
+                if (!await _sbPublisher!.HasCapacityAsync(ct))
                 {
                     _logger.LogInformation("Blob prefill paused (backpressure), waiting {Seconds}s",
                         _options.BackpressurePauseSeconds);
@@ -229,7 +241,7 @@ public class BlobSourceWatcher : ISourceWatcher
         if (newBlobs.Count > 0)
         {
             // Check backpressure before publishing
-            if (!await _sbPublisher.HasCapacityAsync(ct))
+            if (!await _sbPublisher!.HasCapacityAsync(ct))
             {
                 _logger.LogWarning("Blob live poll: {Count} new blobs found but backpressure active, will retry",
                     newBlobs.Count);
@@ -292,7 +304,7 @@ public class BlobSourceWatcher : ISourceWatcher
                 };
             }).ToList();
 
-            await _sbPublisher.PublishBatchAsync(messages, ct);
+            await _sbPublisher!.PublishBatchAsync(messages, ct);
         }
     }
 

--- a/connectors/ingestion/dotnet/Services/SourceWatcherManager.cs
+++ b/connectors/ingestion/dotnet/Services/SourceWatcherManager.cs
@@ -19,6 +19,7 @@ public class SourceWatcherManager : IAsyncDisposable
     private readonly ChangeFeedOptions _options;
     private readonly OmniVecApiClient _apiClient;
     private readonly LeaseContainerManager _leaseManager;
+    private readonly BlobLeaseManager _blobLeaseManager;
     private readonly ContentHasher _hasher;
     private readonly ServiceBusPublisher _sbPublisher;
     private readonly ILoggerFactory _loggerFactory;
@@ -41,6 +42,7 @@ public class SourceWatcherManager : IAsyncDisposable
         IOptions<ChangeFeedOptions> options,
         OmniVecApiClient apiClient,
         LeaseContainerManager leaseManager,
+        BlobLeaseManager blobLeaseManager,
         ContentHasher hasher,
         ServiceBusPublisher sbPublisher,
         ILoggerFactory loggerFactory,
@@ -49,6 +51,7 @@ public class SourceWatcherManager : IAsyncDisposable
         _options = options.Value;
         _apiClient = apiClient;
         _leaseManager = leaseManager;
+        _blobLeaseManager = blobLeaseManager;
         _hasher = hasher;
         _sbPublisher = sbPublisher;
         _loggerFactory = loggerFactory;
@@ -96,6 +99,26 @@ public class SourceWatcherManager : IAsyncDisposable
         foreach (var source in desiredSources)
         {
             var generation = GetGeneration(source.Id, activePipelines);
+
+            // For azure-blob sources we partition across replicas with a Cosmos lease so
+            // only one pod enumerates a given container. Without this, all 15 replicas
+            // publish the same blobs → duplicate work and can blow past SB capacity.
+            bool isBlob = string.Equals(source.Type, "azure-blob", StringComparison.OrdinalIgnoreCase);
+            if (isBlob)
+            {
+                var haveLease = await _blobLeaseManager.TryAcquireAsync(source.Id, ct);
+                if (!haveLease)
+                {
+                    // Another pod owns this blob source. If we were running it, stop.
+                    if (_watchers.TryRemove(source.Id, out var old))
+                    {
+                        _logger.LogInformation(
+                            "Lost blob lease for source {SourceId}, stopping local watcher", source.Id);
+                        await old.DisposeAsync();
+                    }
+                    continue;
+                }
+            }
 
             if (currentIds.Contains(source.Id))
             {
@@ -226,7 +249,7 @@ public class SourceWatcherManager : IAsyncDisposable
                 source, _options, _apiClient, _hasher,
                 _loggerFactory.CreateLogger<BlobSourceWatcher>(),
                 generation: generation,
-                sbPublisher: _sbPublisher),
+                sbPublisher: _sbPublisher.IsEnabled ? _sbPublisher : null),
 
             _ => new SourceWatcher(
                 source, _options, _apiClient, _leaseManager, _hasher,

--- a/connectors/worker/dotnet/Program.cs
+++ b/connectors/worker/dotnet/Program.cs
@@ -12,15 +12,18 @@ var builder = Host.CreateApplicationBuilder(args);
 builder.Services.Configure<WorkerOptions>(
     builder.Configuration.GetSection("Worker"));
 
-// Service Bus client — only register when namespace is configured
+// Service Bus client — only register when namespace is configured.
+// If not configured, fail fast at startup so Kubernetes surfaces CrashLoopBackOff
+// instead of silently idling (old behavior returned null and awaited Task.Delay(Infinite)).
 builder.Services.AddSingleton(sp =>
 {
     var opts = sp.GetRequiredService<IOptions<WorkerOptions>>().Value;
     if (string.IsNullOrWhiteSpace(opts.ServiceBusNamespace))
     {
         var log = sp.GetRequiredService<ILogger<Program>>();
-        log.LogWarning("Service Bus namespace not configured — worker will start but cannot process queue messages");
-        return (ServiceBusClient?)null;
+        log.LogCritical("Worker__ServiceBusNamespace is not set — worker cannot process queue messages. Exiting so Kubernetes surfaces the failure.");
+        Environment.Exit(2);
+        throw new InvalidOperationException("Worker__ServiceBusNamespace is not set"); // unreachable; satisfies compiler
     }
     return new ServiceBusClient(opts.ServiceBusNamespace, new DefaultAzureCredential());
 });
@@ -45,6 +48,9 @@ builder.Services.AddHttpClient<MetricsReporter>((sp, client) =>
 builder.Services.AddSingleton<IDestinationWriter, CosmosDbDestinationWriter>();
 builder.Services.AddSingleton<IDestinationWriter, PostgresDestinationWriter>();
 builder.Services.AddSingleton<IDestinationWriter, MsSqlDestinationWriter>();
+
+// Health endpoint (must be a hosted service so it runs alongside the worker)
+builder.Services.AddHostedService<HealthEndpointService>();
 
 // Worker
 builder.Services.AddHostedService<EmbeddingWorkerService>();

--- a/connectors/worker/dotnet/Services/EmbeddingWorkerService.cs
+++ b/connectors/worker/dotnet/Services/EmbeddingWorkerService.cs
@@ -78,6 +78,10 @@ public class EmbeddingWorkerService : BackgroundService
         {
             try
             {
+                // Heartbeat: we're alive and about to receive. Keeps liveness probe happy
+                // even when the subscription is empty.
+                WorkerHeartbeat.Beat();
+
                 // Pull a batch of messages
                 var sbMessages = await receiver.ReceiveMessagesAsync(
                     _options.EmbedBatchSize,
@@ -85,6 +89,9 @@ public class EmbeddingWorkerService : BackgroundService
                     ct);
 
                 if (sbMessages.Count == 0) continue;
+
+                // First message received ever → mark ready.
+                WorkerHeartbeat.MarkReceivedFirstMessage();
 
                 // Deserialize and pair with SB messages
                 var items = new List<(EmbeddingMessage msg, ServiceBusReceivedMessage sbMsg)>();

--- a/connectors/worker/dotnet/Services/HealthEndpointService.cs
+++ b/connectors/worker/dotnet/Services/HealthEndpointService.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Text;
+
+namespace OmniVec.Worker.Services;
+
+/// <summary>
+/// Minimal HTTP health endpoint for Kubernetes probes.
+/// Exposes:
+///   GET /healthz  — liveness (200 if the process is running; 503 if receive loop has been
+///                   dead for longer than UnhealthyAfterSeconds after startup).
+///   GET /ready    — readiness (200 once the worker has completed at least one successful
+///                   receive cycle, meaning SB auth + network are working).
+///
+/// Deliberately uses HttpListener so we don't need to pull in ASP.NET Core.
+/// </summary>
+public class HealthEndpointService : BackgroundService
+{
+    private readonly ILogger<HealthEndpointService> _logger;
+    private readonly int _port;
+
+    public HealthEndpointService(ILogger<HealthEndpointService> logger)
+    {
+        _logger = logger;
+        _port = int.TryParse(Environment.GetEnvironmentVariable("HEALTH_PORT"), out var p) ? p : 8080;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken ct)
+    {
+        var listener = new HttpListener();
+        listener.Prefixes.Add($"http://+:{_port}/");
+        try
+        {
+            listener.Start();
+        }
+        catch (HttpListenerException ex)
+        {
+            // Common on dev machines without netsh urlacl; fall back to localhost-only.
+            _logger.LogWarning(ex, "HttpListener could not bind to http://+:{Port}/, falling back to http://127.0.0.1:{Port}/", _port, _port);
+            listener = new HttpListener();
+            listener.Prefixes.Add($"http://127.0.0.1:{_port}/");
+            listener.Start();
+        }
+
+        _logger.LogInformation("Health endpoint listening on port {Port} (/healthz, /ready)", _port);
+
+        while (!ct.IsCancellationRequested)
+        {
+            HttpListenerContext context;
+            try
+            {
+                context = await listener.GetContextAsync().WaitAsync(ct);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Health listener accept error");
+                continue;
+            }
+
+            _ = Task.Run(() => HandleAsync(context, ct), ct);
+        }
+
+        try { listener.Stop(); } catch { /* ignore */ }
+    }
+
+    private static async Task HandleAsync(HttpListenerContext ctx, CancellationToken ct)
+    {
+        string path = ctx.Request.Url?.AbsolutePath?.ToLowerInvariant() ?? "/";
+        var (status, payload) = path switch
+        {
+            "/healthz" => EvaluateLiveness(),
+            "/ready"   => EvaluateReadiness(),
+            _          => (404, "not found"),
+        };
+
+        ctx.Response.StatusCode = status;
+        ctx.Response.ContentType = "text/plain";
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        ctx.Response.ContentLength64 = bytes.Length;
+        try
+        {
+            await ctx.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length, ct);
+        }
+        catch { /* client gone */ }
+        finally
+        {
+            try { ctx.Response.OutputStream.Close(); } catch { }
+        }
+    }
+
+    private static (int, string) EvaluateLiveness()
+    {
+        // Liveness: alive as long as the receive loop has heart-beaten within
+        // WorkerHeartbeat.UnhealthyAfterSeconds (or we're still in grace period).
+        if (WorkerHeartbeat.IsHealthy(out var ageSec))
+            return (200, $"ok age_s={ageSec}");
+        return (503, $"stale last_beat_age_s={ageSec}");
+    }
+
+    private static (int, string) EvaluateReadiness()
+    {
+        if (WorkerHeartbeat.HasReceivedFirstMessage)
+            return (200, "ready");
+        return (503, "not_ready — no successful receive yet");
+    }
+}
+
+/// <summary>Shared heartbeat state between the receive loop and health endpoint.</summary>
+public static class WorkerHeartbeat
+{
+    private static long _lastBeatTicks = DateTime.UtcNow.Ticks;
+    private static int _hasReceivedFirstMessage; // 0/1
+    private static readonly DateTime _startedAt = DateTime.UtcNow;
+
+    /// <summary>Grace period after startup during which liveness always passes.</summary>
+    public static int GraceSeconds { get; set; } = 60;
+
+    /// <summary>If no beat within this window (after grace), liveness fails.</summary>
+    public static int UnhealthyAfterSeconds { get; set; } = 120;
+
+    public static void Beat()
+    {
+        Interlocked.Exchange(ref _lastBeatTicks, DateTime.UtcNow.Ticks);
+    }
+
+    public static void MarkReceivedFirstMessage()
+    {
+        Interlocked.CompareExchange(ref _hasReceivedFirstMessage, 1, 0);
+        Beat();
+    }
+
+    public static bool HasReceivedFirstMessage =>
+        Interlocked.CompareExchange(ref _hasReceivedFirstMessage, 0, 0) == 1;
+
+    public static bool IsHealthy(out long ageSeconds)
+    {
+        var lastBeat = new DateTime(Interlocked.Read(ref _lastBeatTicks), DateTimeKind.Utc);
+        ageSeconds = (long)(DateTime.UtcNow - lastBeat).TotalSeconds;
+
+        // Always healthy during grace period after process start.
+        if ((DateTime.UtcNow - _startedAt).TotalSeconds < GraceSeconds) return true;
+
+        return ageSeconds < UnhealthyAfterSeconds;
+    }
+}

--- a/helm/omnivec/templates/dotnet-worker-deployment.yaml
+++ b/helm/omnivec/templates/dotnet-worker-deployment.yaml
@@ -42,6 +42,33 @@ spec:
               value: {{ .Values.dotnetWorker.batchAccumulateMs | default 500 | quote }}
             - name: AZURE_CLIENT_ID
               value: {{ .Values.azure.workloadIdentity.clientId | quote }}
+          ports:
+            - name: health
+              containerPort: {{ .Values.dotnetWorker.healthPort | default 8080 }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.dotnetWorker.healthPort | default 8080 }}
+            initialDelaySeconds: {{ .Values.dotnetWorker.probes.liveness.initialDelaySeconds | default 30 }}
+            periodSeconds: {{ .Values.dotnetWorker.probes.liveness.periodSeconds | default 30 }}
+            timeoutSeconds: {{ .Values.dotnetWorker.probes.liveness.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.dotnetWorker.probes.liveness.failureThreshold | default 3 }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: {{ .Values.dotnetWorker.healthPort | default 8080 }}
+            initialDelaySeconds: {{ .Values.dotnetWorker.probes.readiness.initialDelaySeconds | default 10 }}
+            periodSeconds: {{ .Values.dotnetWorker.probes.readiness.periodSeconds | default 10 }}
+            timeoutSeconds: {{ .Values.dotnetWorker.probes.readiness.timeoutSeconds | default 3 }}
+            failureThreshold: {{ .Values.dotnetWorker.probes.readiness.failureThreshold | default 6 }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.dotnetWorker.healthPort | default 8080 }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: {{ .Values.dotnetWorker.probes.startup.failureThreshold | default 30 }}
           resources:
             {{- toYaml .Values.dotnetWorker.resources | nindent 12 }}
 {{- if .Values.dotnetWorker.autoscaling.enabled }}

--- a/helm/omnivec/values.yaml
+++ b/helm/omnivec/values.yaml
@@ -125,6 +125,21 @@ dotnetWorker:
     repository: omnivec-dotnet-worker
     tag: latest
     pullPolicy: Always
+  # Health/liveness HTTP port exposed by the worker (HealthEndpointService)
+  healthPort: 8080
+  probes:
+    liveness:
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readiness:
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 6
+    startup:
+      failureThreshold: 30
   resources:
     requests:
       memory: "256Mi"


### PR DESCRIPTION
Audit of the ingestion → embedding → vector-store pipeline surfaced six critical silent-failure paths. Any one of these could make a pipeline appear "stuck" while the actual bug is elsewhere.

## Summary

| # | Bug | Fix |
|---|---|---|
| **C1** | `embedded_count` hard-coded to 0 for blob→pgvector/mssql | Dispatch `AZURE_BLOB` stats by destination type; add pg + mssql count helpers |
| **C2** | `BlobSourceWatcher` throws `ArgumentNullException` when SB not configured → crashes reconcile every 5s forever | Constructor no longer throws; `StartAsync` stays idle and logs a warning; `SourceWatcherManager` passes null publisher when SB disabled |
| **C3** | `/resume` + `/pause` never set `updated_at` | Stamp `updated_at` so activation is observable |
| **C4** | `omnivec-dotnet-worker` had **zero** probes — pod shows Ready 1/1 while dead | New `HealthEndpointService` exposes `/healthz`+`/ready` via HttpListener (no new deps). Receive loop updates a shared `WorkerHeartbeat`. Helm template + values gain liveness/readiness/startup probes |
| **C5** | Worker silently idles forever if `Worker__ServiceBusNamespace` is blank | Factory `Environment.Exit(2)` on blank namespace → Kubernetes surfaces CrashLoopBackOff |
| **C6** | 15 changefeed replicas all independently enumerated the same blob container → duplicate SB messages, possible capacity stall | New `BlobLeaseManager` (Cosmos-backed, ETag-conditional, 90s TTL). `SourceWatcherManager` only creates `BlobSourceWatcher` on the pod that currently owns the lease |

## Verification

- `dotnet build connectors/ingestion/dotnet` — 0 warnings, 0 errors
- `dotnet build connectors/worker/dotnet` — 0 warnings, 0 errors
- `api/api.py` — passes `ast.parse`
- `helm lint helm/omnivec` — pass (no new warnings)

## Impact

C1 is almost certainly the cause of the recent `e2e-demo.ps1` hang at Step 8 — the polling loop watches `stats.embedded_count` which was frozen at 0 for blob→pgvector even when the worker had already written the embeddings. After this fix the script sees progress immediately.

C2 + C5 turn two silent-idle failures into loud, self-healing CrashLoops.
C4 ensures the dotnet worker can be restarted by Kubernetes when its receive loop dies.
C6 makes blob ingestion safe to scale beyond one replica.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
