### PR TITLE
fix(hooks): fail loud on postprovision errors

### DIFF
--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -401,6 +401,10 @@ $OMNIVEC_KUBECONFIG = Join-Path $HOME ".kube" "omnivec-$env:AZURE_ENV_NAME"
 $env:KUBECONFIG = $OMNIVEC_KUBECONFIG
 
 az aks get-credentials --resource-group $RESOURCE_GROUP --name $AKS_CLUSTER --file $OMNIVEC_KUBECONFIG --overwrite-existing
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "`e[31mFailed to fetch AKS credentials for cluster $AKS_CLUSTER`e[0m"
+    exit 1
+}
 Write-Host "`e[32mConnected to AKS cluster: $AKS_CLUSTER`e[0m"
 
 # =============================================================================
@@ -410,9 +414,11 @@ Write-Host "`e[32mConnected to AKS cluster: $AKS_CLUSTER`e[0m"
 Write-Host "`n`e[33mPhase 3: Creating namespaces and secrets...`e[0m"
 
 kubectl --context $KUBE_CONTEXT create namespace omnivec --dry-run=client -o yaml | kubectl --context $KUBE_CONTEXT apply -f -
+if ($LASTEXITCODE -ne 0) { Write-Host "`e[31mFailed to create namespace omnivec`e[0m"; exit 1 }
 kubectl --context $KUBE_CONTEXT create namespace docgrok --dry-run=client -o yaml | kubectl --context $KUBE_CONTEXT apply -f -
-kubectl --context $KUBE_CONTEXT label namespace omnivec app.kubernetes.io/managed-by=Helm --overwrite
-kubectl --context $KUBE_CONTEXT annotate namespace omnivec meta.helm.sh/release-name=omnivec meta.helm.sh/release-namespace=omnivec --overwrite
+if ($LASTEXITCODE -ne 0) { Write-Host "`e[31mFailed to create namespace docgrok`e[0m"; exit 1 }
+kubectl --context $KUBE_CONTEXT label namespace omnivec app.kubernetes.io/managed-by=Helm --overwrite | Out-Null
+kubectl --context $KUBE_CONTEXT annotate namespace omnivec meta.helm.sh/release-name=omnivec meta.helm.sh/release-namespace=omnivec --overwrite | Out-Null
 
 if ($ENABLE_BLOB_SOURCE -eq "true" -and $STORAGE_ACCOUNT) {
     kubectl --context $KUBE_CONTEXT create secret generic omnivec-storage `

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -201,11 +201,21 @@ build_image() {
 
   printf "  ${CYAN}Building ${name}:${tag}...${NC}\n"
   if [ "$BUILD_MODE" = "docker" ]; then
-    docker build -t "${ACR_LOGIN_SERVER}/${name}:${tag}" -f "$dockerfile" "$context"
-    docker push "${ACR_LOGIN_SERVER}/${name}:${tag}"
+    if ! docker build -t "${ACR_LOGIN_SERVER}/${name}:${tag}" -f "$dockerfile" "$context"; then
+      printf "${RED}docker build failed for ${name}:${tag}${NC}\n"
+      exit 1
+    fi
+    if ! docker push "${ACR_LOGIN_SERVER}/${name}:${tag}"; then
+      printf "${RED}docker push failed for ${name}:${tag}${NC}\n"
+      exit 1
+    fi
   else
-    az acr build --registry "$ACR_NAME" --image "${name}:${tag}" --file "$dockerfile" "$context" --no-logs </dev/null 2>/dev/null || \
-    az acr build --registry "$ACR_NAME" --image "${name}:${tag}" --file "$dockerfile" "$context" </dev/null
+    if ! az acr build --registry "$ACR_NAME" --image "${name}:${tag}" --file "$dockerfile" "$context" --no-logs </dev/null 2>/dev/null; then
+      if ! az acr build --registry "$ACR_NAME" --image "${name}:${tag}" --file "$dockerfile" "$context" </dev/null; then
+        printf "${RED}az acr build failed for ${name}:${tag}${NC}\n"
+        exit 1
+      fi
+    fi
   fi
   printf "  ${GREEN}${name}:${tag} pushed.${NC}\n"
 }
@@ -472,11 +482,14 @@ KUBE_CONTEXT="${AKS_CLUSTER}"
 OMNIVEC_KUBECONFIG="$HOME/.kube/omnivec-${AZURE_ENV_NAME:-omnivec}"
 export KUBECONFIG="$OMNIVEC_KUBECONFIG"
 
-az aks get-credentials \
+if ! az aks get-credentials \
   --resource-group "$RESOURCE_GROUP" \
   --name "$AKS_CLUSTER" \
   --file "$OMNIVEC_KUBECONFIG" \
-  --overwrite-existing >/dev/null
+  --overwrite-existing >/dev/null; then
+  printf "${RED}Failed to fetch AKS credentials for cluster $AKS_CLUSTER${NC}\n"
+  exit 1
+fi
 
 # Also materialize to the default kubeconfig path so kubectl finds the context
 # even if $KUBECONFIG is reset by the outer runner (azd / heartbeat wrappers).
@@ -562,7 +575,10 @@ if [ -n "$CURRENT_HASH" ] && [ "$CURRENT_HASH" = "$CACHED_HASH" ]; then
   printf "  ${GREEN}Helm dependencies up to date, skipping.${NC}\n"
 else
   printf "  ${CYAN}Resolving helm dependencies...${NC}\n"
-  helm dependency build "$CHART_DIR" </dev/null 2>/dev/null
+  if ! helm dependency build "$CHART_DIR" </dev/null; then
+    printf "  ${RED}helm dependency build failed.${NC}\n"
+    exit 1
+  fi
   if [ -n "$CURRENT_HASH" ]; then
     echo "$CURRENT_HASH" > "$LOCK_HASH_FILE"
   fi


### PR DESCRIPTION
Mirror the fail-loud pattern applied elsewhere in recent PRs. Converts several silent-failure paths in `hooks/postprovision.{sh,ps1}` into explicit `exit 1` so azd up surfaces real errors instead of continuing and failing confusingly downstream.

### Changes
- `az aks get-credentials` — exit 1 on failure (no point proceeding without kubeconfig)
- `kubectl create namespace omnivec/docgrok` — exit 1 on failure
- `docker build` / `docker push` — exit 1 on failure
- `az acr build` — existing fallback to verbose-logs invocation preserved; exit 1 only if both fail
- `kubectl label/annotate namespace` — silence success output (idempotent metadata, not a failure path)

No new commands; only error handling on existing ones. No observed bug driving this — speculative hardening. Happy to drop if risk/benefit isn't worth it.