### PR TITLE
hooks: skip helm deploy when nothing changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ id_mappings.json
 # Windows
 nul
 .lock-hash
+
+helm/omnivec/.last-deploy-fingerprint
+

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -505,34 +505,87 @@ $helmArgs += @("--kube-context", $KUBE_CONTEXT, "--wait", "--timeout", "10m", "-
 
 # Detect stuck Helm release (pending-install / pending-upgrade from interrupted deploy)
 $helmStatus = helm status omnivec -n omnivec --kube-context $KUBE_CONTEXT -o json 2>$null | ConvertFrom-Json -ErrorAction SilentlyContinue
+$helmState = if ($helmStatus -and $helmStatus.info) { $helmStatus.info.status } else { "" }
 if ($helmStatus -and $helmStatus.info -and $helmStatus.info.status -match "^pending-") {
     Write-Host "`e[33mDetected stuck Helm release (status: $($helmStatus.info.status)). Rolling back...`e[0m"
     helm rollback omnivec -n omnivec --kube-context $KUBE_CONTEXT 2>$null
     if ($LASTEXITCODE -ne 0) {
         Write-Host "`e[33mRollback failed — uninstalling stuck release...`e[0m"
         helm uninstall omnivec -n omnivec --kube-context $KUBE_CONTEXT 2>$null
+        $helmState = ""
     }
     Write-Host "`e[32mStuck release cleared. Proceeding with fresh deploy.`e[0m"
 }
 
-& helm @helmArgs
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "`e[31mHelm deploy failed. Collecting pod diagnostics...`e[0m"
-    kubectl --context $KUBE_CONTEXT get pods -n omnivec -o wide
+# ── Skip helm upgrade if nothing has changed ────────────────────────────────
+# Rationale: helm upgrade --install --wait --atomic takes 1-2 minutes even
+# when the computed manifest is identical to the live one. Skip when:
+#   1. release is currently 'deployed' (healthy, not pending/failed),
+#   2. no images were imported/rebuilt this run ($script:imagesChanged is false),
+#   3. helm args fingerprint matches the one cached after the last successful deploy,
+#   4. all deployments in the omnivec namespace have >=1 available replica.
+# Set $env:OMNIVEC_FORCE_HELM = 'true' to bypass.
+$fingerprintFile = "$chartDir/.last-deploy-fingerprint"
+# Fingerprint captures everything that determines the rendered manifest:
+#   - the helm args (values + --set) we're about to pass in
+#   - every file under the chart dir (templates, values.yaml, Chart.yaml,
+#     Chart.lock, built subcharts) — so template edits invalidate the cache.
+$currentFp = ""
+try {
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    $argsHash = [BitConverter]::ToString($sha.ComputeHash(
+        [Text.Encoding]::UTF8.GetBytes(($helmArgs -join "`n"))
+    )) -replace '-',''
+    $chartHashes = Get-ChildItem -Path $chartDir -Recurse -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -ne '.last-deploy-fingerprint' } |
+        Sort-Object FullName |
+        ForEach-Object { (Get-FileHash $_.FullName -Algorithm SHA256).Hash }
+    $combined = $argsHash + "`n" + ($chartHashes -join "`n")
+    $currentFp = [BitConverter]::ToString($sha.ComputeHash(
+        [Text.Encoding]::UTF8.GetBytes($combined)
+    )) -replace '-',''
+} catch {
+    $currentFp = ""
+}
+$cachedFp = ""
+if (Test-Path $fingerprintFile) { $cachedFp = (Get-Content $fingerprintFile -Raw).Trim() }
 
-    $problemPods = kubectl --context $KUBE_CONTEXT get pods -n omnivec --no-headers 2>$null | `
-        Where-Object { $_ -match "ImagePullBackOff|ErrImagePull|CrashLoopBackOff|Error|Pending" }
-
-    foreach ($line in $problemPods) {
-        $parts = ($line -replace '\s+', ' ').Trim().Split(' ')
-        if ($parts.Count -lt 3) { continue }
-        $podName = $parts[0]
-        $status = $parts[2]
-        Write-Host "`n`e[33m=== $podName ($status) ===`e[0m"
-        kubectl --context $KUBE_CONTEXT describe pod $podName -n omnivec | Select-String -Pattern "Events:" -Context 0,60
-        kubectl --context $KUBE_CONTEXT logs $podName -n omnivec --tail=80 2>$null
+$skipHelm = $false
+if ($env:OMNIVEC_FORCE_HELM -ne "true" `
+    -and -not $script:imagesChanged `
+    -and $helmState -eq "deployed" `
+    -and $currentFp -and $currentFp -eq $cachedFp) {
+    $unavail = kubectl --context $KUBE_CONTEXT get deploy -n omnivec -o jsonpath='{range .items[?(@.status.availableReplicas==0)]}{.metadata.name}{"\n"}{end}' 2>$null
+    if ($LASTEXITCODE -eq 0 -and -not $unavail) {
+        $skipHelm = $true
     }
-    exit 1
+}
+
+if ($skipHelm) {
+    Write-Host "  `e[32mNo image/config changes detected and cluster is healthy — skipping helm upgrade.`e[0m"
+    Write-Host "  `e[36m(Set `$env:OMNIVEC_FORCE_HELM='true' to force a redeploy.)`e[0m"
+} else {
+    & helm @helmArgs
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "`e[31mHelm deploy failed. Collecting pod diagnostics...`e[0m"
+        kubectl --context $KUBE_CONTEXT get pods -n omnivec -o wide
+
+        $problemPods = kubectl --context $KUBE_CONTEXT get pods -n omnivec --no-headers 2>$null | `
+            Where-Object { $_ -match "ImagePullBackOff|ErrImagePull|CrashLoopBackOff|Error|Pending" }
+
+        foreach ($line in $problemPods) {
+            $parts = ($line -replace '\s+', ' ').Trim().Split(' ')
+            if ($parts.Count -lt 3) { continue }
+            $podName = $parts[0]
+            $status = $parts[2]
+            Write-Host "`n`e[33m=== $podName ($status) ===`e[0m"
+            kubectl --context $KUBE_CONTEXT describe pod $podName -n omnivec | Select-String -Pattern "Events:" -Context 0,60
+            kubectl --context $KUBE_CONTEXT logs $podName -n omnivec --tail=80 2>$null
+        }
+        exit 1
+    }
+    # Cache fingerprint only on success so a failed run doesn't poison future skips
+    if ($currentFp) { $currentFp | Set-Content $fingerprintFile -NoNewline }
 }
 
 Write-Host "`e[32mHelm deployment complete.`e[0m"

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -627,6 +627,7 @@ run_helm_deploy() {
 set +e
 _helm_status=$(helm status omnivec -n omnivec --kube-context "$KUBE_CONTEXT" --kubeconfig "$OMNIVEC_KUBECONFIG" -o json </dev/null 2>/dev/null)
 _helm_phase=$(echo "$_helm_status" | grep -o '"status":"pending-[^"]*"' | head -1 | cut -d'"' -f4)
+_helm_state=$(echo "$_helm_status" | grep -o '"status":"[^"]*"' | head -1 | cut -d'"' -f4)
 set -e
 if [ -n "$_helm_phase" ]; then
   printf "${YELLOW}Detected stuck Helm release (status: ${_helm_phase}). Rolling back...${NC}\n"
@@ -637,23 +638,84 @@ if [ -n "$_helm_phase" ]; then
   if [ "$_rb_rc" -ne 0 ]; then
     printf "${YELLOW}Rollback failed — uninstalling stuck release...${NC}\n"
     helm uninstall omnivec -n omnivec --kube-context "$KUBE_CONTEXT" --kubeconfig "$OMNIVEC_KUBECONFIG" </dev/null 2>/dev/null || true
+    _helm_state=""
   fi
   printf "${GREEN}Stuck release cleared. Proceeding with fresh deploy.${NC}\n"
 fi
 
-# Execute (d1: retry on transient ARM / Helm errors)
-set +e
-if command -v retry_run >/dev/null 2>&1; then
-  retry_run "helm-deploy" -- run_helm_deploy
-  helm_rc=$?
-else
-  run_helm_deploy
-  helm_rc=$?
+# ── Skip helm upgrade if nothing has changed ────────────────────────────────
+# Rationale: helm upgrade --install --wait --atomic takes 1-2 minutes even
+# when the computed manifest is identical to the live one. We avoid that cost
+# when:
+#   1. the release is currently 'deployed' (healthy, not pending/failed),
+#   2. no images were imported / rebuilt in this run (IMAGES_CHANGED != true),
+#   3. the helm values fingerprint matches the one we cached after the last
+#      successful deploy,
+#   4. all deployments in the omnivec namespace report at least one available
+#      replica (so we don't skip past a broken cluster).
+# Set OMNIVEC_FORCE_HELM=true to bypass this optimisation.
+FINGERPRINT_FILE="${CHART_DIR}/.last-deploy-fingerprint"
+# Fingerprint captures everything that determines the rendered manifest:
+#   - the helm values we're about to pass in
+#   - every file under the chart directory (templates, values.yaml, Chart.yaml,
+#     Chart.lock, built subcharts) — so a template edit invalidates the cache
+#     even if images/values didn't change.
+# Any failure to compute the fingerprint → empty string → skip never triggers.
+CURRENT_FP=""
+if [ -f "$HELM_VALUES_FILE" ] && [ -d "$CHART_DIR" ]; then
+  CURRENT_FP=$(
+    {
+      sha256sum "$HELM_VALUES_FILE" 2>/dev/null | cut -d' ' -f1
+      find "$CHART_DIR" -type f ! -name '.last-deploy-fingerprint' 2>/dev/null \
+        | LC_ALL=C sort \
+        | xargs -r sha256sum 2>/dev/null \
+        | awk '{print $1}'
+    } | sha256sum 2>/dev/null | cut -d' ' -f1
+  )
 fi
-set -e
+CACHED_FP=""
+[ -f "$FINGERPRINT_FILE" ] && CACHED_FP=$(cat "$FINGERPRINT_FILE" 2>/dev/null || true)
 
-# Clean up temp values file
-rm -f "$HELM_VALUES_FILE"
+SKIP_HELM=false
+if [ "${OMNIVEC_FORCE_HELM:-}" != "true" ] \
+   && [ "$IMAGES_CHANGED" != "true" ] \
+   && [ "$_helm_state" = "deployed" ] \
+   && [ -n "$CURRENT_FP" ] \
+   && [ "$CURRENT_FP" = "$CACHED_FP" ]; then
+  set +e
+  _unavail=$(kubectl_omnivec get deploy -n omnivec -o jsonpath='{range .items[?(@.status.availableReplicas==0)]}{.metadata.name}{"\n"}{end}' </dev/null 2>/dev/null)
+  _deploy_rc=$?
+  set -e
+  if [ "$_deploy_rc" -eq 0 ] && [ -z "$_unavail" ]; then
+    SKIP_HELM=true
+  fi
+fi
+
+if [ "$SKIP_HELM" = "true" ]; then
+  printf "  ${GREEN}No image/config changes detected and cluster is healthy — skipping helm upgrade.${NC}\n"
+  printf "  ${CYAN}(Set OMNIVEC_FORCE_HELM=true to force a redeploy.)${NC}\n"
+  rm -f "$HELM_VALUES_FILE"
+  helm_rc=0
+else
+  # Execute (d1: retry on transient ARM / Helm errors)
+  set +e
+  if command -v retry_run >/dev/null 2>&1; then
+    retry_run "helm-deploy" -- run_helm_deploy
+    helm_rc=$?
+  else
+    run_helm_deploy
+    helm_rc=$?
+  fi
+  set -e
+
+  # Clean up temp values file
+  rm -f "$HELM_VALUES_FILE"
+
+  # Cache fingerprint only on success so a failed run doesn't poison future skips
+  if [ "$helm_rc" -eq 0 ] && [ -n "$CURRENT_FP" ]; then
+    echo "$CURRENT_FP" > "$FINGERPRINT_FILE"
+  fi
+fi
 
 if [ "$helm_rc" -ne 0 ]; then
   printf "${RED}Helm deploy failed. Collecting pod diagnostics...${NC}\n"

--- a/tests/hooks/test-helm-skip.sh
+++ b/tests/hooks/test-helm-skip.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# test-helm-skip.sh - Static checks on the helm-skip logic in postprovision.sh
+# and postprovision.ps1. Ensures the skip block exists, gates on all required
+# conditions, and caches the fingerprint only on a successful deploy.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ROOT_DIR=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+pass=0
+fail=0
+_ok()   { pass=$((pass + 1)); printf "  OK  %s\n" "$1"; }
+_fail() { fail=$((fail + 1)); printf "  FAIL %s -- %s\n" "$1" "$2"; }
+
+SH="$ROOT_DIR/hooks/postprovision.sh"
+PS="$ROOT_DIR/hooks/postprovision.ps1"
+
+if bash -n "$SH"; then _ok "postprovision.sh parses cleanly"; else _fail "postprovision.sh parses cleanly" "bash -n failed"; fi
+
+for needle in OMNIVEC_FORCE_HELM IMAGES_CHANGED _helm_state CURRENT_FP "availableReplicas==0"; do
+    if grep -q "$needle" "$SH"; then
+        _ok "sh: skip check references '"'"'$needle'"'"'"
+    else
+        _fail "sh: skip check references '"'"'$needle'"'"'" "missing"
+    fi
+done
+
+if grep -q "find.*CHART_DIR.*" "$SH" && grep -q "xargs.*sha256sum" "$SH"; then
+    _ok "sh: fingerprint covers chart directory contents"
+else
+    _fail "sh: fingerprint covers chart directory contents" "chart hash not rolled in"
+fi
+
+if awk '"'"'/helm_rc.*-eq 0/ { seen=NR } /FINGERPRINT_FILE/ && seen && NR-seen<=3 { found=1 } END { exit(found?0:1) }'"'"' "$SH"; then
+    _ok "sh: fingerprint cached only after helm_rc=0"
+else
+    _fail "sh: fingerprint cached only after helm_rc=0" "not gated on success"
+fi
+
+for needle in OMNIVEC_FORCE_HELM imagesChanged helmState currentFp availableReplicas; do
+    if grep -q "$needle" "$PS"; then
+        _ok "ps1: references '"'"'$needle'"'"'"
+    else
+        _fail "ps1: references '"'"'$needle'"'"'" "missing"
+    fi
+done
+
+if grep -q "Get-ChildItem" "$PS" && grep -q "chartDir" "$PS"; then
+    _ok "ps1: fingerprint covers chart directory contents"
+else
+    _fail "ps1: fingerprint covers chart directory contents" "chart hash not rolled in"
+fi
+
+printf "\n%d passed, %d failed\n" "$pass" "$fail"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
## Problem
Rerunning zd up (or just the postprovision hook) runs helm upgrade --install --wait --atomic every time, even when all images are up-to-date and the chart is untouched. Users were seeing 2-5 minute waits and transient retries for a no-op redeploy:

```
Phase 1: Importing pre-built images from shared registry...
  omnivec-api:latest already imported (auth test).
  (...all 6 images skipped...)
Phase 4: Deploying OmniVec via Helm...
  [helm-deploy] transient failure (attempt 1/4, rc=1). Retrying in 5s...
```

## Fix
Added a skip gate in both `hooks/postprovision.sh` and `hooks/postprovision.ps1`. Helm runs only if **any** of these hold:

1. Release is not `deployed` (pending/failed/absent)
2. `IMAGES_CHANGED=true` (we imported or rebuilt an image this run)
3. Fingerprint of values+chart differs from the last successful deploy
4. Any deployment has `availableReplicas==0` (self-heal)
5. `OMNIVEC_FORCE_HELM=true` (explicit override)

### Fingerprint includes chart files (important)
Hash combines:
- `sha256` of the rendered helm values file
- `sha256` of every file under `helm/omnivec/` (templates, Chart.yaml, Chart.lock, subcharts), minus the cache file itself

So any template/Chart edit invalidates the cache and forces a redeploy ΓÇö **helm will always run when it is supposed to**.

### Safety
- Cache is written only after `helm_rc=0` (failed runs don't poison future skips).
- Override with `OMNIVEC_FORCE_HELM=true`.

## Tests
- New `tests/hooks/test-helm-skip.sh`: 14 assertions covering sh + ps1 parity, fingerprint scope, success-only caching.
- Full `tests/run.sh --shell bash` suite: 50/51 suites pass (only unrelated pre-existing WSL path issue in test-bicep-params.sh).