### PR TITLE
fix(azd up): default to preserving local ACR images (follow-up to #83)

### DIFF
--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -261,13 +261,11 @@ FIRST_IMAGE=$(echo "$IMAGES" | awk '{print $1}')
 SKIP_IMPORT=${OMNIVEC_SKIP_IMPORT:-$(get_azd_value "OMNIVEC_SKIP_IMPORT")}
 
 # Auth-test helper: skip the unconditional auth-test re-import when the
-# first image already exists locally and either (a) the user asked us to
-# preserve local, or (b) it already matches the shared digest.
+# first image already exists locally. Default policy is "prefer local" —
+# re-import only if the user explicitly asked via OMNIVEC_FORCE_IMPORT.
 _auth_test_can_skip() {
   if [ "$FORCE_IMPORT" = "true" ]; then return 1; fi
-  if ! image_exists "$FIRST_IMAGE" "latest"; then return 1; fi
-  if [ "$SKIP_IMPORT" = "true" ] || [ "$SKIP_IMPORT" = "1" ]; then return 0; fi
-  if image_up_to_date "$FIRST_IMAGE" "latest"; then return 0; fi
+  if image_exists "$FIRST_IMAGE" "latest"; then return 0; fi
   return 1
 }
 
@@ -342,17 +340,14 @@ else
       printf "  ${GREEN}${image}:latest already imported (auth test).${NC}\n"
       continue
     fi
-    if [ "$FORCE_IMPORT" != "true" ] && image_up_to_date "$image" "latest"; then
-      printf "  ${GREEN}${image}:latest up to date (digest match), skipping.${NC}\n"
+    if [ "$FORCE_IMPORT" != "true" ] && image_exists "$image" "latest"; then
+      # Default policy: local image wins. Re-import only when the user
+      # explicitly sets OMNIVEC_FORCE_IMPORT=true. This prevents the
+      # shared-registry :latest (which may lag behind hotfixes) from
+      # clobbering locally built / patched images on every azd up.
+      printf "  ${GREEN}${image}:latest already present locally, preserving (set OMNIVEC_FORCE_IMPORT=true to overwrite).${NC}\n"
       skip_count=$((skip_count + 1))
       continue
-    elif [ "$FORCE_IMPORT" != "true" ] && image_exists "$image" "latest"; then
-      if [ "$SKIP_IMPORT" = "true" ] || [ "$SKIP_IMPORT" = "1" ]; then
-        printf "  ${GREEN}${image}:latest exists locally, preserving (OMNIVEC_SKIP_IMPORT=true).${NC}\n"
-        skip_count=$((skip_count + 1))
-        continue
-      fi
-      printf "  ${CYAN}${image}:latest exists but digest differs, re-importing (set OMNIVEC_SKIP_IMPORT=true to keep local).${NC}\n"
     fi
 
     printf "  ${CYAN}Importing ${image}:latest...${NC}\n"


### PR DESCRIPTION
Follow-up to #83. Previous fix honoured OMNIVEC_SKIP_IMPORT but default was still 'clobber on digest mismatch'. Shared registry :latest lags behind local ACR (where hotfixes land), so every azd up was silently downgrading worker/api/web images.

**Observed today:** worker image downgraded from sha `31cd8f17` (main-9cbf5ca, has #81+#82 fixes) back to sha `5a27499` (stale shared) mid-deploy. Startup probes failed. Helm --wait hung 10+ minutes.

**New policy:**
- If `:latest` exists in our ACR → keep it.
- Re-import only when `OMNIVEC_FORCE_IMPORT=true`.
- Auth-test skip no longer depends on digest matching shared.

Escape hatches preserved: `OMNIVEC_FORCE_IMPORT=true` and `OMNIVEC_BUILD=true`.