### PR TITLE
hooks: live heartbeat during helm deploy (no more frozen-screen UX)

### DIFF
--- a/hooks/lib/retry.sh
+++ b/hooks/lib/retry.sh
@@ -85,8 +85,44 @@ retry_run() {
     _rc=0
     while [ "$_attempt" -le "$OMNIVEC_RETRY_ATTEMPTS" ]; do
         : > "$_log"
+
+        # Optional heartbeat: while the command runs, periodically print an
+        # "elapsed + pod status" line to stderr so the user doesn't stare at
+        # a frozen terminal during long helm waits. Activated by setting
+        #   OMNIVEC_RETRY_HEARTBEAT_CMD  — shell cmd that prints a one-shot status
+        #   OMNIVEC_RETRY_HEARTBEAT_SEC  — interval (default 20)
+        _hb_pid=""
+        if [ -n "${OMNIVEC_RETRY_HEARTBEAT_CMD:-}" ]; then
+            _hb_interval=${OMNIVEC_RETRY_HEARTBEAT_SEC:-20}
+            _hb_label=$_label
+            (
+                _hb_start=$(date +%s 2>/dev/null || echo 0)
+                # Wait one interval before the first heartbeat so fast commands
+                # (< interval) never produce any heartbeat noise.
+                sleep "$_hb_interval"
+                while :; do
+                    _hb_now=$(date +%s 2>/dev/null || echo 0)
+                    _hb_el=$(( _hb_now - _hb_start ))
+                    printf "  ${CYAN}[%s] still running (%ds elapsed)...${NC}\n" \
+                        "$_hb_label" "$_hb_el" >&2
+                    # Run the heartbeat command; ignore its stderr (cluster may
+                    # be briefly unreachable during a rollout), pipe its stdout
+                    # to the parent's stderr so the user sees status inline.
+                    sh -c "$OMNIVEC_RETRY_HEARTBEAT_CMD" >&2 2>/dev/null || true
+                    sleep "$_hb_interval"
+                done
+            ) &
+            _hb_pid=$!
+        fi
+
         "$@" </dev/null >"$_log" 2>&1
         _rc=$?
+
+        if [ -n "$_hb_pid" ]; then
+            kill "$_hb_pid" 2>/dev/null || true
+            wait "$_hb_pid" 2>/dev/null || true
+        fi
+
         if [ "$_rc" -eq 0 ]; then
             cat "$_log"
             return 0

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -698,6 +698,11 @@ if [ "$SKIP_HELM" = "true" ]; then
   helm_rc=0
 else
   # Execute (d1: retry on transient ARM / Helm errors)
+  # While helm waits (can take 1-3 minutes with --wait --atomic), show a
+  # heartbeat so the user isn't staring at a frozen screen.
+  OMNIVEC_RETRY_HEARTBEAT_SEC=${OMNIVEC_HELM_HEARTBEAT_SEC:-20}
+  OMNIVEC_RETRY_HEARTBEAT_CMD='kubectl --context "'"$KUBE_CONTEXT"'" --kubeconfig "'"$OMNIVEC_KUBECONFIG"'" -n omnivec get pods --no-headers 2>/dev/null | awk '"'"'{printf "    %-50s %-12s %s\n", $1, $3, $2}'"'"' | head -20'
+  export OMNIVEC_RETRY_HEARTBEAT_SEC OMNIVEC_RETRY_HEARTBEAT_CMD
   set +e
   if command -v retry_run >/dev/null 2>&1; then
     retry_run "helm-deploy" -- run_helm_deploy
@@ -707,6 +712,7 @@ else
     helm_rc=$?
   fi
   set -e
+  unset OMNIVEC_RETRY_HEARTBEAT_CMD OMNIVEC_RETRY_HEARTBEAT_SEC
 
   # Clean up temp values file
   rm -f "$HELM_VALUES_FILE"

--- a/tests/hooks/test-retry.sh
+++ b/tests/hooks/test-retry.sh
@@ -80,5 +80,32 @@ else
 fi
 rm -f "$T4" "$ERR"
 
+# ── 6. Heartbeat fires while a long-running command is executing ────────────
+export OMNIVEC_RETRY_HEARTBEAT_SEC=1
+export OMNIVEC_RETRY_HEARTBEAT_CMD='echo "    sentinel-pod  Running"'
+slow_ok() { sleep 3; return 0; }
+HB_ERR=$(mktemp)
+retry_run "hb-test" -- slow_ok >/dev/null 2>"$HB_ERR"
+if grep -q 'still running' "$HB_ERR" && grep -q 'sentinel-pod' "$HB_ERR"; then
+    ok "heartbeat emitted during long-running cmd"
+else
+    bad "heartbeat emitted during long-running cmd" "stderr missing heartbeat"
+fi
+unset OMNIVEC_RETRY_HEARTBEAT_CMD OMNIVEC_RETRY_HEARTBEAT_SEC
+rm -f "$HB_ERR"
+
+# ── 7. Heartbeat does NOT fire for sub-interval commands ────────────────────
+export OMNIVEC_RETRY_HEARTBEAT_SEC=5
+export OMNIVEC_RETRY_HEARTBEAT_CMD='echo "should-not-appear"'
+HB_ERR2=$(mktemp)
+retry_run "hb-fast" -- true >/dev/null 2>"$HB_ERR2"
+if ! grep -q 'should-not-appear' "$HB_ERR2"; then
+    ok "heartbeat suppressed for fast commands"
+else
+    bad "heartbeat suppressed for fast commands" "heartbeat leaked"
+fi
+unset OMNIVEC_RETRY_HEARTBEAT_CMD OMNIVEC_RETRY_HEARTBEAT_SEC
+rm -f "$HB_ERR2"
+
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
`Phase 4: Deploying OmniVec via Helm...` followed by 1-2 minutes of total silence looks indistinguishable from a hung process.

Added an optional heartbeat to `retry_run` (`OMNIVEC_RETRY_HEARTBEAT_CMD` + `_SEC`). Postprovision wires it into the helm-deploy call so the user now sees every 20s:

```
  [helm-deploy] still running (20s elapsed)...
      omnivec-api-7b9d6-xxxxx                       Pending      0/1
      omnivec-web-6f8c4-yyyyy                       Running      1/1
```

Heartbeat fires ONLY after the first interval, so commands under 20s produce zero noise. 7/7 retry tests pass.