### PR TITLE
fix(scripts): robust JSON parsing in pgvector demo existence check

### DIFF
--- a/scripts/e2e-pgvector-demo.ps1
+++ b/scripts/e2e-pgvector-demo.ps1
@@ -409,9 +409,13 @@ if ($FromStep -le 3) {
     $PG_ADMIN = "omnivecadmin"
 
     # Check if server already exists
-    $showArgs = @('postgres','flexible-server','show','--name',$PG_SERVER,'--resource-group',$RESOURCE_GROUP)
-    $showJson = & $AzExe @showArgs 2>$null
-    $existing = if ($showJson) { $showJson | ConvertFrom-Json -ErrorAction SilentlyContinue } else { $null }
+    $showArgs = @('postgres','flexible-server','show','--name',$PG_SERVER,'--resource-group',$RESOURCE_GROUP,'-o','json')
+    $showRaw = & $AzExe @showArgs 2>$null
+    $showText = if ($null -ne $showRaw) { ($showRaw | Out-String).Trim() } else { '' }
+    $existing = $null
+    if ($showText -and $showText.StartsWith('{')) {
+        try { $existing = $showText | ConvertFrom-Json -ErrorAction Stop } catch { $existing = $null }
+    }
     if ($existing) {
         LogOk "PostgreSQL server already exists: $PG_SERVER"
         $PG_LOCATION = $existing.location


### PR DESCRIPTION
The 'server already exists?' check at Step 3 of `e2e-pgvector-demo.ps1` threw:

```
Cannot convert value 'System.Management.Automation.PSCustomObject' to type 'System.Management.Automation.SwitchParameter'
```

aborting the demo before any real work on `-Existing` re-runs.

### Fix
- Force `-o json` on `az postgres flexible-server show` (was relying on default output mode).
- Coerce az stdout to a single string via `Out-String` before piping to `ConvertFrom-Json` (az can return a string array that trips binding in some PS7 configurations).
- Only attempt the parse when text actually looks like JSON.
- Wrap in try/catch so a malformed payload becomes 'no existing server' instead of a hard stop.

No behavioral change on the happy path; just stops the early abort.