### PR TITLE
test(emu): CrashLoopBackOff fault + fix subshell PASS/FAIL counting

### DIFF
--- a/tests/emu/bin/helm
+++ b/tests/emu/bin/helm
@@ -57,10 +57,12 @@ case "$verb" in
         chart=""
         ns="default"
         flags=""
+        wait_flag=false
         while [ $# -gt 0 ]; do
             case "$1" in
                 --install) shift ;;
-                --wait|--atomic|--create-namespace|--force|--reset-values|--reuse-values) shift ;;
+                --wait|--atomic) wait_flag=true; shift ;;
+                --create-namespace|--force|--reset-values|--reuse-values) shift ;;
                 --timeout|--kube-context|--kubeconfig|--values|-f|--set|--set-string|--version|-o|--output)
                     flags="$flags $1=$2"; shift 2 ;;
                 -n|--namespace) ns=$2; shift 2 ;;
@@ -85,17 +87,38 @@ EOF
 
         # Synthesise deployments + pods in emulated kubernetes state so
         # subsequent kubectl calls see a healthy cluster.
+        # CrashLoopBackOff fault: when OMNIVEC_EMU_CRASHLOOP_DEPLOY names a
+        # component, synthesise it with readyReplicas=0 and pods in
+        # CrashLoopBackOff, plus a warning event. This mirrors the real
+        # worker regression we saw on 2026-04-20 where helm --wait blocked
+        # ~25 min because deployment ready count never caught up.
+        crash_name=${OMNIVEC_EMU_CRASHLOOP_DEPLOY:-}
         nsdir=$(emu_dir "k8s/ns/$ns")
-        mkdir -p "$nsdir/deployments" "$nsdir/pods" "$nsdir/services"
+        mkdir -p "$nsdir/deployments" "$nsdir/pods" "$nsdir/services" "$nsdir/events"
+        any_crashed=false
         for comp_spec in $OMNIVEC_COMPONENTS; do
             comp=${comp_spec%:*}
             replicas=${comp_spec##*:}
+            if [ -n "$crash_name" ] && [ "$comp" = "$crash_name" ]; then
+                ready=0
+                avail=0
+                pod_status=CrashLoopBackOff
+                pod_ready=0/1
+                pod_restarts=12
+                any_crashed=true
+            else
+                ready=$replicas
+                avail=$replicas
+                pod_status=Running
+                pod_ready=1/1
+                pod_restarts=0
+            fi
             cat > "$nsdir/deployments/$comp" <<D_EOF
 name=$comp
 namespace=$ns
 replicas=$replicas
-readyReplicas=$replicas
-availableReplicas=$replicas
+readyReplicas=$ready
+availableReplicas=$avail
 updatedReplicas=$replicas
 image=emu/$comp:latest
 D_EOF
@@ -107,14 +130,21 @@ D_EOF
 name=$suffix
 namespace=$ns
 deployment=$comp
-status=Running
-ready=1/1
-restarts=0
+status=$pod_status
+ready=$pod_ready
+restarts=$pod_restarts
 age=1m
 node=aks-system-xyz
 P_EOF
                 i=$((i + 1))
             done
+            if [ -n "$crash_name" ] && [ "$comp" = "$crash_name" ]; then
+                # Surface warning events kubectl will pick up.
+                {
+                    printf 'Warning\tBackOff\tBack-off restarting failed container in pod %s-xxxxx\n' "$comp"
+                    printf 'Warning\tUnhealthy\tStartup probe failed: Get "http://10.224.0.42:8080/healthz": dial tcp connection refused\n'
+                } >> "$nsdir/events/warnings"
+            fi
         done
 
         # Synthesise a LoadBalancer service for omnivec-web (the only one
@@ -129,6 +159,20 @@ clusterIP=10.0.42.1
 externalIP=20.42.42.42
 port=80
 S_EOF
+        fi
+
+        # If we synthesised a CrashLoopBackOff deployment AND the caller
+        # asked helm to --wait/--atomic, mimic the real failure mode:
+        # mark release as failed and exit 1 so the hooks' retry/rollback
+        # logic can be regressed.
+        if [ "$any_crashed" = "true" ] && [ "$wait_flag" = "true" ]; then
+            sed -i.bak 's/^status=.*/status=failed/' "$RELEASES/$name" 2>/dev/null
+            rm -f "$RELEASES/$name.bak"
+            cat >&2 <<ERR
+Error: UPGRADE FAILED: release $name failed, and has been rolled back due to atomic being set: context deadline exceeded
+  pre-upgrade hooks failed: timed out waiting for the condition
+ERR
+            exit 1
         fi
 
         # Emit a canonical helm success banner.

--- a/tests/hooks/test-emu-faults.sh
+++ b/tests/hooks/test-emu-faults.sh
@@ -6,11 +6,19 @@ REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
 HARNESS="$REPO_ROOT/tests/emu/run-azd-up.sh"
 
 PASS=0; FAIL=0
-ok()  { PASS=$((PASS+1)); printf "  OK  %s\n" "$1"; }
-bad() { FAIL=$((FAIL+1)); printf "  FAIL %s -- %s\n" "$1" "$2"; }
+COUNTS="$(mktemp)"
+printf '0 0\n' > "$COUNTS"
+_inc() {
+    # $1 = field (1=pass, 2=fail); atomic-ish since suite runs serially.
+    read _p _f < "$COUNTS"
+    if [ "$1" = "1" ]; then _p=$((_p+1)); else _f=$((_f+1)); fi
+    printf '%d %d\n' "$_p" "$_f" > "$COUNTS"
+}
+ok()  { _inc 1; printf "  OK  %s\n" "$1"; }
+bad() { _inc 2; printf "  FAIL %s -- %s\n" "$1" "$2"; }
 
 TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
+trap 'rm -rf "$TMP" "$COUNTS"' EXIT
 chmod +x "$REPO_ROOT/tests/emu/bin"/* "$HARNESS" 2>/dev/null || true
 
 # Keep retries fast for tests
@@ -91,5 +99,28 @@ export OMNIVEC_RETRY_ATTEMPTS=4
     fi
 )
 
+# ── Scenario 5: CrashLoopBackOff regression — worker never becomes ready ────
+# Reproduces the live-cluster bug we shipped PR #81/#82 for.
+(
+    OMNIVEC_EMU_STATE="$TMP/s5"
+    export OMNIVEC_EMU_STATE
+    mkdir -p "$OMNIVEC_EMU_STATE"
+    export OMNIVEC_EMU_CRASHLOOP_DEPLOY=omnivec-dotnet-worker
+    LOG="$TMP/s5.log"
+    sh "$HARNESS" >"$LOG" 2>&1
+    rc=$?
+    # Harness should fail (rc != 0) AND the hook logs should surface the
+    # CrashLoopBackOff or the UPGRADE FAILED banner so the user is never
+    # left staring at a silent hang.
+    if [ "$rc" -ne 0 ] \
+       && grep -qE 'UPGRADE FAILED|CrashLoopBackOff|BackOff|context deadline exceeded' "$LOG"; then
+        ok "CrashLoopBackOff surfaces a visible failure (no silent hang)"
+    else
+        bad "CrashLoopBackOff surfaces a visible failure (no silent hang)" "rc=$rc; tail:"
+        tail -15 "$LOG" | sed 's/^/    /'
+    fi
+)
+
+read PASS FAIL < "$COUNTS"
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

**Scenario 5: CrashLoopBackOff.** Reproduces the live-cluster bug we shipped PR #81/#82 for: helm --wait sits 25 minutes because pods are Running but readyReplicas never catches up. When `OMNIVEC_EMU_CRASHLOOP_DEPLOY=<name>` is set, the helm emulator synthesises that deployment with `readyReplicas=0`, pods in CrashLoopBackOff (12 restarts), plus warning events kubectl picks up. If `--wait`/`--atomic` was passed, helm marks the release `failed` and exits 1 with the exact `UPGRADE FAILED ... context deadline exceeded` banner helm prints in production.

**Latent bug fix.** `test-emu-faults.sh` incremented PASS/FAIL inside `( ... )` subshells → counters never propagated → script always exited 0 ("5 passed, 0 failed") even when every scenario failed. Replaced with a tempfile-backed counter.

## Verified

* `bash tests/hooks/test-emu-faults.sh` → **5/5** in ~20s
* `dash tests/hooks/test-emu-faults.sh` → **5/5** in ~20s
* `dash tests/hooks/test-emu-e2e.sh` → **6/6**

Already picked up by `tests/run.sh` via its existing `tests/hooks/test-*.sh` glob — no runner wiring change needed.