### PR TITLE
fix(worker): restore graceful idle when Service Bus is not configured

### DIFF
--- a/connectors/worker/dotnet/Program.cs
+++ b/connectors/worker/dotnet/Program.cs
@@ -13,17 +13,18 @@ builder.Services.Configure<WorkerOptions>(
     builder.Configuration.GetSection("Worker"));
 
 // Service Bus client — only register when namespace is configured.
-// If not configured, fail fast at startup so Kubernetes surfaces CrashLoopBackOff
-// instead of silently idling (old behavior returned null and awaited Task.Delay(Infinite)).
+// When not configured, return null; EmbeddingWorkerService detects this, logs a
+// warning, marks the pod Ready (so helm --wait doesn't hang), and idles. This
+// allows deployments without blob source (no Service Bus provisioned) to run
+// cleanly instead of CrashLoopBackOff'ing the worker pod.
 builder.Services.AddSingleton(sp =>
 {
     var opts = sp.GetRequiredService<IOptions<WorkerOptions>>().Value;
     if (string.IsNullOrWhiteSpace(opts.ServiceBusNamespace))
     {
         var log = sp.GetRequiredService<ILogger<Program>>();
-        log.LogCritical("Worker__ServiceBusNamespace is not set — worker cannot process queue messages. Exiting so Kubernetes surfaces the failure.");
-        Environment.Exit(2);
-        throw new InvalidOperationException("Worker__ServiceBusNamespace is not set"); // unreachable; satisfies compiler
+        log.LogWarning("Service Bus namespace not configured — worker will start but stay idle (set Worker__ServiceBusNamespace to enable queue processing).");
+        return (ServiceBusClient?)null;
     }
     return new ServiceBusClient(opts.ServiceBusNamespace, new DefaultAzureCredential());
 });


### PR DESCRIPTION
## Problem

PR #70 (commit `87b8427`, item **C5**) made the .NET worker `Environment.Exit(2)` at startup whenever `Worker__ServiceBusNamespace` is empty, on the theory that silent idling hides misconfiguration.

The side effect: any deployment with `OMNIVEC_ENABLE_BLOB_SOURCE=false` has no Service Bus namespace provisioned (by design — that's what the flag controls). So every worker pod CrashLoopBackOffs, and `helm upgrade --wait` hangs indefinitely during `azd up`:

```
Unhealthy: Startup probe failed: Get http://10.224.0.18:8080/healthz: connection refused
BackOff: Back-off restarting failed container dotnet-worker ...
[helm-deploy] still running (68s elapsed)...
```

## Fix

Revert C5 only. Return a null `ServiceBusClient` and let `EmbeddingWorkerService` log a warning, call `WorkerHeartbeat.MarkReady()` so the pod reports Ready, then idle on `Task.Delay(Infinite)`. This is the original Apr 7 behavior (commit `3366255`).

All other C1–C4, C6 fixes from PR #70 are **preserved** (blob lease manager, health probes, blob-watcher resilience, pipeline-stats dispatch).

## Validation

Fresh env provisioned with `OMNIVEC_ENABLE_BLOB_SOURCE=false` (exact repro of Abhishek's broken config):

- `azd up` completed in **22m47s** (previously hung indefinitely).
- `omnivec-dotnet-worker`: both replicas **1/1 Running, 0 restarts**.
- `helm upgrade --wait` returned cleanly on first pass.

Pod log in no-SB env:
> warn: Program[0]
> Service Bus namespace not configured — worker will start but stay idle (set Worker__ServiceBusNamespace to enable queue processing).

Also validated in the with-SB env (`fresh-search`): worker enters normal receive loop as before.

## Notes

- Shared registry `omnivecregistry.azurecr.io/omnivec-dotnet-worker:latest` has been rebuilt with this fix; existing broken envs can recover by re-running `azd up`/`azd deploy` — no code changes required on their side.