### PR TITLE
fix(emu+hooks): ship emulator shims + idempotent rerun actually skips helm

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,12 @@ tests/hooks/mocks/azd     text eol=lf
 tests/hooks/mocks/az      text eol=lf
 tests/hooks/mocks/kubectl text eol=lf
 tests/hooks/mocks/helm    text eol=lf
+# Emulator shims for full azd-up E2E tests.
+tests/emu/bin/az      text eol=lf
+tests/emu/bin/azd     text eol=lf
+tests/emu/bin/docker  text eol=lf
+tests/emu/bin/helm    text eol=lf
+tests/emu/bin/kubectl text eol=lf
 scripts/*.sh    text eol=lf
 Dockerfile*     text eol=lf
 *.yaml          text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ scripts/bench_embedding_rs/target/
 # .NET build output
 bin/
 obj/
+# …but keep emulator shims for hooks tests
+!tests/emu/bin/
+!tests/emu/bin/**
 
 # Build artifacts
 *.tar.gz

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -251,6 +251,8 @@ build_missing_images() {
 # ── If not explicitly set to build, try import ──────────────────────────
 ANON_OK=false
 TOKEN_OK=false
+AUTH_IMPORTED=false
+IMAGES_CHANGED=false
 FIRST_IMAGE=$(echo "$IMAGES" | awk '{print $1}')
 
 # Honour OMNIVEC_SKIP_IMPORT — set this when you have locally built (or
@@ -285,6 +287,7 @@ if [ "$OMNIVEC_BUILD" != "true" ] && [ "$SKIP_IMPORT" != "true" ] && [ "$SKIP_IM
     if timeout 90 az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:latest" --image "${FIRST_IMAGE}:latest" --force >/dev/null 2>&1; then
       printf " ${GREEN}✓ anonymous pull works${NC}\n"
       ANON_OK=true
+      AUTH_IMPORTED=true
     else
       printf " ${YELLOW}✗ requires auth${NC}\n"
       # Try stored token
@@ -293,6 +296,7 @@ if [ "$OMNIVEC_BUILD" != "true" ] && [ "$SKIP_IMPORT" != "true" ] && [ "$SKIP_IM
         if az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:latest" --image "${FIRST_IMAGE}:latest" --username "$SHARED_REGISTRY_USER" --password "$SHARED_REGISTRY_TOKEN" --force >/dev/null 2>&1; then
           printf " ${GREEN}✓ token works${NC}\n"
           TOKEN_OK=true
+          AUTH_IMPORTED=true
         else
           printf " ${RED}✗ token invalid/expired${NC}\n"
         fi
@@ -307,6 +311,7 @@ if [ "$OMNIVEC_BUILD" != "true" ] && [ "$SKIP_IMPORT" != "true" ] && [ "$SKIP_IM
             azd env set OMNIVEC_SHARED_REGISTRY_TOKEN "$_new_token" </dev/null 2>/dev/null || true
             printf "  ${GREEN}Token valid — saved for future use.${NC}\n"
             TOKEN_OK=true
+            AUTH_IMPORTED=true
           else
             printf "  ${RED}Token invalid. Will build from source.${NC}\n"
           fi
@@ -328,16 +333,25 @@ if [ "$OMNIVEC_BUILD" = "true" ] || { [ "$ANON_OK" = "false" ] && [ "$TOKEN_OK" 
   IMAGES_CHANGED=true
   printf "${GREEN}All images built and pushed.${NC}\n"
 else
-  # IMPORT MODE: first image already imported by test above, do the rest
-  import_count=1
+  # IMPORT MODE: iterate every image. FIRST_IMAGE was handled by the auth
+  # test above — count it as imported only if the auth test actually ran
+  # an import (AUTH_IMPORTED=true); otherwise count it as a skip so
+  # IMAGES_CHANGED stays false when nothing really changed.
+  import_count=0
   skip_count=0
   IMPORT_TMP=$(mktemp -d)
   import_pids=""
 
   for image in $IMAGES; do
-    # Skip first image — already imported during auth test
+    # First image — already handled by auth test (imported or preserved)
     if [ "$image" = "$FIRST_IMAGE" ]; then
-      printf "  ${GREEN}${image}:latest already imported (auth test).${NC}\n"
+      if [ "$AUTH_IMPORTED" = "true" ]; then
+        printf "  ${GREEN}${image}:latest already imported (auth test).${NC}\n"
+        import_count=$((import_count + 1))
+      else
+        printf "  ${GREEN}${image}:latest already present locally, preserving (auth test).${NC}\n"
+        skip_count=$((skip_count + 1))
+      fi
       continue
     fi
     if [ "$FORCE_IMPORT" != "true" ] && image_exists "$image" "latest"; then

--- a/tests/emu/bin/az
+++ b/tests/emu/bin/az
@@ -1,0 +1,217 @@
+#!/bin/sh
+# tests/emu/bin/az - stateful emulator of the Azure CLI.
+_DIR=$(cd "$(dirname "$0")" && pwd)
+. "$_DIR/../lib/_common.sh"
+emu_enter az "$@"
+
+# Parse out --query and -o/--output flags; keep positional args in $PARGS.
+_q=""
+_out=""
+PARGS=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --query)       _q=$2; shift 2 ;;
+        -o|--output)   _out=$2; shift 2 ;;
+        --subscription|--resource-group|-g|--name|-n|--namespace|--tags|--operation|--file|--registry|--image|--context|--source|--username|--password|--location|-l|--vm-size|--node-count|--kubernetes-version|--install-location|--kubelogin-install-location)
+            # Most flags take a value; preserve as positional-like args for matching.
+            PARGS="$PARGS $1=$2"
+            shift 2 ;;
+        --force|--overwrite-existing|--no-logs|--yes|-y)
+            PARGS="$PARGS $1"
+            shift ;;
+        -*)
+            # Unknown flag; try to swallow with optional value
+            if [ $# -ge 2 ] && [ "${2#-}" = "$2" ]; then
+                PARGS="$PARGS $1=$2"; shift 2
+            else
+                PARGS="$PARGS $1"; shift
+            fi ;;
+        *)
+            PARGS="$PARGS $1"; shift ;;
+    esac
+done
+
+_emit() {
+    # _emit <value> - print as tsv (default) or json if requested
+    if [ "$_out" = "json" ]; then
+        printf '"%s"\n' "$1"
+    else
+        printf '%s\n' "$1"
+    fi
+}
+
+_arg() {
+    # _arg <flag-name> - extract value of "--flag=value" from PARGS
+    printf '%s' "$PARGS" | tr ' ' '\n' | awk -F= -v k="$1" '$1==k {print $2; exit}'
+}
+
+# Dispatch on positional verbs recorded while parsing flags:
+set -- $PARGS
+# $1 may be "--flag=val" entries; strip those to find first positional verb.
+VERBS=""
+for a in "$@"; do
+    case "$a" in
+        --*) : ;;
+        *)   VERBS="$VERBS $a" ;;
+    esac
+done
+set -- $VERBS
+
+case "${1:-}" in
+    version)
+        printf '{"azure-cli":"2.60.0 (emu)"}\n' ;;
+    account)
+        case "${2:-}" in
+            show)
+                case "$_q" in
+                    name)      _emit "emu-subscription" ;;
+                    id)        _emit "00000000-0000-0000-0000-000000000000" ;;
+                    tenantId)  _emit "11111111-1111-1111-1111-111111111111" ;;
+                    *)         printf '{"id":"00000000-0000-0000-0000-000000000000","name":"emu-subscription","tenantId":"11111111-1111-1111-1111-111111111111","state":"Enabled"}\n' ;;
+                esac
+                ;;
+            list)
+                printf '[{"id":"00000000-0000-0000-0000-000000000000","name":"emu-subscription","isDefault":true}]\n' ;;
+            set)
+                exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    login|logout)
+        exit 0 ;;
+    provider)
+        case "${2:-}" in
+            register|show)
+                _ns=$(_arg --namespace)
+                case "$_q" in
+                    *registrationState*) _emit "Registered" ;;
+                    *) printf '{"namespace":"%s","registrationState":"Registered"}\n' "$_ns" ;;
+                esac ;;
+            list)
+                printf '[]\n' ;;
+            *) exit 0 ;;
+        esac ;;
+    group)
+        rg=$(_arg --name)
+        [ -z "$rg" ] && rg=$(_arg -g)
+        case "${2:-}" in
+            create)
+                emu_set "arm/groups" "$rg" "{\"name\":\"$rg\",\"id\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/$rg\"}"
+                _emit "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/$rg" ;;
+            show)
+                if ! emu_has "arm/groups" "$rg"; then
+                    emu_set "arm/groups" "$rg" "{\"name\":\"$rg\"}"
+                fi
+                case "$_q" in
+                    *id*) _emit "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/$rg" ;;
+                    *)    printf '{"name":"%s","id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/%s","location":"eastus2"}\n' "$rg" "$rg" ;;
+                esac ;;
+            exists)
+                if emu_has "arm/groups" "$rg"; then echo true; else echo false; fi ;;
+            delete)
+                emu_del "arm/groups" "$rg" ;;
+            *) exit 0 ;;
+        esac ;;
+    tag)
+        case "${2:-}" in
+            update|list|create|delete) exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    acr)
+        acr_name=$(_arg --registry)
+        [ -z "$acr_name" ] && acr_name=$(_arg --name)
+        case "${2:-}" in
+            build)
+                img=$(_arg --image)
+                [ -n "$img" ] && emu_set "arm/acr/$acr_name/images" "$(emu_safe "$img")" "built"
+                echo "Run ID: emu-$(date +%s)" ;;
+            import)
+                img=$(_arg --image)
+                src=$(_arg --source)
+                [ -n "$img" ] && emu_set "arm/acr/$acr_name/images" "$(emu_safe "$img")" "imported-from-$src"
+                ;;
+            login)
+                echo "Login Succeeded" ;;
+            show)
+                printf '{"name":"%s","loginServer":"%s.azurecr.io","sku":{"name":"Standard"}}\n' "$acr_name" "$acr_name" ;;
+            repository)
+                case "${3:-}" in
+                    list)
+                        # List unique repos from imported/built images
+                        _d="$OMNIVEC_EMU_STATE/arm/acr/$acr_name/images"
+                        if [ -d "$_d" ]; then
+                            ls "$_d" 2>/dev/null | awk -F_ '{print $1}' | sort -u
+                        else
+                            printf '[]\n'
+                        fi ;;
+                    show-manifests|show-tags)
+                        printf '[{"digest":"sha256:deadbeef","tags":["latest"]}]\n' ;;
+                    *) exit 0 ;;
+                esac ;;
+            check-health)
+                echo "health ok" ;;
+            *) exit 0 ;;
+        esac ;;
+    aks)
+        aks_name=$(_arg --name)
+        rg=$(_arg --resource-group)
+        [ -z "$rg" ] && rg=$(_arg -g)
+        case "${2:-}" in
+            get-credentials)
+                kc=$(_arg --file)
+                [ -z "$kc" ] && kc="${HOME:-/tmp}/.kube/config"
+                mkdir -p "$(dirname "$kc")"
+                cat > "$kc" <<KUBECONFIG
+apiVersion: v1
+kind: Config
+clusters:
+- name: $aks_name
+  cluster:
+    server: https://emu-aks.emu.local:443
+contexts:
+- name: $aks_name
+  context:
+    cluster: $aks_name
+    user: emu-admin
+current-context: $aks_name
+users:
+- name: emu-admin
+  user:
+    token: emu-token
+KUBECONFIG
+                echo "Merged \"$aks_name\" as current context in $kc" >&2 ;;
+            install-cli)
+                # Pretend kubelogin/kubectl are installed; tests already have kubectl emu on PATH.
+                loc=$(_arg --install-location)
+                [ -n "$loc" ] && mkdir -p "$(dirname "$loc")" && : > "$loc" 2>/dev/null || true
+                ;;
+            show)
+                printf '{"name":"%s","powerState":{"code":"Running"},"provisioningState":"Succeeded","kubernetesVersion":"1.30.5"}\n' "$aks_name" ;;
+            *) exit 0 ;;
+        esac ;;
+    cosmosdb)
+        case "${2:-}" in
+            show) printf '{"name":"%s","documentEndpoint":"https://emu-cosmos.documents.azure.com:443/"}\n' "$(_arg --name)" ;;
+            *) exit 0 ;;
+        esac ;;
+    keyvault)
+        case "${2:-}" in
+            show)   printf '{"name":"%s","properties":{"vaultUri":"https://%s.vault.azure.net/"}}\n' "$(_arg --name)" "$(_arg --name)" ;;
+            secret) exit 0 ;;
+            *) exit 0 ;;
+        esac ;;
+    storage)
+        case "${2:-}" in
+            account) printf '{"name":"%s","primaryEndpoints":{"blob":"https://%s.blob.core.windows.net/"}}\n' "$(_arg --name)" "$(_arg --name)" ;;
+            *) exit 0 ;;
+        esac ;;
+    servicebus)
+        case "${2:-}" in
+            namespace) printf '{"name":"%s","serviceBusEndpoint":"https://%s.servicebus.windows.net:443/"}\n' "$(_arg --name)" "$(_arg --name)" ;;
+            *) exit 0 ;;
+        esac ;;
+    monitor|log-analytics|extension|bicep|deployment)
+        exit 0 ;;
+    *)
+        # Unknown command: succeed silently so hook flows are robust to drift.
+        exit 0 ;;
+esac

--- a/tests/emu/bin/azd
+++ b/tests/emu/bin/azd
@@ -1,0 +1,51 @@
+#!/bin/sh
+# tests/emu/bin/azd - stateful emulator of the azd CLI.
+_DIR=$(cd "$(dirname "$0")" && pwd)
+. "$_DIR/../lib/_common.sh"
+emu_enter azd "$@"
+
+case "${1:-}" in
+    version) echo "azd version 1.11.0 (emu)" ;;
+    env)
+        case "${2:-}" in
+            set)
+                # azd env set KEY VALUE
+                [ -n "${3:-}" ] || exit 1
+                emu_set "azd-env" "$3" "${4:-}"
+                ;;
+            get-value)
+                val=$(emu_get "azd-env" "${3:-}")
+                printf '%s\n' "$val"
+                ;;
+            get-values)
+                _d="$OMNIVEC_EMU_STATE/azd-env"
+                if [ -d "$_d" ]; then
+                    for k in $(ls "$_d" 2>/dev/null); do
+                        v=$(cat "$_d/$k" 2>/dev/null)
+                        # escape double quotes in value
+                        v_esc=$(printf '%s' "$v" | sed 's/"/\\"/g')
+                        printf '%s="%s"\n' "$k" "$v_esc"
+                    done
+                fi
+                ;;
+            list)
+                printf 'NAME            DEFAULT  LOCAL  REMOTE\n'
+                printf '%s  true     true   false\n' "${AZURE_ENV_NAME:-emu-env}"
+                ;;
+            new|select|refresh)
+                # no-op for emulator
+                exit 0
+                ;;
+            *)
+                exit 0 ;;
+        esac
+        ;;
+    provision|deploy|down|up)
+        # no-op; harness drives these phases directly
+        exit 0 ;;
+    hooks)
+        # azd hooks run <phase>
+        exit 0 ;;
+    *)
+        exit 0 ;;
+esac

--- a/tests/emu/bin/docker
+++ b/tests/emu/bin/docker
@@ -1,0 +1,38 @@
+#!/bin/sh
+# tests/emu/bin/docker - stateful emulator of docker.
+_DIR=$(cd "$(dirname "$0")" && pwd)
+. "$_DIR/../lib/_common.sh"
+emu_enter docker "$@"
+
+case "${1:-}" in
+    version)
+        echo "Docker version 27.0.0 (emu)" ;;
+    build|buildx)
+        # parse -t TAG to record the built image
+        tag=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                -t|--tag) tag=$2; shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        [ -n "$tag" ] && emu_set "docker/images" "$(emu_safe "$tag")" "built"
+        echo "Successfully built (emu) $tag" ;;
+    push)
+        tag=${2:-}
+        [ -n "$tag" ] && emu_set "docker/registry" "$(emu_safe "$tag")" "pushed"
+        echo "Successfully pushed (emu) $tag" ;;
+    pull)
+        tag=${2:-}
+        [ -n "$tag" ] && emu_set "docker/images" "$(emu_safe "$tag")" "pulled"
+        echo "Successfully pulled (emu) $tag" ;;
+    images)
+        printf 'REPOSITORY  TAG   IMAGE ID     CREATED  SIZE\n'
+        emu_list "docker/images" | while read -r t; do
+            printf '%s  latest  emu-id   1m      1MB\n' "$t"
+        done ;;
+    login|logout|rmi|rm|tag|info)
+        exit 0 ;;
+    *)
+        exit 0 ;;
+esac

--- a/tests/emu/bin/helm
+++ b/tests/emu/bin/helm
@@ -1,0 +1,165 @@
+#!/bin/sh
+# tests/emu/bin/helm - stateful emulator of helm.
+_DIR=$(cd "$(dirname "$0")" && pwd)
+. "$_DIR/../lib/_common.sh"
+emu_enter helm "$@"
+
+ROOT="$OMNIVEC_EMU_STATE/helm"
+RELEASES="$ROOT/releases"
+mkdir -p "$RELEASES"
+
+# Standard OmniVec release components. When helm upgrade runs, it synthesises
+# these deployments + pods in the target namespace so kubectl get deploy/pods
+# reflects realistic state.
+OMNIVEC_COMPONENTS='omnivec-api:2 omnivec-web:2 omnivec-controller:1 omnivec-cosmos-changefeed:3 omnivec-dotnet-worker:1 docgrok:1 docgrok-controller:1'
+
+verb=${1:-}
+case "$verb" in
+    version)
+        echo 'version.BuildInfo{Version:"v3.16.2 (emu)"}' ;;
+    list|ls)
+        printf 'NAME    NAMESPACE  REVISION  STATUS    CHART     APP VERSION\n'
+        for f in "$RELEASES"/*; do
+            [ -f "$f" ] || continue
+            name=$(basename "$f")
+            status=$(grep '^status=' "$f" | cut -d= -f2)
+            ns=$(grep '^namespace=' "$f" | cut -d= -f2)
+            printf '%s  %s  1  %s  omnivec-0.1  1.0\n' "$name" "$ns" "$status"
+        done ;;
+    dependency)
+        # helm dependency build CHART - no-op
+        exit 0 ;;
+    status)
+        shift
+        name=${1:-omnivec}
+        # parse -n NS / --namespace NS
+        ns="default"
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                -n|--namespace) ns=$2; shift 2 ;;
+                --kube-context|--kubeconfig) shift 2 ;;
+                -o|--output) shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        rf="$RELEASES/$name"
+        if [ ! -f "$rf" ]; then
+            echo "Error: release: not found" >&2
+            exit 1
+        fi
+        status=$(grep '^status=' "$rf" | cut -d= -f2)
+        printf '{"name":"%s","info":{"status":"%s"},"namespace":"%s"}\n' "$name" "$status" "$ns" ;;
+    upgrade|install)
+        # helm upgrade --install <release> <chart> [opts]
+        shift
+        # First two positional args (skipping flags) are release name + chart.
+        name=""
+        chart=""
+        ns="default"
+        flags=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                --install) shift ;;
+                --wait|--atomic|--create-namespace|--force|--reset-values|--reuse-values) shift ;;
+                --timeout|--kube-context|--kubeconfig|--values|-f|--set|--set-string|--version|-o|--output)
+                    flags="$flags $1=$2"; shift 2 ;;
+                -n|--namespace) ns=$2; shift 2 ;;
+                -*) shift ;;
+                *)
+                    if [ -z "$name" ]; then name=$1
+                    elif [ -z "$chart" ]; then chart=$1
+                    fi
+                    shift ;;
+            esac
+        done
+        [ -z "$name" ] && name=omnivec
+
+        # Record release
+        cat > "$RELEASES/$name" <<EOF
+name=$name
+namespace=$ns
+chart=$chart
+status=deployed
+revision=1
+EOF
+
+        # Synthesise deployments + pods in emulated kubernetes state so
+        # subsequent kubectl calls see a healthy cluster.
+        nsdir=$(emu_dir "k8s/ns/$ns")
+        mkdir -p "$nsdir/deployments" "$nsdir/pods" "$nsdir/services"
+        for comp_spec in $OMNIVEC_COMPONENTS; do
+            comp=${comp_spec%:*}
+            replicas=${comp_spec##*:}
+            cat > "$nsdir/deployments/$comp" <<D_EOF
+name=$comp
+namespace=$ns
+replicas=$replicas
+readyReplicas=$replicas
+availableReplicas=$replicas
+updatedReplicas=$replicas
+image=emu/$comp:latest
+D_EOF
+            i=0
+            while [ $i -lt "$replicas" ]; do
+                suffix=$(printf '%s-%x%x%x%x%x' "$comp" \
+                    $((RANDOM % 16)) $((RANDOM % 16)) $((RANDOM % 16)) $((RANDOM % 16)) $((RANDOM % 16)) 2>/dev/null || echo "$comp-$i")
+                cat > "$nsdir/pods/$suffix" <<P_EOF
+name=$suffix
+namespace=$ns
+deployment=$comp
+status=Running
+ready=1/1
+restarts=0
+age=1m
+node=aks-system-xyz
+P_EOF
+                i=$((i + 1))
+            done
+        done
+
+        # Synthesise a LoadBalancer service for omnivec-web (the only one
+        # postprovision.sh polls for an external IP). Without this the
+        # hook would poll forever and make emulator runs take minutes.
+        if [ "$ns" = "omnivec" ]; then
+            cat > "$nsdir/services/omnivec-web" <<S_EOF
+name=omnivec-web
+namespace=$ns
+type=LoadBalancer
+clusterIP=10.0.42.1
+externalIP=20.42.42.42
+port=80
+S_EOF
+        fi
+
+        # Emit a canonical helm success banner.
+        cat <<BANNER
+Release "$name" has been upgraded. Happy Helming!
+NAME: $name
+LAST DEPLOYED: $(date 2>/dev/null || echo "now")
+NAMESPACE: $ns
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+BANNER
+        ;;
+    rollback)
+        shift
+        name=${1:-omnivec}
+        rf="$RELEASES/$name"
+        if [ -f "$rf" ]; then
+            sed -i.bak 's/^status=.*/status=deployed/' "$rf" 2>/dev/null
+            rm -f "$rf.bak"
+        fi
+        echo "Rollback was a success! Happy Helming!" ;;
+    uninstall|delete)
+        shift
+        name=${1:-omnivec}
+        rm -f "$RELEASES/$name"
+        # Also wipe synthesised k8s state
+        rm -rf "$OMNIVEC_EMU_STATE/k8s/ns/omnivec" 2>/dev/null
+        echo "release \"$name\" uninstalled" ;;
+    history|get|template|lint|search|repo|show)
+        exit 0 ;;
+    *)
+        exit 0 ;;
+esac

--- a/tests/emu/bin/kubectl
+++ b/tests/emu/bin/kubectl
@@ -1,0 +1,270 @@
+#!/bin/sh
+# tests/emu/bin/kubectl - stateful emulator of kubectl.
+# Supports the subset of verbs/resources used by hooks/postprovision.sh.
+_DIR=$(cd "$(dirname "$0")" && pwd)
+. "$_DIR/../lib/_common.sh"
+emu_enter kubectl "$@"
+
+# ── Flag parsing ────────────────────────────────────────────────────────────
+NS="default"
+OUT=""
+JSONPATH=""
+SELECTOR=""
+TAIL=""
+TIMEOUT=""
+OVERWRITE=""
+FROM_LIT=""
+PARGS=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -n|--namespace) NS=$2; shift 2 ;;
+        -o|--output)
+            case "$2" in
+                jsonpath=*)  OUT=jsonpath; JSONPATH=${2#jsonpath=}; shift 2 ;;
+                jsonpath)    OUT=jsonpath; JSONPATH=$3; shift 3 ;;
+                *)           OUT=$2; shift 2 ;;
+            esac ;;
+        --context|--kubeconfig|--sort-by) shift 2 ;;
+        -l|--selector) SELECTOR=$2; shift 2 ;;
+        --tail=*)    TAIL=${1#--tail=}; shift ;;
+        --tail)      TAIL=$2; shift 2 ;;
+        --timeout=*) TIMEOUT=${1#--timeout=}; shift ;;
+        --timeout)   TIMEOUT=$2; shift 2 ;;
+        --overwrite) OVERWRITE=1; shift ;;
+        --from-literal=*) FROM_LIT="$FROM_LIT ${1#--from-literal=}"; shift ;;
+        --all|--no-headers|--ignore-not-found|--force|--recursive|--wait=true|--wait=false|-A|--all-namespaces) shift ;;
+        -f|--filename) shift 2 ;;
+        --dry-run=*) shift ;;
+        --type=*|--image=*) shift ;;
+        -*) shift ;;
+        *)  PARGS="$PARGS $1"; shift ;;
+    esac
+done
+set -- $PARGS
+verb=${1:-}; kind=${2:-}; name=${3:-}
+
+NSDIR="$OMNIVEC_EMU_STATE/k8s/ns/$NS"
+
+_ensure_ns() {
+    mkdir -p "$NSDIR/deployments" "$NSDIR/pods" "$NSDIR/services" \
+             "$NSDIR/secrets" "$NSDIR/configmaps" "$NSDIR/events"
+    [ -f "$NSDIR/_meta" ] || printf 'name=%s\nphase=Active\n' "$NS" > "$NSDIR/_meta"
+}
+
+_pod_line() {
+    _f=$1
+    nm=$(grep '^name=' "$_f" | cut -d= -f2)
+    st=$(grep '^status=' "$_f" | cut -d= -f2)
+    rd=$(grep '^ready=' "$_f" | cut -d= -f2)
+    rs=$(grep '^restarts=' "$_f" | cut -d= -f2)
+    ag=$(grep '^age=' "$_f" | cut -d= -f2)
+    printf '%-50s %-8s %-10s %-5s %s\n' "$nm" "$rd" "$st" "$rs" "$ag"
+}
+
+_deploy_line() {
+    _f=$1
+    nm=$(grep '^name=' "$_f" | cut -d= -f2)
+    rep=$(grep '^replicas=' "$_f" | cut -d= -f2)
+    rdy=$(grep '^readyReplicas=' "$_f" | cut -d= -f2)
+    avl=$(grep '^availableReplicas=' "$_f" | cut -d= -f2)
+    printf '%-40s %s/%s  %s  %s  1m\n' "$nm" "$rdy" "$rep" "$rep" "$avl"
+}
+
+# ── Handle common JSONPath queries used by the hooks ────────────────────────
+_handle_jsonpath() {
+    _kind=$1
+    _dir="$NSDIR/$2"
+    [ -d "$_dir" ] || return 0
+
+    case "$JSONPATH" in
+        *'availableReplicas==0'*|*'readyReplicas<@.spec.replicas'*|*'!@.status.readyReplicas'*)
+            # list deployments that are NOT fully ready
+            for f in "$_dir"/*; do
+                [ -f "$f" ] || continue
+                nm=$(grep '^name=' "$f" | cut -d= -f2)
+                rep=$(grep '^replicas=' "$f" | cut -d= -f2)
+                rdy=$(grep '^readyReplicas=' "$f" | cut -d= -f2)
+                rdy=${rdy:-0}
+                if [ "${rdy:-0}" -lt "${rep:-1}" ]; then
+                    printf '%s %s/%s\n' "$nm" "$rdy" "$rep"
+                fi
+            done ;;
+        *'status.loadBalancer.ingress[0].ip'*|*'loadBalancer.ingress'*)
+            # Direct IP query — either for a specific service (kubectl get svc NAME
+            # -o jsonpath=...) or for all. RESOURCE_NAME is set by the caller if
+            # a specific one was requested.
+            if [ -n "${RESOURCE_NAME:-}" ]; then
+                sf="$_dir/$RESOURCE_NAME"
+                [ -f "$sf" ] && grep '^externalIP=' "$sf" | cut -d= -f2
+            else
+                for f in "$_dir"/*; do
+                    [ -f "$f" ] || continue
+                    ty=$(grep '^type=' "$f" | cut -d= -f2)
+                    [ "$ty" = "LoadBalancer" ] && grep '^externalIP=' "$f" | cut -d= -f2
+                done
+            fi ;;
+        *'spec.type=="LoadBalancer"'*|*'LoadBalancer'*)
+            for f in "$_dir"/*; do
+                [ -f "$f" ] || continue
+                nm=$(grep '^name=' "$f" | cut -d= -f2)
+                ty=$(grep '^type=' "$f" | cut -d= -f2)
+                ip=$(grep '^externalIP=' "$f" | cut -d= -f2)
+                [ "$ty" = "LoadBalancer" ] && printf '%s %s\n' "$nm" "$ip"
+            done ;;
+        *'type=="Warning"'*)
+            _ef="$NSDIR/events/warnings"
+            [ -f "$_ef" ] && cat "$_ef" ;;
+        *)
+            # Generic fallback: print names
+            for f in "$_dir"/*; do
+                [ -f "$f" ] || continue
+                grep '^name=' "$f" | cut -d= -f2
+            done ;;
+    esac
+}
+
+case "$verb" in
+    version)
+        case "$OUT" in
+            json) printf '{"clientVersion":{"gitVersion":"v1.30.0-emu"}}\n' ;;
+            *)    printf 'Client Version: v1.30.0 (emu)\nServer Version: v1.30.5 (emu)\n' ;;
+        esac ;;
+    cluster-info)
+        echo "Kubernetes control plane is running at https://emu-aks.emu.local:443" ;;
+    config)
+        exit 0 ;;
+    create)
+        _ensure_ns
+        case "$kind" in
+            namespace|ns)
+                tgt=$name
+                [ -z "$tgt" ] && tgt=$NS
+                ndir="$OMNIVEC_EMU_STATE/k8s/ns/$tgt"
+                if [ -d "$ndir" ]; then
+                    echo "Error from server (AlreadyExists): namespaces \"$tgt\" already exists" >&2
+                    exit 1
+                fi
+                mkdir -p "$ndir"
+                printf 'name=%s\nphase=Active\n' "$tgt" > "$ndir/_meta"
+                echo "namespace/$tgt created" ;;
+            secret)
+                # `kubectl create secret generic <name> --from-literal=k=v ...`
+                sname=$name
+                [ -z "$sname" ] && sname=${4:-secret}
+                _ensure_ns
+                cat > "$NSDIR/secrets/$sname" <<EOF
+name=$sname
+namespace=$NS
+data=$FROM_LIT
+EOF
+                echo "secret/$sname created" ;;
+            deployment|deploy)
+                _ensure_ns
+                cat > "$NSDIR/deployments/$name" <<EOF
+name=$name
+namespace=$NS
+replicas=1
+readyReplicas=1
+availableReplicas=1
+EOF
+                echo "deployment.apps/$name created" ;;
+            *)
+                echo "${kind}/${name:-obj} created" ;;
+        esac ;;
+    apply|replace)
+        _ensure_ns
+        echo "resource configured" ;;
+    label|annotate)
+        # label/annotate namespace omnivec k=v [--overwrite]
+        _ensure_ns
+        echo "${kind}/${name:-$NS} ${verb}ed" ;;
+    delete)
+        case "$kind" in
+            namespace|ns) rm -rf "$OMNIVEC_EMU_STATE/k8s/ns/${name:-$NS}" ;;
+            pod|pods)     [ -n "$name" ] && rm -f "$NSDIR/pods/$name" ;;
+            deployment|deploy) [ -n "$name" ] && rm -f "$NSDIR/deployments/$name" ;;
+            secret|secrets)    [ -n "$name" ] && rm -f "$NSDIR/secrets/$name" ;;
+            service|svc)       [ -n "$name" ] && rm -f "$NSDIR/services/$name" ;;
+        esac
+        echo "${kind}/${name:-x} deleted" ;;
+    get)
+        _ensure_ns
+        if [ "$OUT" = "jsonpath" ]; then
+            RESOURCE_NAME="$name"
+            case "$kind" in
+                deploy|deployment|deployments) _handle_jsonpath deploy deployments ;;
+                svc|service|services)          _handle_jsonpath svc services ;;
+                events|ev)                     _handle_jsonpath events events ;;
+                pod|pods)                      _handle_jsonpath pods pods ;;
+                *)                             : ;;
+            esac
+            exit 0
+        fi
+        case "$kind" in
+            nodes|node)
+                printf 'NAME              STATUS   ROLES           AGE   VERSION\n'
+                printf 'aks-sys-001       Ready    control-plane   1h    v1.30.5-emu\n'
+                printf 'aks-sys-002       Ready    <none>          1h    v1.30.5-emu\n' ;;
+            ns|namespace|namespaces)
+                printf 'NAME              STATUS   AGE\n'
+                for n in $(ls "$OMNIVEC_EMU_STATE/k8s/ns" 2>/dev/null); do
+                    printf '%-18s Active  1h\n' "$n"
+                done ;;
+            pods|pod)
+                for f in "$NSDIR/pods"/*; do
+                    [ -f "$f" ] || continue
+                    if [ -n "$SELECTOR" ]; then
+                        dep=$(grep '^deployment=' "$f" | cut -d= -f2)
+                        key=${SELECTOR#app=}
+                        [ "$dep" = "$key" ] || continue
+                    fi
+                    _pod_line "$f"
+                done ;;
+            deploy|deployment|deployments)
+                printf 'NAME                                       READY   UP-TO-DATE  AVAILABLE  AGE\n'
+                for f in "$NSDIR/deployments"/*; do
+                    [ -f "$f" ] || continue
+                    _deploy_line "$f"
+                done ;;
+            svc|service|services)
+                printf 'NAME     TYPE         CLUSTER-IP   EXTERNAL-IP  PORT(S)  AGE\n'
+                for f in "$NSDIR/services"/*; do
+                    [ -f "$f" ] || continue
+                    nm=$(grep '^name=' "$f" | cut -d= -f2)
+                    ty=$(grep '^type=' "$f" | cut -d= -f2)
+                    ip=$(grep '^externalIP=' "$f" | cut -d= -f2)
+                    printf '%-8s %-12s 10.0.0.1     %-12s 80/TCP   1m\n' "$nm" "$ty" "${ip:-<pending>}"
+                done ;;
+            secret|secrets)
+                printf 'NAME   TYPE     DATA  AGE\n'
+                for f in "$NSDIR/secrets"/*; do
+                    [ -f "$f" ] || continue
+                    nm=$(grep '^name=' "$f" | cut -d= -f2)
+                    printf '%-8s Opaque   1     1m\n' "$nm"
+                done ;;
+            events|ev)
+                printf 'LAST SEEN   TYPE      REASON    OBJECT      MESSAGE\n' ;;
+            *)
+                exit 0 ;;
+        esac ;;
+    describe)
+        printf 'Name: %s\nNamespace: %s\nEvents: <none>\n' "${name:-obj}" "$NS" ;;
+    logs)
+        # kubectl logs POD
+        printf '[%s] ready\n' "${kind:-pod}"
+        [ -n "$TAIL" ] && printf '[%s] tail=%s\n' "${kind:-pod}" "$TAIL" ;;
+    rollout)
+        # kubectl rollout restart deployment [-n X]  | rollout status deployment/X
+        case "$kind" in
+            status)
+                tgt=${name:-deployment}
+                printf 'deployment "%s" successfully rolled out\n' "$tgt" ;;
+            restart)
+                echo "deployment.apps restarted" ;;
+            *)  echo "rollout $kind $name" ;;
+        esac ;;
+    exec|port-forward|cp|top|scale|wait|auth)
+        exit 0 ;;
+    *)
+        exit 0 ;;
+esac


### PR DESCRIPTION
## What

1. **Ship the emulator shims.** PR #80 added tests/emu/bin/{az,azd,docker,helm,kubectl} but .gitignore's catch-all `bin/` rule silently excluded them. Fresh clones had a broken emulator. Added `!tests/emu/bin/**` negation + `.gitattributes` eol=lf entries.

2. **Fix idempotent rerun.** Scenario-4 of test-emu-faults.sh (second azd up should skip helm when nothing changed) was failing because `import_count` was pre-seeded to 1 on the assumption the auth-test always re-imports FIRST_IMAGE. With PR #84's preserve-local default, the auth test is skipped, but we still counted 1 ''imported'' → IMAGES_CHANGED=true → skip-helm never triggered.

   Added `AUTH_IMPORTED` flag set only inside the three branches that actually ran `az acr import`. FIRST_IMAGE now counts as imported when AUTH_IMPORTED=true, else as a skip. Also init'd IMAGES_CHANGED=false at the top for `set -u` safety.

## Verified

* `bash tests/emu/run-azd-up.sh` → 16s (happy path).
* `bash tests/hooks/test-emu-e2e.sh` → 6/6 pass.
* `bash tests/hooks/test-emu-faults.sh` → 4/4 pass in 18s total.