### PR TITLE
fix(worker): readiness 200 once SB receiver ready, not on first message

### DIFF
--- a/connectors/worker/dotnet/Services/EmbeddingWorkerService.cs
+++ b/connectors/worker/dotnet/Services/EmbeddingWorkerService.cs
@@ -43,6 +43,9 @@ public class EmbeddingWorkerService : BackgroundService
         if (_sbClient is null)
         {
             _logger.LogWarning("Service Bus not configured — worker idle. Set Worker__ServiceBusNamespace to enable queue processing.");
+            // Mark ready so the pod becomes Ready in k8s (idle is a legitimate
+            // steady state — helm --wait must not hang on an optional worker).
+            WorkerHeartbeat.MarkReady();
             // Stay alive but idle — don't crash the pod
             await Task.Delay(Timeout.Infinite, ct);
             return;
@@ -60,6 +63,11 @@ public class EmbeddingWorkerService : BackgroundService
                 PrefetchCount = _options.EmbedBatchSize,
                 ReceiveMode = ServiceBusReceiveMode.PeekLock,
             });
+
+        // Receiver constructed successfully — we can serve. Marking ready here
+        // (not on first message) so an empty queue does not keep the pod 0/1
+        // and cause helm --wait to hang for 25 minutes.
+        WorkerHeartbeat.MarkReady();
 
         // Run multiple concurrent receive loops
         var tasks = Enumerable.Range(0, _options.MaxConcurrentCalls)

--- a/connectors/worker/dotnet/Services/HealthEndpointService.cs
+++ b/connectors/worker/dotnet/Services/HealthEndpointService.cs
@@ -125,9 +125,16 @@ public class HealthEndpointService : BackgroundService
 
     private static (int, string) EvaluateReadiness()
     {
-        if (WorkerHeartbeat.HasReceivedFirstMessage)
-            return (200, "ready");
-        return (503, "not_ready — no successful receive yet");
+        // Readiness means: the worker is able to serve — it has successfully
+        // initialised its Service Bus client (or is deliberately idle) and the
+        // liveness heartbeat is fresh. It does NOT require that a message has
+        // actually been received, because an idle queue would then leave the
+        // pod 0/1 forever and helm --wait --atomic would hang.
+        if (!WorkerHeartbeat.IsReady)
+            return (503, "not_ready — worker still initialising");
+        if (!WorkerHeartbeat.IsHealthy(out var age))
+            return (503, $"not_ready — heartbeat stale ({age}s)");
+        return (200, WorkerHeartbeat.HasReceivedFirstMessage ? "ready" : "ready (idle)");
     }
 }
 
@@ -136,6 +143,7 @@ public static class WorkerHeartbeat
 {
     private static long _lastBeatTicks = DateTime.UtcNow.Ticks;
     private static int _hasReceivedFirstMessage; // 0/1
+    private static int _isReady;                 // 0/1 — worker is initialised and able to serve
     private static readonly DateTime _startedAt = DateTime.UtcNow;
 
     /// <summary>Grace period after startup during which liveness always passes.</summary>
@@ -148,6 +156,21 @@ public static class WorkerHeartbeat
     {
         Interlocked.Exchange(ref _lastBeatTicks, DateTime.UtcNow.Ticks);
     }
+
+    /// <summary>
+    /// Mark the worker as ready to serve. Call this once the Service Bus
+    /// receiver is created (or the deliberately-idle path is entered), not
+    /// when a message is first received — otherwise idle clusters never
+    /// become Ready and helm --wait will hang.
+    /// </summary>
+    public static void MarkReady()
+    {
+        Interlocked.CompareExchange(ref _isReady, 1, 0);
+        Beat();
+    }
+
+    public static bool IsReady =>
+        Interlocked.CompareExchange(ref _isReady, 0, 0) == 1;
 
     public static void MarkReceivedFirstMessage()
     {


### PR DESCRIPTION
Second root cause of the ''helm --wait hangs'' experience. Old probe required a first SB message to flip ready=true, so idle queues never made pods 1/1, and helm --wait timed out. Now readiness flips once the receiver is constructed (or the idle-by-config path is entered). Details in commit.