### PR TITLE
fix(helm): remove chart-owned Namespace resource to stop uninstall-cascades

### DIFF
--- a/helm/omnivec/templates/namespace.yaml
+++ b/helm/omnivec/templates/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.global.namespace }}
-  labels:
-    {{- include "omnivec.labels" . | nindent 4 }}


### PR DESCRIPTION
fix(helm): remove chart-owned Namespace resource to stop uninstall-cascades

Symptom
-------
After PR #88 dropped --atomic and added stuck-release recovery, the
next azd up would land on:

  Error: create: failed to create: secrets
  "sh.helm.release.v1.omnivec.v1" is forbidden: unable to create
  new content in namespace omnivec because it is being terminated

and leave every workload pod in Terminating.

Root cause
----------
helm/omnivec/templates/namespace.yaml declared the omnivec namespace
as a chart resource. Phase 3 of postprovision also kubectl-applies
the namespace. When stuck-release recovery ran `helm uninstall` on
a pending-install release, helm deleted everything it owned —
INCLUDING the namespace — which cascade-deleted every pod, hpa,
svc, secret. The namespace then sat in Terminating state for 30-60s,
and the retry `helm install` raced it and hit the "being terminated"
error.

Fix
---
Delete templates/namespace.yaml. The namespace is already created
(and Helm-labeled/annotated for adoption) by postprovision Phase 3;
the chart shouldn't also own it. Net result: helm uninstall now
removes only the workload, leaving the namespace intact so the next
install starts clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
