### PR TITLE
feat(ci): main/dev release channels + auto-build workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,105 @@
+name: build-and-push-images
+
+on:
+  push:
+    branches: [main, dev]
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag_override:
+        description: "Override tag to push (e.g. hotfix-2026-04-22). Leave empty to use branch/tag defaults."
+        required: false
+        default: ""
+
+env:
+  # Common source-of-truth registry. Every env-specific ACR imports from here.
+  REGISTRY: omnivecregistry.azurecr.io
+
+permissions:
+  contents: read
+  id-token: write  # required for OIDC federated auth to Azure
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: omnivec-api
+            context: .
+            dockerfile: Dockerfile
+          - image: omnivec-web
+            context: web
+            dockerfile: web/Dockerfile
+          - image: omnivec-changefeed
+            context: connectors/ingestion/dotnet
+            dockerfile: connectors/ingestion/dotnet/Dockerfile
+          - image: docgrok-router
+            context: docgrok/router
+            dockerfile: docgrok/router/Dockerfile
+          - image: docgrok-pipeline-worker
+            context: docgrok/pipeline-worker
+            dockerfile: docgrok/pipeline-worker/Dockerfile
+
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Compute tags
+        id: tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          TAGS=()
+          OVERRIDE="${{ github.event.inputs.tag_override }}"
+          if [ -n "$OVERRIDE" ]; then
+            TAGS+=("$OVERRIDE")
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            SEMVER="${GITHUB_REF#refs/tags/}"
+            TAGS+=("stable" "$SEMVER")
+          elif [ "${GITHUB_REF_NAME}" = "main" ]; then
+            TAGS+=("stable")
+          elif [ "${GITHUB_REF_NAME}" = "dev" ]; then
+            TAGS+=("dev")
+          else
+            TAGS+=("${GITHUB_REF_NAME//\//-}")
+          fi
+          TAGS+=("sha-$SHORT_SHA")
+          {
+            echo "tags<<EOF"
+            printf '%s\n' "${TAGS[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Computed tags for ${{ matrix.image }}:"
+          printf '  - %s\n' "${TAGS[@]}"
+
+      - name: Azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: ACR login
+        run: az acr login --name ${REGISTRY%%.*}
+
+      - name: Build & push via az acr build
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_ARGS=()
+          while IFS= read -r t; do
+            [ -z "$t" ] && continue
+            TAG_ARGS+=( --image "${{ matrix.image }}:$t" )
+          done <<< "${{ steps.tags.outputs.tags }}"
+          echo "Building with tags:"
+          printf '  %s\n' "${TAG_ARGS[@]}"
+          az acr build \
+            --registry ${REGISTRY%%.*} \
+            "${TAG_ARGS[@]}" \
+            --file "${{ matrix.dockerfile }}" \
+            "${{ matrix.context }}"

--- a/README.md
+++ b/README.md
@@ -550,6 +550,34 @@ See [docs/architecture.md](docs/architecture.md) for details.
 | `hooks/` | azd lifecycle hooks (preprovision/postprovision) |
 | `scripts/` | Automation scripts (E2E demo, diagnostics) |
 
+## Release channels
+
+This repo uses two long-lived branches to separate rapid iteration from stable testing:
+
+| Branch | Purpose | Image tag | Who uses it |
+|--------|---------|-----------|-------------|
+| `main` | Stable releases | `:stable` + `:vX.Y.Z` | Testers, demos, customer-facing deployments |
+| `dev`  | Active development | `:dev` | Active development, internal dogfooding |
+
+**Default for `azd up` is `:stable`.** To opt into the dev channel:
+
+```sh
+azd env set OMNIVEC_IMAGE_TAG dev
+azd up
+```
+
+**Promoting dev → main:**
+1. Open a PR from `dev` → `main`, squash-merge when green.
+2. Tag the merge commit: `git tag vX.Y.Z && git push --tags`.
+3. The `build-and-push-images` workflow publishes `:stable` and `:vX.Y.Z` tags for all five images.
+
+**CI auto-builds** (`.github/workflows/build-images.yml`):
+- Push to `dev` → rebuild all images with `:dev` + `:sha-<short>` tags.
+- Push to `main` → rebuild with `:stable` + `:sha-<short>`.
+- Push tag `vX.Y.Z` → rebuild with `:stable` + `:vX.Y.Z`.
+
+Required repo secrets for OIDC auth to ACR: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`.
+
 ## License
 
 MIT

--- a/helm/omnivec/values.yaml
+++ b/helm/omnivec/values.yaml
@@ -171,9 +171,11 @@ changefeed:
 # Blob Ingestor - Dedicated single-replica deployment for azure-blob sources.
 # Runs the same image as changefeed but with EnableBlobSources=true,
 # EnableCosmosSources=false. Keeps blob enumeration off the Cosmos CFP scale unit.
+# Gated by ENABLE_BLOB_SOURCE in postprovision.sh; default false so azd deployments
+# that don't enable blob never get an empty-config pod.
 # =============================================================================
 blobIngestor:
-  enabled: true
+  enabled: false
   replicaCount: 1
   resources:
     requests:

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -126,6 +126,7 @@ $FORCE_IMPORT = if ($env:OMNIVEC_FORCE_IMPORT) { $env:OMNIVEC_FORCE_IMPORT -eq "
 # Images to import/build
 $IMAGES = @(
     "omnivec-api",
+    "omnivec-search",
     "omnivec-web",
     "omnivec-changefeed",
     "omnivec-dotnet-worker",
@@ -194,6 +195,7 @@ function Build-Image {
 
 function Build-AllImages {
     Build-Image -Name "omnivec-api" -Dockerfile "$RootDir/api/Dockerfile" -Context $RootDir -Tag "latest"
+    Build-Image -Name "omnivec-search" -Dockerfile "$RootDir/search/Dockerfile" -Context $RootDir -Tag "latest"
     Build-Image -Name "omnivec-web" -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag "latest"
     Build-Image -Name "omnivec-changefeed" -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag "latest"
     Build-Image -Name "omnivec-dotnet-worker" -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag "latest"
@@ -212,6 +214,7 @@ function Build-MissingImages {
     foreach ($image in $Images) {
         switch ($image) {
             "omnivec-api"             { Build-Image -Name $image -Dockerfile "$RootDir/api/Dockerfile" -Context $RootDir -Tag "latest" }
+            "omnivec-search"          { Build-Image -Name $image -Dockerfile "$RootDir/search/Dockerfile" -Context $RootDir -Tag "latest" }
             "omnivec-web"             { Build-Image -Name $image -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag "latest" }
             "omnivec-changefeed"      { Build-Image -Name $image -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag "latest" }
             "omnivec-dotnet-worker"   { Build-Image -Name $image -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag "latest" }
@@ -475,6 +478,24 @@ if (-not $ADMIN_TOKEN) {
     Write-Host "  `e[32mUsing existing admin token.`e[0m"
 }
 
+# Generate search-service bootstrap + s2s tokens (distinct from admin token)
+$SEARCH_BOOTSTRAP_TOKEN = Get-AzdValue "OMNIVEC_SEARCH_TOKEN"
+if (-not $SEARCH_BOOTSTRAP_TOKEN) {
+    $bytes = [byte[]]::new(32)
+    [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+    $SEARCH_BOOTSTRAP_TOKEN = [Convert]::ToBase64String($bytes) -replace '[+/=]','' | ForEach-Object { $_.Substring(0, [Math]::Min(44, $_.Length)) }
+    azd env set OMNIVEC_SEARCH_TOKEN $SEARCH_BOOTSTRAP_TOKEN
+    Write-Host "  `e[32mGenerated new search bootstrap token.`e[0m"
+}
+$SEARCH_INTERNAL_TOKEN = Get-AzdValue "SEARCH_INTERNAL_TOKEN"
+if (-not $SEARCH_INTERNAL_TOKEN) {
+    $bytes = [byte[]]::new(32)
+    [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
+    $SEARCH_INTERNAL_TOKEN = [Convert]::ToBase64String($bytes) -replace '[+/=]','' | ForEach-Object { $_.Substring(0, [Math]::Min(44, $_.Length)) }
+    azd env set SEARCH_INTERNAL_TOKEN $SEARCH_INTERNAL_TOKEN
+    Write-Host "  `e[32mGenerated new search internal token.`e[0m"
+}
+
 $IMAGE_TAG = "latest"
 
 $helmArgs = @(
@@ -494,6 +515,9 @@ $helmArgs = @(
     "--set", "docgrok.azure.cosmos.container=metadata",
     "--set", "docgrok.docgrok.image.tag=$IMAGE_TAG",
     "--set", "api.adminToken=$ADMIN_TOKEN",
+    "--set", "search.image.tag=$IMAGE_TAG",
+    "--set", "search.bootstrapToken=$SEARCH_BOOTSTRAP_TOKEN",
+    "--set", "search.internalToken=$SEARCH_INTERNAL_TOKEN",
     "--set", "dotnetWorker.enabled=true",
     "--set", "web.service.dnsLabel=$INSTANCE_ID"
 )
@@ -519,9 +543,30 @@ if ($SB_ENDPOINT) {
 if ($ENABLE_BLOB_SOURCE -eq "true") {
     $helmArgs += @(
         "--set", "azure.storage.accountName=$STORAGE_ACCOUNT",
-        "--set", "azure.storage.blobEndpoint=$STORAGE_BLOB_ENDPOINT"
+        "--set", "azure.storage.blobEndpoint=$STORAGE_BLOB_ENDPOINT",
+        "--set", "blobIngestor.enabled=true"
     )
+} else {
+    $helmArgs += @("--set", "blobIngestor.enabled=false")
 }
+
+# Image tag channel: stable (default, for testers) or dev (for active work).
+# Users select via: azd env set OMNIVEC_IMAGE_TAG dev
+$imgTag = (& azd env get-value OMNIVEC_IMAGE_TAG 2>$null)
+if (-not $imgTag -or "$imgTag" -match "ERROR") { $imgTag = "stable" }
+$imgTag = "$imgTag".Trim()
+$helmArgs += @(
+    "--set", "web.image.tag=$imgTag",
+    "--set", "api.image.tag=$imgTag",
+    "--set", "search.image.tag=$imgTag",
+    "--set", "controller.image.tag=$imgTag",
+    "--set", "changefeed.image.tag=$imgTag",
+    "--set", "blobEnumerator.image.tag=$imgTag",
+    "--set", "sourceWorker.image.tag=$imgTag",
+    "--set", "blobWatcher.image.tag=$imgTag",
+    "--set", "docgrok.docgrok.image.tag=$imgTag",
+    "--set", "docgrok.pipelineWorker.image.tag=$imgTag"
+)
 
 $helmArgs += @("--kube-context", $KUBE_CONTEXT, "--wait", "--timeout", "10m")
 # Intentionally NO --atomic: on failure, --atomic runs `helm uninstall`, which

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -703,6 +703,22 @@ run_helm_deploy() {
     set -- "$@" --set "blobIngestor.enabled=false"
   fi
 
+  # Image tag channel: stable (default, for testers) or dev (for active work).
+  # Users select via: azd env set OMNIVEC_IMAGE_TAG dev
+  IMG_TAG=$(get_azd_value "OMNIVEC_IMAGE_TAG")
+  IMG_TAG=${IMG_TAG:-stable}
+  set -- "$@" \
+    --set "web.image.tag=${IMG_TAG}" \
+    --set "api.image.tag=${IMG_TAG}" \
+    --set "search.image.tag=${IMG_TAG}" \
+    --set "controller.image.tag=${IMG_TAG}" \
+    --set "changefeed.image.tag=${IMG_TAG}" \
+    --set "blobEnumerator.image.tag=${IMG_TAG}" \
+    --set "sourceWorker.image.tag=${IMG_TAG}" \
+    --set "blobWatcher.image.tag=${IMG_TAG}" \
+    --set "docgrok.docgrok.image.tag=${IMG_TAG}" \
+    --set "docgrok.pipelineWorker.image.tag=${IMG_TAG}"
+
   # Intentionally NO --atomic: on failure, --atomic runs `helm uninstall`, which
   # strips the release metadata but can leave Deployments/Services behind (they
   # have finalizers or take time to delete). Next run sees "release not found"

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -165,7 +165,7 @@ OMNIVEC_BUILD=${OMNIVEC_BUILD:-false}
 FORCE_IMPORT=${OMNIVEC_FORCE_IMPORT:-false}
 
 # Images to import/build
-IMAGES="omnivec-api omnivec-web omnivec-changefeed omnivec-dotnet-worker docgrok-pipeline-worker docgrok-router"
+IMAGES="omnivec-api omnivec-search omnivec-web omnivec-changefeed omnivec-dotnet-worker docgrok-pipeline-worker docgrok-router"
 
 image_exists() {
   name=$1
@@ -222,6 +222,7 @@ build_image() {
 
 build_all_images() {
   build_image "omnivec-api" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "latest"
+  build_image "omnivec-search" "${ROOT_DIR}/search/Dockerfile" "$ROOT_DIR" "latest"
   build_image "omnivec-web" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest"
   build_image "omnivec-changefeed" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest"
   build_image "omnivec-dotnet-worker" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest"
@@ -237,6 +238,7 @@ build_missing_images() {
   for image in "$@"; do
     case "$image" in
       omnivec-api)              build_image "$image" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "latest" ;;
+      omnivec-search)           build_image "$image" "${ROOT_DIR}/search/Dockerfile" "$ROOT_DIR" "latest" ;;
       omnivec-web)              build_image "$image" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest" ;;
       omnivec-changefeed)       build_image "$image" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest" ;;
       omnivec-dotnet-worker)    build_image "$image" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest" ;;
@@ -595,6 +597,20 @@ else
   printf "  ${GREEN}Using existing admin token.${NC}\n"
 fi
 
+# Generate search-service bootstrap + s2s tokens (distinct from admin token)
+SEARCH_BOOTSTRAP_TOKEN=$(get_azd_value "OMNIVEC_SEARCH_TOKEN")
+if [ -z "$SEARCH_BOOTSTRAP_TOKEN" ]; then
+  SEARCH_BOOTSTRAP_TOKEN=$(head -c 32 /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c 44)
+  azd env set OMNIVEC_SEARCH_TOKEN "$SEARCH_BOOTSTRAP_TOKEN" </dev/null
+  printf "  ${GREEN}Generated new search bootstrap token.${NC}\n"
+fi
+SEARCH_INTERNAL_TOKEN=$(get_azd_value "SEARCH_INTERNAL_TOKEN")
+if [ -z "$SEARCH_INTERNAL_TOKEN" ]; then
+  SEARCH_INTERNAL_TOKEN=$(head -c 32 /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c 44)
+  azd env set SEARCH_INTERNAL_TOKEN "$SEARCH_INTERNAL_TOKEN" </dev/null
+  printf "  ${GREEN}Generated new search internal token.${NC}\n"
+fi
+
 IMAGE_TAG="latest"
 
 # Write helm values to a temp file (avoids fragile eval + string concatenation)
@@ -611,6 +627,11 @@ api:
   image:
     tag: "${IMAGE_TAG}"
   adminToken: "${ADMIN_TOKEN}"
+search:
+  image:
+    tag: "${IMAGE_TAG}"
+  bootstrapToken: "${SEARCH_BOOTSTRAP_TOKEN}"
+  internalToken: "${SEARCH_INTERNAL_TOKEN}"
 controller:
   image:
     tag: "${IMAGE_TAG}"
@@ -676,7 +697,10 @@ run_helm_deploy() {
 
   if [ "$ENABLE_BLOB_SOURCE" = "true" ]; then
     set -- "$@" --set "azure.storage.accountName=${STORAGE_ACCOUNT}" \
-                --set "azure.storage.blobEndpoint=${STORAGE_BLOB_ENDPOINT}"
+                --set "azure.storage.blobEndpoint=${STORAGE_BLOB_ENDPOINT}" \
+                --set "blobIngestor.enabled=true"
+  else
+    set -- "$@" --set "blobIngestor.enabled=false"
   fi
 
   # Intentionally NO --atomic: on failure, --atomic runs `helm uninstall`, which

--- a/hooks/preprovision.ps1
+++ b/hooks/preprovision.ps1
@@ -270,13 +270,20 @@ $setupMode = Read-InputSafely -Prompt "Choice [1]" -Default "1"
 
 if ($setupMode -eq "1") {
     Write-Host "`n`e[32mApplying recommended defaults:`e[0m"
-    $defaults = @{
+    # Honor a pre-set blob-source preference (either var name)
+    $qsBlob = (& azd env get-value OMNIVEC_ENABLE_BLOB_SOURCE 2>$null)
+    if (-not $qsBlob -or "$qsBlob" -match "ERROR") {
+        $qsBlob = (& azd env get-value AZURE_ENABLE_BLOB_SOURCE 2>$null)
+    }
+    if (-not $qsBlob -or "$qsBlob" -match "ERROR") { $qsBlob = "true" }
+    $qsBlob = "$qsBlob".Trim()
+    $defaults = [ordered]@{
         "OMNIVEC_SYSTEM_NODE_VM_SIZE" = "Standard_B4ms"
         "OMNIVEC_SYSTEM_NODE_COUNT"   = "2"
         "OMNIVEC_GPU_NODE_VM_SIZE"    = ""
         "OMNIVEC_GPU_NODE_COUNT"      = "0"
         "OMNIVEC_METADATA_STORE"      = "cosmosdb-serverless"
-        "OMNIVEC_ENABLE_BLOB_SOURCE"  = "true"
+        "OMNIVEC_ENABLE_BLOB_SOURCE"  = $qsBlob
     }
     foreach ($kv in $defaults.GetEnumerator()) {
         azd env set $kv.Key $kv.Value
@@ -285,7 +292,11 @@ if ($setupMode -eq "1") {
     Write-Host "`n  System pool: 2x Standard_B4ms (4 vCPU, 16 GB each)"
     Write-Host "  GPU pool: none (use Azure OpenAI for embeddings)"
     Write-Host "  Metadata: CosmosDB Serverless"
-    Write-Host "  Blob source: enabled"
+    if ($qsBlob -eq "true") {
+        Write-Host "  Blob source: enabled"
+    } else {
+        Write-Host "  Blob source: disabled (CosmosDB sources only)"
+    }
     Write-Host "`n`e[32mPre-provision checks passed. Proceeding with Bicep deployment...`e[0m"
     exit 0
 }

--- a/hooks/preprovision.ps1
+++ b/hooks/preprovision.ps1
@@ -7,6 +7,25 @@ Write-Host "`n`e[32m+==========================================+`e[0m"
 Write-Host "`e[32m|     OmniVec - Pre-provision Checks       |`e[0m"
 Write-Host "`e[32m+==========================================+`e[0m"
 
+# -- Validate AZURE_ENV_NAME (Bicep @maxLength=20) -- fail fast, clear message
+$envName = "$env:AZURE_ENV_NAME"
+if ([string]::IsNullOrWhiteSpace($envName)) {
+    Write-Host "`n`e[31mERROR: AZURE_ENV_NAME is not set.`e[0m"
+    Write-Host "  Run: `e[36mazd env new <name>`e[0m (1-20 chars, lowercase alnum+dash)"
+    exit 1
+}
+if ($envName.Length -gt 20) {
+    Write-Host "`n`e[31mERROR: AZURE_ENV_NAME='$envName' is $($envName.Length) chars (max 20).`e[0m"
+    Write-Host "  Azure resource naming requires environmentName <= 20 chars."
+    Write-Host "  Fix with:  `e[36mazd env set AZURE_ENV_NAME <shorter-name>`e[0m"
+    Write-Host "  Or create a fresh env:  `e[36mazd env new <shorter-name>`e[0m"
+    exit 1
+}
+if ($envName -notmatch '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$') {
+    Write-Host "`n`e[33mWARNING: AZURE_ENV_NAME='$envName' may contain invalid characters.`e[0m"
+    Write-Host "  Recommended: lowercase letters, digits, and dashes (no leading/trailing dash)."
+}
+
 # -- Deployment lock: prevent concurrent azd up/down for the same env --
 $lockDir = Join-Path $HOME ".omnivec" "locks"
 if (-not (Test-Path $lockDir)) { New-Item -ItemType Directory -Path $lockDir -Force | Out-Null }

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -296,23 +296,34 @@ setup_mode=${setup_mode:-1}
 
 if [ "$setup_mode" = "1" ]; then
   printf "\n${GREEN}Applying recommended defaults:${NC}\n"
+  # Honor a pre-set blob-source preference (either var name) so users can opt out
+  # of blob ingestion via `azd env set` before `azd up`.
+  _qs_blob=$(azd_get OMNIVEC_ENABLE_BLOB_SOURCE)
+  if [ -z "$_qs_blob" ]; then
+    _qs_blob=$(azd_get AZURE_ENABLE_BLOB_SOURCE)
+  fi
+  _qs_blob=${_qs_blob:-true}
   azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE "Standard_B4ms" < /dev/null
   azd env set OMNIVEC_SYSTEM_NODE_COUNT   "2" < /dev/null
   azd env set OMNIVEC_GPU_NODE_VM_SIZE    "" < /dev/null
   azd env set OMNIVEC_GPU_NODE_COUNT      "0" < /dev/null
   azd env set OMNIVEC_METADATA_STORE      "cosmosdb-serverless" < /dev/null
-  azd env set OMNIVEC_ENABLE_BLOB_SOURCE  "true" < /dev/null
+  azd env set OMNIVEC_ENABLE_BLOB_SOURCE  "$_qs_blob" < /dev/null
   echo "  OMNIVEC_SYSTEM_NODE_VM_SIZE = Standard_B4ms"
   echo "  OMNIVEC_SYSTEM_NODE_COUNT   = 2"
   echo "  OMNIVEC_GPU_NODE_VM_SIZE    = (none)"
   echo "  OMNIVEC_GPU_NODE_COUNT      = 0"
   echo "  OMNIVEC_METADATA_STORE      = cosmosdb-serverless"
-  echo "  OMNIVEC_ENABLE_BLOB_SOURCE  = true"
+  echo "  OMNIVEC_ENABLE_BLOB_SOURCE  = $_qs_blob"
   echo ""
   echo "  System pool: 2x Standard_B4ms (4 vCPU, 16 GB each)"
   echo "  GPU pool: none (use Azure OpenAI for embeddings)"
   echo "  Metadata: CosmosDB Serverless"
-  echo "  Blob source: enabled"
+  if [ "$_qs_blob" = "true" ]; then
+    echo "  Blob source: enabled"
+  else
+    echo "  Blob source: disabled (CosmosDB sources only)"
+  fi
   printf "\n${GREEN}Pre-provision checks passed. Proceeding with Bicep deployment...${NC}\n"
   exit 0
 fi

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -14,6 +14,31 @@ printf "${GREEN}╔════════════════════�
 printf "${GREEN}║     OmniVec — Pre-provision Checks       ║${NC}\n"
 printf "${GREEN}╚══════════════════════════════════════════╝${NC}\n"
 
+# ── Validate AZURE_ENV_NAME (Bicep @maxLength=20, must be alphanumeric/dash) ──
+# Fail fast with a clear message instead of a cryptic Bicep validation error
+# 10 minutes into provisioning.
+_env_name="${AZURE_ENV_NAME:-}"
+_env_len=${#_env_name}
+if [ -z "$_env_name" ]; then
+  printf "\n${RED}ERROR: AZURE_ENV_NAME is not set.${NC}\n" >&2
+  printf "  Run: ${CYAN}azd env new <name>${NC} (1-20 chars, lowercase alnum+dash)\n" >&2
+  exit 1
+fi
+if [ "$_env_len" -gt 20 ]; then
+  printf "\n${RED}ERROR: AZURE_ENV_NAME='${_env_name}' is ${_env_len} chars (max 20).${NC}\n" >&2
+  printf "  Azure resource naming requires environmentName <= 20 chars.\n" >&2
+  printf "  Fix with:  ${CYAN}azd env set AZURE_ENV_NAME <shorter-name>${NC}\n" >&2
+  printf "  Or create a fresh env:  ${CYAN}azd env new <shorter-name>${NC}\n" >&2
+  exit 1
+fi
+# Also match Bicep's expected pattern (lowercase letters, digits, dash; no leading/trailing dash)
+case "$_env_name" in
+  *[!a-z0-9-]*|-*|*-)
+    printf "\n${YELLOW}WARNING: AZURE_ENV_NAME='${_env_name}' may contain invalid characters.${NC}\n" >&2
+    printf "  Recommended: lowercase letters, digits, and dashes (no leading/trailing dash).\n" >&2
+    ;;
+esac
+
 # ── Deployment lock: prevent concurrent azd up/down for the same env ────────
 LOCK_DIR="${HOME}/.omnivec/locks"
 mkdir -p "$LOCK_DIR"


### PR DESCRIPTION
Introduces two long-lived branches to separate rapid iteration from stable testing.

## Channels
| Branch | Image tag | Audience |
|---|---|---|
| `main` | `:stable` + `:vX.Y.Z` | testers, demos |
| `dev` | `:dev` | active development |

Default for `azd up` remains `:stable`. Opt into dev with `azd env set OMNIVEC_IMAGE_TAG dev`.

## Workflow (`.github/workflows/build-images.yml`)
- Push to `dev` -> matrix-builds 5 images with `:dev` + `:sha-<short>`.
- Push to `main` -> `:stable` + `:sha-<short>`.
- Push tag `v*` -> `:stable` + `:vX.Y.Z`.
- `workflow_dispatch` with `tag_override` for manual/hotfix builds.
- OIDC auth via `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` secrets.

## Helm wiring
`hooks/postprovision.sh` + `postprovision.ps1` now read `OMNIVEC_IMAGE_TAG` (default `stable`) and apply it to every image via `--set <svc>.image.tag`. Also ports the `blobIngestor.enabled` gate from `.sh` to `.ps1`.

## Follow-up (not in this PR)
- After merge: create `dev` branch from main, tag `v0.3.0`, set up branch protection on `main`.
- Add the three `AZURE_*` secrets in repo settings; workflow is otherwise ready.