### PR TITLE
fix(hooks): drop --atomic + adopt orphaned resources to end the azd-up helm loop

### DIFF
--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -501,7 +501,12 @@ if ($ENABLE_BLOB_SOURCE -eq "true") {
     )
 }
 
-$helmArgs += @("--kube-context", $KUBE_CONTEXT, "--wait", "--timeout", "10m", "--atomic")
+$helmArgs += @("--kube-context", $KUBE_CONTEXT, "--wait", "--timeout", "10m")
+# Intentionally NO --atomic: on failure, --atomic runs `helm uninstall`, which
+# strips the release metadata but can leave Deployments/Services behind (they
+# have finalizers or take time to delete). Next run sees "release not found"
+# + orphaned resources → fresh install conflicts on AlreadyExists → --atomic
+# times out → uninstall again → infinite loop.
 
 # Detect stuck Helm release (pending-install / pending-upgrade from interrupted deploy)
 $helmStatus = helm status omnivec -n omnivec --kube-context $KUBE_CONTEXT -o json 2>$null | ConvertFrom-Json -ErrorAction SilentlyContinue
@@ -517,8 +522,33 @@ if ($helmStatus -and $helmStatus.info -and $helmStatus.info.status -match "^pend
     Write-Host "`e[32mStuck release cleared. Proceeding with fresh deploy.`e[0m"
 }
 
+# If no helm release exists but resources do (orphaned from a prior --atomic
+# uninstall), relabel them with Helm ownership so `helm install` can adopt
+# them instead of failing with AlreadyExists.
+if (-not $helmState) {
+    $existing = kubectl --context $KUBE_CONTEXT get deploy -n omnivec -o name 2>$null | Select-Object -First 1
+    if ($existing) {
+        Write-Host "`e[33mNo Helm release found but resources exist in omnivec ns — adopting them for Helm ownership...`e[0m"
+        foreach ($kind in @('deploy','svc','sa','cm','secret','hpa','ingress')) {
+            $resources = kubectl --context $KUBE_CONTEXT get $kind -n omnivec -o name 2>$null
+            foreach ($res in $resources) {
+                if (-not $res) { continue }
+                if ($res -eq 'secret/omnivec-storage') { continue }
+                if ($res -like 'secret/sh.helm.*') { continue }
+                if ($res -like 'secret/default-token-*') { continue }
+                kubectl --context $KUBE_CONTEXT annotate $res -n omnivec --overwrite `
+                    meta.helm.sh/release-name=omnivec `
+                    meta.helm.sh/release-namespace=omnivec 2>$null | Out-Null
+                kubectl --context $KUBE_CONTEXT label $res -n omnivec --overwrite `
+                    app.kubernetes.io/managed-by=Helm 2>$null | Out-Null
+            }
+        }
+        Write-Host "`e[32mAdoption annotations applied — helm install will take ownership.`e[0m"
+    }
+}
+
 # ── Skip helm upgrade if nothing has changed ────────────────────────────────
-# Rationale: helm upgrade --install --wait --atomic takes 1-2 minutes even
+# Rationale: helm upgrade --install --wait takes 1-2 minutes even
 # when the computed manifest is identical to the live one. Skip when:
 #   1. release is currently 'deployed' (healthy, not pending/failed),
 #   2. no images were imported/rebuilt this run ($script:imagesChanged is false),

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -663,9 +663,45 @@ run_helm_deploy() {
                 --set "azure.storage.blobEndpoint=${STORAGE_BLOB_ENDPOINT}"
   fi
 
-  set -- "$@" --wait --timeout 10m --atomic
+  # Intentionally NO --atomic: on failure, --atomic runs `helm uninstall`, which
+  # strips the release metadata but can leave Deployments/Services behind (they
+  # have finalizers or take time to delete). Next run sees "release not found"
+  # + orphaned resources → fresh install conflicts on AlreadyExists → --atomic
+  # times out → uninstall again → infinite loop. Without --atomic, a failed
+  # upgrade just leaves a release in `status=failed` that the next upgrade can
+  # retry cleanly.
+  set -- "$@" --wait --timeout 10m
 
   "$@"
+}
+
+# Adopt orphaned resources when no helm release exists but the workload does.
+# Caused by a previous --atomic timeout that wiped the release secret while
+# the Deployments/Services persisted. We relabel them with Helm ownership so
+# the next `helm install` takes them over instead of erroring on AlreadyExists.
+adopt_orphaned_resources() {
+  _existing=$(kubectl_omnivec get deploy -n omnivec -o name </dev/null 2>/dev/null | head -1)
+  if [ -z "$_existing" ]; then
+    return 0
+  fi
+  printf "${YELLOW}No Helm release found but resources exist in omnivec ns — adopting them for Helm ownership...${NC}\n"
+  _adopt_kinds="deploy svc sa cm secret hpa ingress serviceaccount"
+  # NOTE: exclude the auto-generated storage secret (omnivec-storage) — it is
+  # created by postprovision itself and would conflict with helm-managed ones.
+  for _kind in $_adopt_kinds; do
+    kubectl_omnivec get "$_kind" -n omnivec -o name </dev/null 2>/dev/null | while read -r _res; do
+      [ -z "$_res" ] && continue
+      case "$_res" in
+        secret/omnivec-storage|secret/sh.helm.*|secret/default-token-*) continue ;;
+      esac
+      kubectl_omnivec annotate "$_res" -n omnivec --overwrite \
+        meta.helm.sh/release-name=omnivec \
+        meta.helm.sh/release-namespace=omnivec </dev/null >/dev/null 2>&1 || true
+      kubectl_omnivec label "$_res" -n omnivec --overwrite \
+        app.kubernetes.io/managed-by=Helm </dev/null >/dev/null 2>&1 || true
+    done
+  done
+  printf "${GREEN}Adoption annotations applied — helm install will take ownership.${NC}\n"
 }
 
 # Detect stuck Helm release (pending-install / pending-upgrade from interrupted deploy)
@@ -688,8 +724,14 @@ if [ -n "$_helm_phase" ]; then
   printf "${GREEN}Stuck release cleared. Proceeding with fresh deploy.${NC}\n"
 fi
 
+# If no release exists but resources do (orphaned from a prior --atomic
+# uninstall), adopt them so `helm install` can take ownership cleanly.
+if [ -z "$_helm_state" ]; then
+  adopt_orphaned_resources
+fi
+
 # ── Skip helm upgrade if nothing has changed ────────────────────────────────
-# Rationale: helm upgrade --install --wait --atomic takes 1-2 minutes even
+# Rationale: helm upgrade --install --wait takes 1-2 minutes even
 # when the computed manifest is identical to the live one. We avoid that cost
 # when:
 #   1. the release is currently 'deployed' (healthy, not pending/failed),
@@ -743,13 +785,13 @@ if [ "$SKIP_HELM" = "true" ]; then
   helm_rc=0
 else
   # Execute (d1: retry on transient ARM / Helm errors)
-  # While helm waits (can take 1-3 minutes with --wait --atomic), show a
+  # While helm waits (can take 1-3 minutes with --wait), show a
   # focused heartbeat so the user sees WHAT helm is blocked on. We surface:
   #   - deployments with ready != desired (the primary `helm --wait` target)
   #   - services of type LoadBalancer still waiting for external IP
   #   - the 5 most recent warning/error events
   # If everything is green, a single line tells the user helm itself is just
-  # finalising (common: 15-30s post-ready wait for atomic).
+  # finalising (common: 15-30s post-ready wait).
   OMNIVEC_RETRY_HEARTBEAT_SEC=${OMNIVEC_HELM_HEARTBEAT_SEC:-20}
   OMNIVEC_RETRY_HEARTBEAT_CMD='
 KC="kubectl --context '"$KUBE_CONTEXT"' --kubeconfig '"$OMNIVEC_KUBECONFIG"' -n omnivec"
@@ -771,7 +813,7 @@ _events=$($KC get events --sort-by=.lastTimestamp -o "jsonpath={range .items[?(@
     printf "%s\n" "$_events" | awk "{printf \"      %s\n\", substr(\$0,1,120)}"
   fi
   if [ -z "$_not_ready$_not_ready_all$_pending_lb$_events" ]; then
-    printf "    all resources ready — helm is finalising (atomic wait, typically 15-30s)\n"
+    printf "    all resources ready — helm is finalising (wait, typically 15-30s)\n"
   fi
 }'
   export OMNIVEC_RETRY_HEARTBEAT_SEC OMNIVEC_RETRY_HEARTBEAT_CMD


### PR DESCRIPTION
fix(hooks): drop --atomic + adopt orphaned resources to end the azd-up helm loop

Symptom
-------
azd up against an existing healthy cluster repeatedly failed with:

    Release "omnivec" does not exist. Installing it now.
    Error: release omnivec failed, and has been uninstalled due to
    atomic being set: context deadline exceeded

Meanwhile kubectl showed all Deployments green and 35h old, but
`helm list -A` reported NO omnivec release.

Root cause
----------
1. A previous azd up timed out during `helm upgrade --install --atomic`.
2. `--atomic` reacted by running `helm uninstall`, which deleted the
   release secret. The Deployments/Services, however, survived
   (finalizers / graceful termination).
3. On the next azd up, helm saw "no release" and tried to `install`.
   Every Deployment create returned AlreadyExists, so helm hung waiting
   for readiness → `--atomic` timed out → uninstalled the release
   secret again → back to step 2. Infinite loop.

Fix (two layers)
----------------
1. Remove `--atomic` from the helm upgrade invocation in both
   postprovision.sh (line 666) and postprovision.ps1 (line 504). We
   keep `--wait --timeout 10m` so failures still surface — we just
   don't want helm to wipe its own release metadata on timeout. A
   failed upgrade now leaves a `status=failed` release that the next
   run cleanly retries.

2. Adopt orphaned resources. When helm status returns empty but
   Deployments exist in the omnivec namespace, relabel/reannotate
   every Deployment, Service, ServiceAccount, ConfigMap, Secret, HPA,
   and Ingress with:
     meta.helm.sh/release-name=omnivec
     meta.helm.sh/release-namespace=omnivec
     app.kubernetes.io/managed-by=Helm
   This tells helm "these are mine" so the next install takes them
   over in-place instead of erroring with AlreadyExists.

Excluded from adoption: `secret/omnivec-storage` (managed directly by
postprovision), helm's own `sh.helm.*` release secrets, and
`default-token-*` SA tokens.

Verification
------------
- Shell + PowerShell syntax checks clean.
- Emulator fault suite 5/5 pass (transient retry, non-transient halt,
  acr-import delay, idempotent skip-helm, crashloop surfacing).
- Live cluster orphan adopted manually ahead of this PR — next azd up
  will exercise the adoption code path on green cluster with healthy
  release metadata.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
