### PR TITLE
hooks: surface error excerpt on transient retries

### DIFF
--- a/hooks/lib/retry.sh
+++ b/hooks/lib/retry.sh
@@ -59,37 +59,55 @@ retry_is_transient() {
 # retry_run LABEL -- cmd args...
 # Runs cmd; on non-zero exit, classifies output; retries with exponential
 # backoff if transient. Exit code of last attempt propagates.
+_retry_print_excerpt() {
+    # Print the last few non-blank lines of $1 to stderr, indented, in yellow.
+    # Helps users understand WHY a transient retry happened without dumping
+    # the entire log mid-flow.
+    _src=$1
+    _max=${2:-6}
+    [ -s "$_src" ] || return 0
+    printf "  ${YELLOW}---- last output ----${NC}\n" >&2
+    grep -v '^[[:space:]]*$' "$_src" 2>/dev/null | tail -n "$_max" \
+        | sed 's/^/    /' >&2
+    printf "  ${YELLOW}---------------------${NC}\n" >&2
+}
+
 retry_run() {
     _label=${1:-retry}; shift 2>/dev/null || true
     [ "${1:-}" = "--" ] && shift
 
+    # Persist last attempt's full log to a stable path so users can inspect it
+    # after a successful retry (mktemp would be lost on success).
+    _log_dir=${TMPDIR:-/tmp}
+    _log="${_log_dir}/omnivec-retry-${_label}.log"
+
     _attempt=1
     _rc=0
     while [ "$_attempt" -le "$OMNIVEC_RETRY_ATTEMPTS" ]; do
-        _tmp=$(mktemp 2>/dev/null || mktemp -t retry)
-        "$@" </dev/null >"$_tmp" 2>&1
+        : > "$_log"
+        "$@" </dev/null >"$_log" 2>&1
         _rc=$?
         if [ "$_rc" -eq 0 ]; then
-            cat "$_tmp"
-            rm -f "$_tmp"
+            cat "$_log"
             return 0
         fi
-        _out=$(cat "$_tmp")
-        rm -f "$_tmp"
+        _out=$(cat "$_log")
         if [ "$_attempt" -ge "$OMNIVEC_RETRY_ATTEMPTS" ]; then
             printf '%s\n' "$_out"
-            printf "  ${RED}[%s] failed after %d attempts (rc=%d).${NC}\n" \
-                "$_label" "$_attempt" "$_rc" >&2
+            printf "  ${RED}[%s] failed after %d attempts (rc=%d). Full log: %s${NC}\n" \
+                "$_label" "$_attempt" "$_rc" "$_log" >&2
             return "$_rc"
         fi
         if ! retry_is_transient "$_out"; then
             printf '%s\n' "$_out"
-            printf "  ${RED}[%s] failed (rc=%d, non-transient).${NC}\n" "$_label" "$_rc" >&2
+            printf "  ${RED}[%s] failed (rc=%d, non-transient). Full log: %s${NC}\n" "$_label" "$_rc" "$_log" >&2
             return "$_rc"
         fi
         _sleep=$(( OMNIVEC_RETRY_BASE_SEC * _attempt ))
         printf "  ${YELLOW}[%s] transient failure (attempt %d/%d, rc=%d). Retrying in %ds...${NC}\n" \
             "$_label" "$_attempt" "$OMNIVEC_RETRY_ATTEMPTS" "$_rc" "$_sleep" >&2
+        _retry_print_excerpt "$_log" 6
+        printf "  ${CYAN}(full log: %s)${NC}\n" "$_log" >&2
         sleep "$_sleep"
         _attempt=$(( _attempt + 1 ))
     done

--- a/tests/hooks/test-retry.sh
+++ b/tests/hooks/test-retry.sh
@@ -59,5 +59,26 @@ _n=$(cat "$T3")
 [ "$_rc" -ne 0 ] && [ "$_n" = "3" ] && ok "gives up after max attempts" || bad "gives up after max attempts" "rc=$_rc calls=$_n"
 
 rm -f "$T" "$T2" "$T3"
+
+# ── 5. Excerpt is shown to stderr on transient retry ────────────────────────
+T4=$(mktemp); echo 0 > "$T4"
+flaky_with_msg() {
+    n=$(cat "$T4"); n=$((n+1)); echo "$n" > "$T4"
+    if [ "$n" -lt 2 ]; then
+        echo "kubectl error: 429 TooManyRequests" >&2
+        echo "  details: throttled by API server" >&2
+        return 1
+    fi
+    return 0
+}
+ERR=$(mktemp)
+retry_run "excerpt-test" -- flaky_with_msg >/dev/null 2>"$ERR"
+if grep -q '\-\-\-\- last output \-\-\-\-' "$ERR" && grep -q 'TooManyRequests' "$ERR"; then
+    ok "excerpt printed on transient retry"
+else
+    bad "excerpt printed on transient retry" "stderr did not contain excerpt"
+fi
+rm -f "$T4" "$ERR"
+
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Users seeing `[helm-deploy] transient failure (attempt 1/4, rc=1). Retrying in 5s...` were left in the dark — the actual helm/kubectl error was suppressed and only re-shown if the FINAL attempt failed. If retry succeeded, the underlying error was lost.

This patch makes `retry_run` show the last 6 non-blank lines on each transient retry, plus a stable log path (`/tmp/omnivec-retry-<label>.log`) for post-mortem inspection.

New test asserts excerpt is emitted; full retry suite (5 tests) passes.