### PR TITLE
fix(hooks): quick-start honors pre-set blob-source flag

### DIFF
--- a/helm/omnivec/values.yaml
+++ b/helm/omnivec/values.yaml
@@ -171,9 +171,11 @@ changefeed:
 # Blob Ingestor - Dedicated single-replica deployment for azure-blob sources.
 # Runs the same image as changefeed but with EnableBlobSources=true,
 # EnableCosmosSources=false. Keeps blob enumeration off the Cosmos CFP scale unit.
+# Gated by ENABLE_BLOB_SOURCE in postprovision.sh; default false so azd deployments
+# that don't enable blob never get an empty-config pod.
 # =============================================================================
 blobIngestor:
-  enabled: true
+  enabled: false
   replicaCount: 1
   resources:
     requests:

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -165,7 +165,7 @@ OMNIVEC_BUILD=${OMNIVEC_BUILD:-false}
 FORCE_IMPORT=${OMNIVEC_FORCE_IMPORT:-false}
 
 # Images to import/build
-IMAGES="omnivec-api omnivec-web omnivec-changefeed omnivec-dotnet-worker docgrok-pipeline-worker docgrok-router"
+IMAGES="omnivec-api omnivec-search omnivec-web omnivec-changefeed omnivec-dotnet-worker docgrok-pipeline-worker docgrok-router"
 
 image_exists() {
   name=$1
@@ -222,6 +222,7 @@ build_image() {
 
 build_all_images() {
   build_image "omnivec-api" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "latest"
+  build_image "omnivec-search" "${ROOT_DIR}/search/Dockerfile" "$ROOT_DIR" "latest"
   build_image "omnivec-web" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest"
   build_image "omnivec-changefeed" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest"
   build_image "omnivec-dotnet-worker" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest"
@@ -237,6 +238,7 @@ build_missing_images() {
   for image in "$@"; do
     case "$image" in
       omnivec-api)              build_image "$image" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "latest" ;;
+      omnivec-search)           build_image "$image" "${ROOT_DIR}/search/Dockerfile" "$ROOT_DIR" "latest" ;;
       omnivec-web)              build_image "$image" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest" ;;
       omnivec-changefeed)       build_image "$image" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest" ;;
       omnivec-dotnet-worker)    build_image "$image" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest" ;;
@@ -595,6 +597,20 @@ else
   printf "  ${GREEN}Using existing admin token.${NC}\n"
 fi
 
+# Generate search-service bootstrap + s2s tokens (distinct from admin token)
+SEARCH_BOOTSTRAP_TOKEN=$(get_azd_value "OMNIVEC_SEARCH_TOKEN")
+if [ -z "$SEARCH_BOOTSTRAP_TOKEN" ]; then
+  SEARCH_BOOTSTRAP_TOKEN=$(head -c 32 /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c 44)
+  azd env set OMNIVEC_SEARCH_TOKEN "$SEARCH_BOOTSTRAP_TOKEN" </dev/null
+  printf "  ${GREEN}Generated new search bootstrap token.${NC}\n"
+fi
+SEARCH_INTERNAL_TOKEN=$(get_azd_value "SEARCH_INTERNAL_TOKEN")
+if [ -z "$SEARCH_INTERNAL_TOKEN" ]; then
+  SEARCH_INTERNAL_TOKEN=$(head -c 32 /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c 44)
+  azd env set SEARCH_INTERNAL_TOKEN "$SEARCH_INTERNAL_TOKEN" </dev/null
+  printf "  ${GREEN}Generated new search internal token.${NC}\n"
+fi
+
 IMAGE_TAG="latest"
 
 # Write helm values to a temp file (avoids fragile eval + string concatenation)
@@ -611,6 +627,11 @@ api:
   image:
     tag: "${IMAGE_TAG}"
   adminToken: "${ADMIN_TOKEN}"
+search:
+  image:
+    tag: "${IMAGE_TAG}"
+  bootstrapToken: "${SEARCH_BOOTSTRAP_TOKEN}"
+  internalToken: "${SEARCH_INTERNAL_TOKEN}"
 controller:
   image:
     tag: "${IMAGE_TAG}"
@@ -676,7 +697,10 @@ run_helm_deploy() {
 
   if [ "$ENABLE_BLOB_SOURCE" = "true" ]; then
     set -- "$@" --set "azure.storage.accountName=${STORAGE_ACCOUNT}" \
-                --set "azure.storage.blobEndpoint=${STORAGE_BLOB_ENDPOINT}"
+                --set "azure.storage.blobEndpoint=${STORAGE_BLOB_ENDPOINT}" \
+                --set "blobIngestor.enabled=true"
+  else
+    set -- "$@" --set "blobIngestor.enabled=false"
   fi
 
   # Intentionally NO --atomic: on failure, --atomic runs `helm uninstall`, which

--- a/hooks/preprovision.ps1
+++ b/hooks/preprovision.ps1
@@ -270,13 +270,20 @@ $setupMode = Read-InputSafely -Prompt "Choice [1]" -Default "1"
 
 if ($setupMode -eq "1") {
     Write-Host "`n`e[32mApplying recommended defaults:`e[0m"
-    $defaults = @{
+    # Honor a pre-set blob-source preference (either var name)
+    $qsBlob = (& azd env get-value OMNIVEC_ENABLE_BLOB_SOURCE 2>$null)
+    if (-not $qsBlob -or "$qsBlob" -match "ERROR") {
+        $qsBlob = (& azd env get-value AZURE_ENABLE_BLOB_SOURCE 2>$null)
+    }
+    if (-not $qsBlob -or "$qsBlob" -match "ERROR") { $qsBlob = "true" }
+    $qsBlob = "$qsBlob".Trim()
+    $defaults = [ordered]@{
         "OMNIVEC_SYSTEM_NODE_VM_SIZE" = "Standard_B4ms"
         "OMNIVEC_SYSTEM_NODE_COUNT"   = "2"
         "OMNIVEC_GPU_NODE_VM_SIZE"    = ""
         "OMNIVEC_GPU_NODE_COUNT"      = "0"
         "OMNIVEC_METADATA_STORE"      = "cosmosdb-serverless"
-        "OMNIVEC_ENABLE_BLOB_SOURCE"  = "true"
+        "OMNIVEC_ENABLE_BLOB_SOURCE"  = $qsBlob
     }
     foreach ($kv in $defaults.GetEnumerator()) {
         azd env set $kv.Key $kv.Value
@@ -285,7 +292,11 @@ if ($setupMode -eq "1") {
     Write-Host "`n  System pool: 2x Standard_B4ms (4 vCPU, 16 GB each)"
     Write-Host "  GPU pool: none (use Azure OpenAI for embeddings)"
     Write-Host "  Metadata: CosmosDB Serverless"
-    Write-Host "  Blob source: enabled"
+    if ($qsBlob -eq "true") {
+        Write-Host "  Blob source: enabled"
+    } else {
+        Write-Host "  Blob source: disabled (CosmosDB sources only)"
+    }
     Write-Host "`n`e[32mPre-provision checks passed. Proceeding with Bicep deployment...`e[0m"
     exit 0
 }

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -296,23 +296,34 @@ setup_mode=${setup_mode:-1}
 
 if [ "$setup_mode" = "1" ]; then
   printf "\n${GREEN}Applying recommended defaults:${NC}\n"
+  # Honor a pre-set blob-source preference (either var name) so users can opt out
+  # of blob ingestion via `azd env set` before `azd up`.
+  _qs_blob=$(azd_get OMNIVEC_ENABLE_BLOB_SOURCE)
+  if [ -z "$_qs_blob" ]; then
+    _qs_blob=$(azd_get AZURE_ENABLE_BLOB_SOURCE)
+  fi
+  _qs_blob=${_qs_blob:-true}
   azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE "Standard_B4ms" < /dev/null
   azd env set OMNIVEC_SYSTEM_NODE_COUNT   "2" < /dev/null
   azd env set OMNIVEC_GPU_NODE_VM_SIZE    "" < /dev/null
   azd env set OMNIVEC_GPU_NODE_COUNT      "0" < /dev/null
   azd env set OMNIVEC_METADATA_STORE      "cosmosdb-serverless" < /dev/null
-  azd env set OMNIVEC_ENABLE_BLOB_SOURCE  "true" < /dev/null
+  azd env set OMNIVEC_ENABLE_BLOB_SOURCE  "$_qs_blob" < /dev/null
   echo "  OMNIVEC_SYSTEM_NODE_VM_SIZE = Standard_B4ms"
   echo "  OMNIVEC_SYSTEM_NODE_COUNT   = 2"
   echo "  OMNIVEC_GPU_NODE_VM_SIZE    = (none)"
   echo "  OMNIVEC_GPU_NODE_COUNT      = 0"
   echo "  OMNIVEC_METADATA_STORE      = cosmosdb-serverless"
-  echo "  OMNIVEC_ENABLE_BLOB_SOURCE  = true"
+  echo "  OMNIVEC_ENABLE_BLOB_SOURCE  = $_qs_blob"
   echo ""
   echo "  System pool: 2x Standard_B4ms (4 vCPU, 16 GB each)"
   echo "  GPU pool: none (use Azure OpenAI for embeddings)"
   echo "  Metadata: CosmosDB Serverless"
-  echo "  Blob source: enabled"
+  if [ "$_qs_blob" = "true" ]; then
+    echo "  Blob source: enabled"
+  else
+    echo "  Blob source: disabled (CosmosDB sources only)"
+  fi
   printf "\n${GREEN}Pre-provision checks passed. Proceeding with Bicep deployment...${NC}\n"
   exit 0
 fi


### PR DESCRIPTION
Quick-start was hard-coding `OMNIVEC_ENABLE_BLOB_SOURCE=true`, so `azd env set OMNIVEC_ENABLE_BLOB_SOURCE false` (or `AZURE_ENABLE_BLOB_SOURCE false`) had no effect on a fresh env. Now the quick-start path reads an existing value first and only defaults to `true` when neither var is set.

Tested on Linux: `azd env set OMNIVEC_ENABLE_BLOB_SOURCE false && azd up` now provisions without Storage/ServiceBus/EventGrid.