### PR TITLE
test(emu): stateful service emulator for full azd-up E2E in seconds

### DIFF
--- a/tests/emu/README.md
+++ b/tests/emu/README.md
@@ -1,0 +1,135 @@
+# OmniVec service emulator
+
+Stateful in-process fakes of **az**, **azd**, **kubectl**, **helm** and **docker**
+that let the real `hooks/preprovision.sh` + `hooks/postprovision.sh` run
+end-to-end in seconds — **no Azure subscription, no AKS cluster, no
+docker daemon required**.
+
+## Why
+
+Previously we had canned-response stubs under `tests/hooks/mocks/` that were
+"good enough" for preprovision unit tests but had no persistent state. The
+postprovision path (`helm upgrade` → `kubectl get pods` → `helm status`)
+needed a real cluster to exercise. That made regression testing painful.
+
+This emulator:
+
+- **Persists state** across commands in `$OMNIVEC_EMU_STATE` (resource
+  groups, ACR images, helm releases, Kubernetes deployments/pods).
+- **Synthesises realistic cluster state** when `helm upgrade` runs —
+  subsequent `kubectl get deploy/pods/svc` returns ready workloads.
+- **Supports fault injection** (delay, transient, hard-fail) via env vars
+  so we can unit-test retry/skip/heartbeat logic deterministically.
+
+## Quick start
+
+```sh
+chmod +x tests/emu/bin/* tests/emu/run-azd-up.sh
+tests/emu/run-azd-up.sh       # runs preprovision + postprovision end-to-end
+```
+
+Output ends with something like:
+
+```
+== Done (rc=0) ==
+State dir: /tmp/omnivec-emu.XXXX
+Event log: /tmp/omnivec-emu.XXXX/events.log
+```
+
+Inspect what the hooks actually called:
+
+```sh
+cat $OMNIVEC_EMU_STATE/events.log
+ls  $OMNIVEC_EMU_STATE/k8s/ns/omnivec/deployments
+cat $OMNIVEC_EMU_STATE/helm/releases/omnivec
+```
+
+## Fault injection
+
+All flags are **env vars**; set them before invoking `run-azd-up.sh` (or
+directly before the hook under test).
+
+| Env var                            | Behaviour                                                                |
+|------------------------------------|--------------------------------------------------------------------------|
+| `OMNIVEC_EMU_MODE=success`         | Default — everything succeeds.                                          |
+| `OMNIVEC_EMU_MODE=slow`            | Every emulated call sleeps `OMNIVEC_EMU_SLOW_SECS` (default 2).         |
+| `OMNIVEC_EMU_MODE=transient`       | `helm upgrade` fails the first `OMNIVEC_EMU_TRANSIENT_N` (def 2) times. |
+| `OMNIVEC_EMU_MODE=fail`            | `helm upgrade/install` fails immediately with a non-transient error.    |
+| `OMNIVEC_EMU_FAIL_CMD=<regex>`     | Match argv → fail with injected non-transient error.                    |
+| `OMNIVEC_EMU_TRANSIENT_CMD=<re>:N` | Match → fail first N invocations with 503 Service Unavailable.          |
+| `OMNIVEC_EMU_DELAY_CMD=<re>:SECS`  | Match → sleep SECS before responding.                                   |
+
+Regex matches against the full `binary args...` string, e.g.
+`"az acr import"`, `"helm upgrade"`, `"kubectl rollout"`.
+
+### Examples
+
+```sh
+# Simulate a flaky helm (fails twice, succeeds on 3rd)
+OMNIVEC_EMU_TRANSIENT_CMD='helm upgrade:2' tests/emu/run-azd-up.sh
+
+# Simulate a permanent helm failure
+OMNIVEC_EMU_FAIL_CMD='helm upgrade' tests/emu/run-azd-up.sh
+
+# Simulate slow ACR import (5s per call)
+OMNIVEC_EMU_DELAY_CMD='az acr import:5' tests/emu/run-azd-up.sh
+
+# Combine: transient helm + slow ACR
+OMNIVEC_EMU_TRANSIENT_CMD='helm upgrade:1' \
+OMNIVEC_EMU_DELAY_CMD='az acr import:2' \
+  tests/emu/run-azd-up.sh
+```
+
+## State layout
+
+```
+$OMNIVEC_EMU_STATE/
+  events.log                        # chronological command log (epoch\tbin\targv)
+  fault/                            # per-pattern invocation counters
+  azd-env/<KEY>                     # azd env vars
+  arm/
+    groups/<rg>                     # resource groups
+    acr/<name>/images/<repo>_<tag>  # ACR images (built or imported)
+  docker/
+    images/<tag>                    # local docker images
+    registry/<tag>                  # pushed images
+  k8s/ns/<namespace>/
+    _meta                           # namespace metadata
+    deployments/<name>              # key=value deployment spec + status
+    pods/<name>                     # pod spec + status
+    services/<name>
+    secrets/<name>
+    events/warnings                 # Warning events surfaced by kubectl
+  helm/releases/<name>              # helm release metadata
+```
+
+## Tests
+
+- `tests/hooks/test-emu-e2e.sh` — happy-path: full azd up completes, helm
+  release recorded, 7 deployments synthesised, event log populated.
+- `tests/hooks/test-emu-faults.sh` — fault scenarios: transient recovery,
+  hard failure halt, delay absorption, idempotent rerun (skip-helm).
+
+Run manually:
+```sh
+bash tests/hooks/test-emu-e2e.sh
+bash tests/hooks/test-emu-faults.sh
+```
+
+Or as part of the normal suite:
+```sh
+bash tests/run.sh --shell bash
+```
+
+## Limitations
+
+- **Not a real Kubernetes API.** JSONPath support is limited to the
+  specific patterns the hooks use (availableReplicas, readyReplicas,
+  LoadBalancer external IP, Warning events). Extending is straightforward
+  — add a case in `tests/emu/bin/kubectl` `_handle_jsonpath`.
+- **Bicep is not executed.** `run-azd-up.sh` seeds the ARM resources Bicep
+  would create (RG, ACR, AKS, Cosmos, Key Vault, Storage, Service Bus).
+  If you change Bicep outputs consumed by postprovision, also update
+  `run-azd-up.sh`.
+- **No admission webhooks / CRDs.** Helm upgrade always "succeeds"
+  structurally; fault injection is the way to simulate failures.

--- a/tests/emu/lib/_common.sh
+++ b/tests/emu/lib/_common.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+# tests/emu/lib/_common.sh - shared helpers for the OmniVec service emulator.
+#
+# Loaded by each emulated binary (az, azd, kubectl, helm, docker). Provides:
+#   - State directory plumbing ($OMNIVEC_EMU_STATE)
+#   - Chronological event log ($OMNIVEC_EMU_STATE/events.log)
+#   - Fault injection via env vars (see tests/emu/README.md)
+
+set -u
+
+: "${OMNIVEC_EMU_STATE:=${TMPDIR:-/tmp}/omnivec-emu}"
+mkdir -p "$OMNIVEC_EMU_STATE"
+
+emu_log_event() {
+    _bin=$1; shift
+    _argv=$*
+    printf '%s\t%s\t%s\n' "$(date +%s 2>/dev/null || echo 0)" "$_bin" "$_argv" \
+        >> "$OMNIVEC_EMU_STATE/events.log" 2>/dev/null || true
+}
+
+emu_dir() {
+    _p="$OMNIVEC_EMU_STATE/$1"
+    mkdir -p "$_p"
+    printf '%s' "$_p"
+}
+
+emu_set() {
+    # emu_set <subdir> <key> <value>
+    _d=$(emu_dir "$1")
+    printf '%s' "$3" > "$_d/$2"
+}
+
+emu_get() {
+    _f="$OMNIVEC_EMU_STATE/$1/$2"
+    [ -f "$_f" ] && cat "$_f"
+}
+
+emu_has() {
+    [ -f "$OMNIVEC_EMU_STATE/$1/$2" ]
+}
+
+emu_list() {
+    _d="$OMNIVEC_EMU_STATE/$1"
+    [ -d "$_d" ] || return 0
+    ls "$_d" 2>/dev/null
+}
+
+emu_del() {
+    rm -f "$OMNIVEC_EMU_STATE/$1/$2"
+}
+
+# Safe filename: translate problematic chars
+emu_safe() {
+    printf '%s' "$1" | tr '/:@ ' '____'
+}
+
+# ── Fault injection ─────────────────────────────────────────────────────────
+emu_match() {
+    printf '%s' "$2" | grep -Eq -- "$1" 2>/dev/null
+}
+
+emu_counter_inc() {
+    _safe=$(printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_')
+    _d=$(emu_dir "fault")
+    _f="$_d/$_safe.count"
+    _n=0
+    [ -f "$_f" ] && _n=$(cat "$_f" 2>/dev/null || echo 0)
+    _n=$((_n + 1))
+    echo "$_n" > "$_f"
+    echo "$_n"
+}
+
+emu_apply_faults() {
+    _bin=$1; shift
+    _cmdline="$_bin $*"
+
+    # Global mode
+    case "${OMNIVEC_EMU_MODE:-success}" in
+        slow)
+            sleep "${OMNIVEC_EMU_SLOW_SECS:-2}" 2>/dev/null || true
+            ;;
+        fail)
+            case "$_cmdline" in
+                *"helm upgrade"*|*"helm install"*)
+                    echo "Error: Internal error occurred: fake failure injected by OMNIVEC_EMU_MODE=fail" >&2
+                    exit 1 ;;
+            esac ;;
+        transient)
+            case "$_cmdline" in
+                *"helm upgrade"*|*"helm install"*)
+                    _n=$(emu_counter_inc "global-transient")
+                    if [ "$_n" -le "${OMNIVEC_EMU_TRANSIENT_N:-2}" ]; then
+                        echo "Error: 503 Service Unavailable (transient, attempt $_n)" >&2
+                        exit 1
+                    fi ;;
+            esac ;;
+    esac
+
+    if [ -n "${OMNIVEC_EMU_DELAY_CMD:-}" ]; then
+        _rx=${OMNIVEC_EMU_DELAY_CMD%:*}
+        _secs=${OMNIVEC_EMU_DELAY_CMD##*:}
+        if emu_match "$_rx" "$_cmdline"; then
+            sleep "$_secs" 2>/dev/null || true
+        fi
+    fi
+
+    if [ -n "${OMNIVEC_EMU_TRANSIENT_CMD:-}" ]; then
+        _rx=${OMNIVEC_EMU_TRANSIENT_CMD%:*}
+        _max=${OMNIVEC_EMU_TRANSIENT_CMD##*:}
+        if emu_match "$_rx" "$_cmdline"; then
+            _n=$(emu_counter_inc "trans_${_rx}")
+            if [ "$_n" -le "$_max" ]; then
+                echo "Error: 503 Service Unavailable (injected transient $_n/$_max)" >&2
+                exit 1
+            fi
+        fi
+    fi
+
+    if [ -n "${OMNIVEC_EMU_FAIL_CMD:-}" ]; then
+        if emu_match "$OMNIVEC_EMU_FAIL_CMD" "$_cmdline"; then
+            echo "Error: injected non-transient failure (matched: $OMNIVEC_EMU_FAIL_CMD)" >&2
+            exit 1
+        fi
+    fi
+}
+
+emu_enter() {
+    _bin=$1; shift
+    emu_log_event "$_bin" "$@"
+    emu_apply_faults "$_bin" "$@"
+}

--- a/tests/emu/run-azd-up.sh
+++ b/tests/emu/run-azd-up.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# tests/emu/run-azd-up.sh — drive the real hooks end-to-end against the emulator.
+#
+# Simulates the complete `azd up` lifecycle:
+#   1. preprovision.sh   (collects inputs, sets azd env vars)
+#   2. provision phase   (we seed the ARM resources Bicep would create)
+#   3. postprovision.sh  (image import, AKS creds, helm deploy)
+#
+# Produces a state dir you can inspect afterwards:
+#   $OMNIVEC_EMU_STATE/events.log                    (chronological calls)
+#   $OMNIVEC_EMU_STATE/arm/...                       (Azure resources)
+#   $OMNIVEC_EMU_STATE/k8s/ns/omnivec/...            (synthesised cluster state)
+#   $OMNIVEC_EMU_STATE/helm/releases/omnivec         (helm release record)
+
+set -u
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+EMU_BIN="$SCRIPT_DIR/bin"
+
+# ── Emulator state (per-run unless caller exports OMNIVEC_EMU_STATE) ────────
+: "${OMNIVEC_EMU_STATE:=$(mktemp -d -t omnivec-emu.XXXXXX)}"
+export OMNIVEC_EMU_STATE
+
+# ── Put emulated binaries at the front of PATH ─────────────────────────────
+chmod +x "$EMU_BIN"/* 2>/dev/null || true
+export PATH="$EMU_BIN:$PATH"
+
+# ── Deterministic env for the hooks ─────────────────────────────────────────
+export AZURE_ENV_NAME=emu-env
+export AZURE_LOCATION=eastus2
+export AZURE_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000
+export HOME=$OMNIVEC_EMU_STATE/home
+mkdir -p "$HOME"
+export OMNIVEC_NONINTERACTIVE=1
+export OMNIVEC_FORCE_NO_TTY=1
+
+banner() { printf '\n\033[1;36m== %s ==\033[0m\n' "$1"; }
+
+banner "Emulator state: $OMNIVEC_EMU_STATE"
+banner "PATH shims: $EMU_BIN"
+
+# ── Phase 1: preprovision ───────────────────────────────────────────────────
+banner "Phase 1: preprovision"
+sh "$REPO_ROOT/hooks/preprovision.sh" </dev/null || {
+    echo "preprovision.sh failed (rc=$?)" >&2
+    exit 1
+}
+
+# ── Phase 2: simulated `azd provision` (Bicep would create these) ──────────
+banner "Phase 2: provision (seeding ARM state)"
+
+RG="${AZURE_ENV_NAME}-rg"
+# Use azd-env values if set, else synthesise stable names the hooks expect.
+ACR_NAME=$(azd env get-value AZURE_ACR_NAME 2>/dev/null)
+[ -z "$ACR_NAME" ] && ACR_NAME="omnivecacremu1234"
+AKS_NAME=$(azd env get-value AZURE_AKS_CLUSTER_NAME 2>/dev/null)
+[ -z "$AKS_NAME" ] && AKS_NAME="omnivec-aks-emu1234"
+INSTANCE_ID=$(azd env get-value AZURE_OMNIVEC_INSTANCE_ID 2>/dev/null)
+[ -z "$INSTANCE_ID" ] && INSTANCE_ID="emu1234"
+
+az group create --name "$RG" --location eastus2 >/dev/null
+
+# Seed values into azd env that postprovision.sh reads
+azd env set AZURE_RESOURCE_GROUP            "$RG"
+azd env set AZURE_ACR_NAME                  "$ACR_NAME"
+azd env set AZURE_ACR_LOGIN_SERVER          "${ACR_NAME}.azurecr.io"
+azd env set AZURE_AKS_CLUSTER_NAME          "$AKS_NAME"
+azd env set AZURE_OMNIVEC_INSTANCE_ID       "$INSTANCE_ID"
+azd env set AZURE_COSMOS_ENDPOINT           "https://omnivec-cosmos-${INSTANCE_ID}.documents.azure.com:443/"
+azd env set AZURE_IDENTITY_CLIENT_ID        "22222222-2222-2222-2222-222222222222"
+azd env set AZURE_KEYVAULT_URI              "https://omnivec-kv-${INSTANCE_ID}.vault.azure.net/"
+azd env set AZURE_STORAGE_ACCOUNT_NAME      "omnivecstg${INSTANCE_ID}"
+azd env set AZURE_STORAGE_BLOB_ENDPOINT     "https://omnivecstg${INSTANCE_ID}.blob.core.windows.net/"
+azd env set AZURE_STORAGE_QUEUE_ENDPOINT    "https://omnivecstg${INSTANCE_ID}.queue.core.windows.net/"
+azd env set AZURE_SERVICEBUS_ENDPOINT       "omnivec-sb-${INSTANCE_ID}.servicebus.windows.net"
+azd env set AZURE_APPINSIGHTS_CONNECTION_STRING "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://emu.applicationinsights.azure.com/"
+azd env set AZURE_LOG_ANALYTICS_WORKSPACE_ID "00000000-0000-0000-0000-000000000000"
+azd env set AZURE_ENABLE_BLOB_SOURCE        "true"
+azd env set OMNIVEC_BUILD_MODE              "acr"
+
+# ── Phase 3: postprovision ──────────────────────────────────────────────────
+banner "Phase 3: postprovision"
+sh "$REPO_ROOT/hooks/postprovision.sh" </dev/null
+_rc=$?
+
+banner "Done (rc=$_rc)"
+echo "State dir: $OMNIVEC_EMU_STATE"
+echo "Event log: $OMNIVEC_EMU_STATE/events.log"
+exit $_rc

--- a/tests/hooks/test-emu-e2e.sh
+++ b/tests/hooks/test-emu-e2e.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# tests/hooks/test-emu-e2e.sh - end-to-end happy-path test against the full
+# service emulator. Runs preprovision.sh + postprovision.sh and asserts the
+# cluster ended up in a healthy state.
+set -u
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+HARNESS="$REPO_ROOT/tests/emu/run-azd-up.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf "  OK  %s\n" "$1"; }
+bad() { FAIL=$((FAIL+1)); printf "  FAIL %s -- %s\n" "$1" "$2"; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+export OMNIVEC_EMU_STATE="$TMP/state"
+mkdir -p "$OMNIVEC_EMU_STATE"
+
+LOG="$TMP/run.log"
+chmod +x "$REPO_ROOT/tests/emu/bin"/* "$HARNESS" 2>/dev/null || true
+
+if sh "$HARNESS" >"$LOG" 2>&1; then
+    ok "azd up end-to-end succeeded"
+else
+    bad "azd up end-to-end succeeded" "rc=$? (see tail below)"
+    tail -40 "$LOG" | sed 's/^/    /'
+fi
+
+if grep -q 'Release "omnivec" has been upgraded' "$LOG"; then
+    ok "helm upgrade emitted success banner"
+else
+    bad "helm upgrade emitted success banner" "missing in log"
+fi
+
+# Check helm release recorded
+if [ -f "$OMNIVEC_EMU_STATE/helm/releases/omnivec" ]; then
+    ok "helm release persisted to state"
+else
+    bad "helm release persisted to state" "file missing"
+fi
+
+# Check synthesised deployments exist
+if [ -d "$OMNIVEC_EMU_STATE/k8s/ns/omnivec/deployments" ] \
+   && [ "$(ls "$OMNIVEC_EMU_STATE/k8s/ns/omnivec/deployments" 2>/dev/null | wc -l)" -ge 5 ]; then
+    ok "at least 5 deployments synthesised in omnivec namespace"
+else
+    bad "at least 5 deployments synthesised in omnivec namespace" \
+        "found: $(ls "$OMNIVEC_EMU_STATE/k8s/ns/omnivec/deployments" 2>/dev/null | wc -l)"
+fi
+
+# Event log recorded hooks-driven calls
+if grep -q '\baz\b' "$OMNIVEC_EMU_STATE/events.log" \
+   && grep -q '\bhelm\b' "$OMNIVEC_EMU_STATE/events.log" \
+   && grep -q '\bkubectl\b' "$OMNIVEC_EMU_STATE/events.log"; then
+    ok "event log captured az+helm+kubectl invocations"
+else
+    bad "event log captured az+helm+kubectl invocations" \
+        "counts: az=$(grep -c '\baz\b' "$OMNIVEC_EMU_STATE/events.log") \
+helm=$(grep -c '\bhelm\b' "$OMNIVEC_EMU_STATE/events.log") \
+kubectl=$(grep -c '\bkubectl\b' "$OMNIVEC_EMU_STATE/events.log")"
+fi
+
+# Helm status reports deployed
+EMU_BIN="$REPO_ROOT/tests/emu/bin"
+export PATH="$EMU_BIN:$PATH"
+if "$EMU_BIN/helm" status omnivec -n omnivec -o json 2>/dev/null | grep -q '"status":"deployed"'; then
+    ok "helm status reports release=deployed"
+else
+    bad "helm status reports release=deployed" "unexpected output"
+fi
+
+printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/tests/hooks/test-emu-faults.sh
+++ b/tests/hooks/test-emu-faults.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# tests/hooks/test-emu-faults.sh - fault-injection scenarios against the emulator.
+set -u
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+HARNESS="$REPO_ROOT/tests/emu/run-azd-up.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf "  OK  %s\n" "$1"; }
+bad() { FAIL=$((FAIL+1)); printf "  FAIL %s -- %s\n" "$1" "$2"; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+chmod +x "$REPO_ROOT/tests/emu/bin"/* "$HARNESS" 2>/dev/null || true
+
+# Keep retries fast for tests
+export OMNIVEC_RETRY_BASE_SEC=0
+export OMNIVEC_RETRY_ATTEMPTS=4
+
+# ── Scenario 1: transient helm failure recovers ─────────────────────────────
+(
+    OMNIVEC_EMU_STATE="$TMP/s1"
+    export OMNIVEC_EMU_STATE
+    mkdir -p "$OMNIVEC_EMU_STATE"
+    export OMNIVEC_EMU_TRANSIENT_CMD='helm upgrade:2'
+    LOG="$TMP/s1.log"
+    if sh "$HARNESS" >"$LOG" 2>&1; then
+        if grep -q 'transient failure' "$LOG" && grep -q 'Release "omnivec" has been upgraded' "$LOG"; then
+            ok "transient helm failure retried and recovered"
+        else
+            bad "transient helm failure retried and recovered" "missing expected markers in log"
+        fi
+    else
+        bad "transient helm failure retried and recovered" "harness rc=$?"
+    fi
+)
+
+# ── Scenario 2: hard failure on helm upgrade halts deploy ──────────────────
+(
+    OMNIVEC_EMU_STATE="$TMP/s2"
+    export OMNIVEC_EMU_STATE
+    mkdir -p "$OMNIVEC_EMU_STATE"
+    export OMNIVEC_EMU_FAIL_CMD='helm upgrade'
+    LOG="$TMP/s2.log"
+    sh "$HARNESS" >"$LOG" 2>&1
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        if grep -q 'injected non-transient failure' "$LOG" \
+           || grep -q 'failed after' "$LOG" \
+           || grep -q 'Helm deploy failed' "$LOG"; then
+            ok "non-transient helm failure halts deploy"
+        else
+            bad "non-transient helm failure halts deploy" \
+                "harness exited $rc but expected markers missing"
+        fi
+    else
+        bad "non-transient helm failure halts deploy" "harness succeeded rc=0"
+    fi
+)
+
+# ── Scenario 3: delay on az acr import does not cause a failure ────────────
+(
+    OMNIVEC_EMU_STATE="$TMP/s3"
+    export OMNIVEC_EMU_STATE
+    mkdir -p "$OMNIVEC_EMU_STATE"
+    export OMNIVEC_EMU_DELAY_CMD='az acr import:1'
+    LOG="$TMP/s3.log"
+    if sh "$HARNESS" >"$LOG" 2>&1; then
+        ok "delay on az acr import is absorbed"
+    else
+        bad "delay on az acr import is absorbed" "harness rc=$?"
+    fi
+)
+
+# ── Scenario 4: idempotent rerun — skip path should kick in ────────────────
+(
+    OMNIVEC_EMU_STATE="$TMP/s4"
+    export OMNIVEC_EMU_STATE
+    mkdir -p "$OMNIVEC_EMU_STATE"
+    # First run: baseline
+    sh "$HARNESS" >"$TMP/s4a.log" 2>&1 || true
+    # Second run: nothing changed, skip-helm should fire
+    LOG="$TMP/s4b.log"
+    sh "$HARNESS" >"$LOG" 2>&1
+    rc=$?
+    if [ "$rc" -eq 0 ] && grep -q 'skipping helm upgrade' "$LOG"; then
+        ok "second run skips helm when nothing changed"
+    else
+        bad "second run skips helm when nothing changed" "rc=$rc; tail:"
+        tail -10 "$LOG" | sed 's/^/    /'
+    fi
+)
+
+printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Stateful in-process emulator of az/azd/kubectl/helm/docker so real preprovision.sh + postprovision.sh can run E2E in seconds. Includes fault injection (success/slow/transient/fail) and two new test suites (test-emu-e2e.sh, test-emu-faults.sh). See tests/emu/README.md.