### PR TITLE
fix(web): pipeline reset no longer snaps modal back to General tab

### DIFF
--- a/web/static/index.html
+++ b/web/static/index.html
@@ -5400,7 +5400,11 @@
                 const data = await res.json();
                 showNotification(data.message || 'Pipeline reset', 'success');
                 await refreshData();
-                showPipelineDetail(currentPipelineId);
+                // Re-render the current tab in place instead of calling
+                // showPipelineDetail, which would reset the modal to the General
+                // tab and feel like the modal "re-opened".
+                const pipeline = pipelines.find(p => p.id === currentPipelineId);
+                if (pipeline) renderPipelineDetailTab(pipeline);
             } catch (err) {
                 showNotification('Error: ' + err.message, 'error');
             }


### PR DESCRIPTION
Follow-up to #97. After hitting Reset from the pipeline detail modal, the modal visibly jumped back to the General tab because `resetPipelineFromDetail` called `showPipelineDetail(currentPipelineId)`, which resets `currentPipelineTab = 'general'` and clears edit state. Users perceived this as 'the modal re-opens'.

### Fix
After `refreshData()`, re-render just the currently-active tab via `renderPipelineDetailTab(pipeline)` — no tab reset, no edit-state wipe.