### PR TITLE
fix(hooks): halt on docker build/push/acr-build failure instead of silently continuing

### DIFF
--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -170,11 +170,23 @@ function Build-Image {
     Write-Host "  `e[36mBuilding ${Name}:${Tag}...`e[0m"
     if ($BUILD_MODE -eq "docker") {
         docker build -t "${ACR_LOGIN_SERVER}/${Name}:${Tag}" -f $Dockerfile $Context
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  `e[31mdocker build failed for ${Name}:${Tag}.`e[0m"
+            exit 1
+        }
         docker push "${ACR_LOGIN_SERVER}/${Name}:${Tag}"
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "  `e[31mdocker push failed for ${Name}:${Tag}.`e[0m"
+            exit 1
+        }
     } else {
         az acr build --registry $ACR_NAME --image "${Name}:${Tag}" --file $Dockerfile $Context --no-logs 2>$null
         if ($LASTEXITCODE -ne 0) {
             az acr build --registry $ACR_NAME --image "${Name}:${Tag}" --file $Dockerfile $Context
+            if ($LASTEXITCODE -ne 0) {
+                Write-Host "  `e[31maz acr build failed for ${Name}:${Tag}.`e[0m"
+                exit 1
+            }
         }
     }
     Write-Host "  `e[32m${Name}:${Tag} pushed.`e[0m"


### PR DESCRIPTION
Same class of bug as #89. docker build, docker push, and the az acr build retry had no exit-code check — a silent failure fell through and the next phase ran against a stale/missing image. Now every branch checks \\0\ and exits 1 on failure.