### PR TITLE
fix(api): register skipped models with DocGrok + add unittest suite

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -5450,11 +5450,6 @@ async def import_bundle(
         }
 
     # Apply writes
-    # For external embedding models we must also register with DocGrok so they
-    # appear in GET /api/models (which is sourced from the DocGrok registry for
-    # non-chat models). Chat models are surfaced via the CosmosDB fallback and
-    # don't need DocGrok registration.
-    model_docs_to_register: list[dict] = []
     for doc_type, item in to_write:
         try:
             doc = {**item, "doc_type": doc_type}
@@ -5481,12 +5476,6 @@ async def import_bundle(
                         f"model's credentials via PUT /api/models/{doc.get('id')} "
                         f"before use"
                     )
-                # Remember models that need DocGrok registration after the write
-                if (doc.get("model_category") or "embedding") != "chat" \
-                        and str(doc.get("id", "")).startswith("mdl-ext-"):
-                    # Keep the plaintext key (if any) around for the registration
-                    # call only; the persisted doc above has already been scrubbed.
-                    model_docs_to_register.append({**doc, "_plain_api_key": api_key_value})
             store.upsert(doc)
         except Exception as e:
             rtype = next((k for k, v in _EXPORT_RESOURCE_TYPES.items() if v == doc_type), doc_type)
@@ -5498,52 +5487,94 @@ async def import_bundle(
         except Exception as e:
             summary["checkpoints"]["errors"].append(f"{cp.get('id')}: {e}")
 
-    # Register imported external embedding models with DocGrok so they show up
-    # in GET /api/models immediately (list_models reads from the DocGrok
-    # registry for non-chat models). Best-effort: a registration failure is
-    # reported as a warning — DocGrok will also rehydrate from CosmosDB on its
-    # next restart, so the model isn't lost either way.
-    for mdoc in model_docs_to_register:
-        mid = mdoc.get("id", "")
-        plain_key = mdoc.pop("_plain_api_key", "") or ""
-        # If the plaintext key wasn't in the bundle but we already have one in
-        # Key Vault (e.g. re-import over an existing model), fetch it so the
-        # DocGrok registration is functional.
-        if (not plain_key or plain_key == "***") and mdoc.get("api_key_source") == "keyvault":
-            try:
-                from keyvault_client import get_model_api_key
-                plain_key = get_model_api_key(mid) or ""
-            except Exception:
-                plain_key = ""
-        reg_payload = {
-            "id": mid,
-            "name": mdoc.get("name", ""),
-            "type": mdoc.get("type", "azure-openai"),
-            "endpoint": mdoc.get("endpoint", ""),
-            "deployment": mdoc.get("deployment", "") or mdoc.get("name", ""),
-            "api_key": plain_key,
-            "api_version": mdoc.get("api_version", "2024-06-01"),
-            "embedding_dim": int(mdoc.get("embedding_dim", 1536) or 1536),
-        }
-        auth_type = mdoc.get("auth_type") or ("managed-identity" if not plain_key else "key")
-        if auth_type == "managed-identity":
-            reg_payload["auth_type"] = "managed-identity"
-            if mdoc.get("client_id"):
-                reg_payload["client_id"] = mdoc["client_id"]
+    # Ensure every external embedding model in the bundle is registered with
+    # DocGrok so it shows up in GET /api/models (list_models is sourced from
+    # DocGrok's in-memory registry for non-chat models).
+    #
+    # This runs for ALL bundle models — including skipped ones — because a
+    # skipped model may already exist in Cosmos but still be missing from
+    # DocGrok (e.g. after a DocGrok restart, or after a pre-fix import that
+    # only wrote to Cosmos). We first ask DocGrok what it already knows, then
+    # register only the gaps, so re-imports are idempotent and don't clobber
+    # live api_key state in the registry.
+    bundle_models = resources.get("models") or []
+    if bundle_models:
+        # Rewrite ids in the bundle-level view too, for rename mode.
+        effective_models: list[dict] = []
+        for m in bundle_models:
+            if not isinstance(m, dict):
+                continue
+            mid = id_map.get(m.get("id"), m.get("id"))
+            effective_models.append({**m, "id": mid})
+
+        existing_reg_ids: set = set()
         try:
-            resp = await http_client.post(
-                f"{DOCGROK_URL}/admin/models/registry", json=reg_payload
-            )
-            if resp.status_code >= 400:
-                warnings.append(
-                    f"models/{mid}: DocGrok registration returned "
-                    f"{resp.status_code}: {resp.text[:200]}"
-                )
+            resp = await http_client.get(f"{DOCGROK_URL}/admin/models/registry")
+            if resp.status_code < 400:
+                reg_body = resp.json() or {}
+                for rm in reg_body.get("models", []) or []:
+                    if isinstance(rm, dict) and rm.get("id"):
+                        existing_reg_ids.add(rm["id"])
         except Exception as e:
-            warnings.append(
-                f"models/{mid}: DocGrok registration failed ({e}); the model "
-                f"will appear after the next DocGrok restart"
-            )
+            warnings.append(f"DocGrok registry probe failed ({e}); will attempt all registrations")
+
+        for m in effective_models:
+            mid = m.get("id") or ""
+            category = m.get("model_category") or "embedding"
+            if category == "chat":
+                continue
+            if not str(mid).startswith("mdl-ext-"):
+                continue
+            if mid in existing_reg_ids:
+                continue
+
+            # Prefer the freshly-written Cosmos doc (authoritative — has
+            # api_key_source=keyvault and no plaintext key after our scrub).
+            try:
+                cosmos_doc = store.get(mid, "docgrok_model") or {}
+            except Exception:
+                cosmos_doc = {}
+            merged = {**m, **{k: v for k, v in cosmos_doc.items() if v is not None}}
+
+            plain_key = m.get("api_key") or ""
+            if plain_key == "***":
+                plain_key = ""
+            if not plain_key and merged.get("api_key_source") == "keyvault":
+                try:
+                    from keyvault_client import get_model_api_key
+                    plain_key = get_model_api_key(mid) or ""
+                except Exception:
+                    plain_key = ""
+
+            reg_payload = {
+                "id": mid,
+                "name": merged.get("name", ""),
+                "type": merged.get("type", "azure-openai"),
+                "endpoint": merged.get("endpoint", ""),
+                "deployment": merged.get("deployment", "") or merged.get("name", ""),
+                "api_key": plain_key,
+                "api_version": merged.get("api_version", "2024-06-01"),
+                "embedding_dim": int(merged.get("embedding_dim", 1536) or 1536),
+            }
+            auth_type = merged.get("auth_type") or ("managed-identity" if not plain_key else "key")
+            if auth_type == "managed-identity":
+                reg_payload["auth_type"] = "managed-identity"
+                if merged.get("client_id"):
+                    reg_payload["client_id"] = merged["client_id"]
+            try:
+                resp = await http_client.post(
+                    f"{DOCGROK_URL}/admin/models/registry", json=reg_payload
+                )
+                if resp.status_code >= 400:
+                    warnings.append(
+                        f"models/{mid}: DocGrok registration returned "
+                        f"{resp.status_code}: {resp.text[:200]}"
+                    )
+            except Exception as e:
+                warnings.append(
+                    f"models/{mid}: DocGrok registration failed ({e}); the model "
+                    f"will appear after the next DocGrok restart"
+                )
 
     return {
         "success": True,

--- a/tests/api/test_admin_endpoints.py
+++ b/tests/api/test_admin_endpoints.py
@@ -1,0 +1,256 @@
+"""Offline tests for admin endpoints that don't require Azure.
+
+Covers:
+  - delete_model guard (pipelines, assistants, no-refs)
+  - import_bundle registering embedding models with DocGrok (create + skip paths)
+
+Run via `python tests/api/test_admin_endpoints.py` or under the test harness
+which also picks up `test-*.sh` and `test-*.ps1`.
+
+No pytest / external test framework required — plain unittest.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import unittest
+from typing import Any
+
+# Make api/ importable and avoid secret-required startup paths.
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(_ROOT, "api"))
+os.environ.setdefault("OMNIVEC_ADMIN_TOKEN", "test-token")
+
+import api  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class FakeResponse:
+    def __init__(self, status_code: int = 200, body: Any = None):
+        self.status_code = status_code
+        self._body = body if body is not None else {}
+        self.text = str(self._body)
+
+    def json(self):
+        return self._body
+
+
+class FakeHttp:
+    """Minimal async httpx-compatible stub; records calls."""
+
+    def __init__(self, registry_ids=(), register_status=201, get_status=200):
+        self._registry = list(registry_ids)
+        self._register_status = register_status
+        self._get_status = get_status
+        self.register_calls: list[dict] = []
+        self.get_calls: list[str] = []
+
+    async def get(self, url: str):
+        self.get_calls.append(url)
+        return FakeResponse(self._get_status, {"models": [{"id": x} for x in self._registry]})
+
+    async def post(self, url: str, json: dict | None = None):
+        if url.endswith("/admin/models/registry"):
+            self.register_calls.append(json or {})
+            if json and json.get("id"):
+                self._registry.append(json["id"])
+            return FakeResponse(self._register_status, {"id": (json or {}).get("id", "")})
+        return FakeResponse(404, "unexpected url")
+
+    async def delete(self, url: str):
+        return FakeResponse(200, {})
+
+
+class FakeStore:
+    """In-memory doc store mimicking store.list/get/upsert/delete."""
+
+    def __init__(self):
+        self._docs: dict[tuple[str, str], dict] = {}  # (doc_type, id) -> doc
+
+    def seed(self, docs):
+        for d in docs:
+            self._docs[(d["doc_type"], d["id"])] = dict(d)
+
+    def list(self, doc_type: str):
+        return [dict(v) for k, v in self._docs.items() if k[0] == doc_type]
+
+    def get(self, doc_id: str, doc_type: str):
+        d = self._docs.get((doc_type, doc_id))
+        return dict(d) if d else None
+
+    def upsert(self, doc: dict):
+        key = (doc["doc_type"], doc["id"])
+        self._docs[key] = dict(doc)
+
+    def delete(self, doc_id: str, doc_type: str):
+        self._docs.pop((doc_type, doc_id), None)
+
+    def query(self, *a, **kw):
+        return []
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# delete_model guard
+# ---------------------------------------------------------------------------
+
+class DeleteModelGuardTests(unittest.TestCase):
+    def setUp(self):
+        self._orig_get_store = api.get_store
+        self._orig_http = api.http_client
+        self.store = FakeStore()
+        api.get_store = lambda: self.store
+        api.http_client = FakeHttp()
+
+    def tearDown(self):
+        api.get_store = self._orig_get_store
+        api.http_client = self._orig_http
+
+    def test_blocks_when_pipeline_uses_model(self):
+        self.store.seed([
+            {"doc_type": "docgrok_model", "id": "mdl-ext-a", "name": "emb", "model_category": "embedding"},
+            {"doc_type": "pipeline", "id": "pip-1", "name": "my-pipe", "docgrok_pipeline": "mdl-ext-a"},
+        ])
+        with self.assertRaises(api.HTTPException) as ctx:
+            _run(api.delete_model("mdl-ext-a"))
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("pipeline", ctx.exception.detail.lower())
+        self.assertIn("my-pipe", ctx.exception.detail)
+
+    def test_blocks_when_assistant_uses_model(self):
+        self.store.seed([
+            {"doc_type": "docgrok_model", "id": "mdl-ext-b", "name": "chat", "model_category": "chat"},
+            {"doc_type": "assistant", "id": "ast-1", "name": "helpful", "model_id": "mdl-ext-b"},
+        ])
+        with self.assertRaises(api.HTTPException) as ctx:
+            _run(api.delete_model("mdl-ext-b"))
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("assistant", ctx.exception.detail.lower())
+        self.assertIn("helpful", ctx.exception.detail)
+
+    def test_proceeds_for_chat_model_with_no_refs(self):
+        self.store.seed([
+            {"doc_type": "docgrok_model", "id": "mdl-ext-c", "name": "orphan-chat", "model_category": "chat"},
+        ])
+        # Chat-only path: deletes from Cosmos, no DocGrok call.
+        result = _run(api.delete_model("mdl-ext-c"))
+        self.assertEqual(result.get("status"), "deleted")
+        self.assertIsNone(self.store.get("mdl-ext-c", "docgrok_model"))
+
+    def test_allows_embedding_model_with_no_refs(self):
+        """Guard must not fire; we don't test the downstream DocGrok call here."""
+        self.store.seed([
+            {"doc_type": "docgrok_model", "id": "mdl-ext-d", "name": "orphan-embed", "model_category": "embedding"},
+        ])
+        # Our FakeHttp.delete returns 200; delete should succeed.
+        result = _run(api.delete_model("mdl-ext-d"))
+        self.assertIsInstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# import_bundle: DocGrok registration
+# ---------------------------------------------------------------------------
+
+class ImportBundleRegistrationTests(unittest.TestCase):
+    def setUp(self):
+        self._orig_get_store = api.get_store
+        self._orig_http = api.http_client
+        self.store = FakeStore()
+        api.get_store = lambda: self.store
+        # Stub keyvault so test doesn't touch Azure.
+        import types
+        fake_kv = types.ModuleType("keyvault_client")
+        fake_kv.set_model_api_key = lambda mid, key: False  # fallback: persist api_key in doc
+        fake_kv.get_model_api_key = lambda mid: None
+        fake_kv.delete_model_api_key = lambda mid: None
+        sys.modules["keyvault_client"] = fake_kv
+
+    def tearDown(self):
+        api.get_store = self._orig_get_store
+        api.http_client = self._orig_http
+        sys.modules.pop("keyvault_client", None)
+
+    def _bundle(self, model_id="mdl-ext-x", category="embedding"):
+        return {
+            "omnivec_export_version": api._EXPORT_VERSION,
+            "resources": {
+                "models": [
+                    {
+                        "id": model_id,
+                        "name": "azure-openai-embed",
+                        "type": "azure-openai",
+                        "endpoint": "https://ex.example.com",
+                        "deployment": "text-embedding-3-small",
+                        "embedding_dim": 1536,
+                        "api_version": "2024-06-01",
+                        "model_category": category,
+                        "api_key": "sekret-123",
+                    }
+                ]
+            },
+        }
+
+    def test_created_model_gets_registered_with_docgrok(self):
+        http = FakeHttp(registry_ids=[])
+        api.http_client = http
+        resp = _run(api.import_bundle(self._bundle(), on_conflict="skip", dry_run=False))
+        self.assertTrue(resp["success"])
+        self.assertEqual(resp["summary"]["models"]["created"], 1)
+        self.assertEqual(len(http.register_calls), 1)
+        self.assertEqual(http.register_calls[0]["id"], "mdl-ext-x")
+        self.assertEqual(http.register_calls[0]["api_key"], "sekret-123")
+
+    def test_skipped_model_is_registered_if_missing_from_docgrok(self):
+        """Regression: on_conflict=skip used to short-circuit registration."""
+        # Model already in Cosmos (prior-run artefact), but missing from DocGrok.
+        self.store.seed([{
+            "doc_type": "docgrok_model", "id": "mdl-ext-y", "name": "stale-embed",
+            "type": "azure-openai", "endpoint": "https://ex.example.com",
+            "deployment": "text-embedding-3-small", "embedding_dim": 1536,
+            "api_version": "2024-06-01", "model_category": "embedding",
+            "api_key": "existing-key",
+        }])
+        http = FakeHttp(registry_ids=[])  # DocGrok registry is empty
+        api.http_client = http
+
+        bundle = self._bundle(model_id="mdl-ext-y")
+        resp = _run(api.import_bundle(bundle, on_conflict="skip", dry_run=False))
+        self.assertTrue(resp["success"])
+        self.assertEqual(resp["summary"]["models"]["skipped"], 1)
+        self.assertEqual(resp["summary"]["models"]["created"], 0)
+        # The fix: skipped models still get registered with DocGrok when missing.
+        self.assertEqual(len(http.register_calls), 1,
+                         f"expected 1 registration; got {http.register_calls}")
+        self.assertEqual(http.register_calls[0]["id"], "mdl-ext-y")
+
+    def test_skipped_model_not_reregistered_if_already_in_docgrok(self):
+        self.store.seed([{
+            "doc_type": "docgrok_model", "id": "mdl-ext-z", "name": "ok-embed",
+            "model_category": "embedding",
+        }])
+        http = FakeHttp(registry_ids=["mdl-ext-z"])
+        api.http_client = http
+        resp = _run(api.import_bundle(self._bundle(model_id="mdl-ext-z"), on_conflict="skip", dry_run=False))
+        self.assertTrue(resp["success"])
+        self.assertEqual(len(http.register_calls), 0,
+                         f"expected no re-registration; got {http.register_calls}")
+
+    def test_chat_model_not_registered_with_docgrok(self):
+        http = FakeHttp(registry_ids=[])
+        api.http_client = http
+        resp = _run(api.import_bundle(self._bundle(model_id="mdl-ext-c", category="chat"),
+                                      on_conflict="skip", dry_run=False))
+        self.assertTrue(resp["success"])
+        self.assertEqual(len(http.register_calls), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/run.ps1
+++ b/tests/run.ps1
@@ -39,6 +39,37 @@ if ($testFiles.Count -eq 0) {
 }
 
 $totalFail = 0
+
+# Python API tests (shell-agnostic — run once).
+$pyTests = Get-ChildItem -Path (Join-Path $RepoRoot 'tests\api') -Filter 'test_*.py' -ErrorAction SilentlyContinue
+if ($pyTests) {
+    $py = $null
+    foreach ($candidate in 'python3','python') {
+        if (Get-Command $candidate -ErrorAction SilentlyContinue) { $py = (Get-Command $candidate).Source; break }
+    }
+    if (-not $py) {
+        Write-Host ">>> skipping python api tests (no python interpreter)" -ForegroundColor Yellow
+    } else {
+        & $py -c "import fastapi, httpx" 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host ">>> skipping python api tests (fastapi/httpx not installed)" -ForegroundColor Yellow
+        } else {
+            Write-Host ""
+            Write-Host "========== python api tests ==========" -ForegroundColor Cyan
+            foreach ($t in $pyTests) {
+                Write-Host ""
+                Write-Host ("--- {0} ---" -f $t.Name) -ForegroundColor Cyan
+                & $py $t.FullName
+                $rc = $LASTEXITCODE
+                if ($rc -ne 0) {
+                    $totalFail++
+                    Write-Host ("*** FAILED python api test (exit {0})" -f $rc) -ForegroundColor Red
+                }
+            }
+        }
+    }
+}
+
 foreach ($sh in $shellsToTry) {
     $shBin = (Get-Command $sh).Source
     Write-Host ""

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -13,7 +13,33 @@ esac
 
 SHELLS_TO_TRY="${TEST_SHELL:-dash bash sh}"
 
+# Run Python-based API tests once (they don't depend on the shell under test)
+# and only if Python + fastapi are importable. We install nothing — they get
+# skipped in minimal environments and reported as passing.
+run_python_api_tests() {
+    if ! command -v python3 >/dev/null 2>&1 && ! command -v python >/dev/null 2>&1; then
+        printf '>>> skipping python api tests (no python interpreter)\n'
+        return 0
+    fi
+    PY=$(command -v python3 || command -v python)
+    if ! "$PY" -c 'import fastapi, httpx' >/dev/null 2>&1; then
+        printf '>>> skipping python api tests (fastapi/httpx not installed)\n'
+        return 0
+    fi
+    for _t in "$SCRIPT_DIR"/api/test_*.py; do
+        [ -f "$_t" ] || continue
+        printf '\n--- %s ---\n' "$(basename "$_t")"
+        "$PY" "$_t"
+        _rc=$?
+        if [ "$_rc" -ne 0 ]; then
+            TOTAL_FAIL=$(( TOTAL_FAIL + 1 ))
+            printf '*** FAILED python api test (exit %d)\n' "$_rc"
+        fi
+    done
+}
+
 TOTAL_FAIL=0
+run_python_api_tests
 for _sh in $SHELLS_TO_TRY; do
     if ! command -v "$_sh" >/dev/null 2>&1; then
         printf '>>> skipping %s (not installed)\n' "$_sh"


### PR DESCRIPTION
## Problem
`on_conflict=skip` short-circuited DocGrok registration, so a model that already exists in Cosmos (from a pre-fix import, or after a DocGrok restart that drops the in-memory registry) would stay invisible in `GET /api/models` until re-imported with `overwrite`.

## Fix
After the write pass, probe DocGrok's registry once and register any bundle model missing from it — regardless of created/overwritten/skipped status. Idempotent: models already in the registry are left alone so their live api_key state isn't clobbered by a redacted bundle.

## Tests
New `tests/api/test_admin_endpoints.py` (plain `unittest`, no new deps) covering:
- **delete_model** guard: blocks on pipeline ref; blocks on assistant ref; proceeds for chat-orphan; proceeds for embedding-orphan.
- **import_bundle** registration: created model → registered; skipped + missing from DocGrok → **registered** (the regression); skipped + already present → not re-registered; chat model → never registered.

`tests/run.sh` and `tests/run.ps1` pick it up automatically when Python + fastapi/httpx are installed; they skip cleanly otherwise. 8/8 tests pass locally.
