### PR TITLE
ci: ACR scope-map token auth (no AAD app needed)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -17,7 +17,6 @@ env:
 
 permissions:
   contents: read
-  id-token: write  # required for OIDC federated auth to Azure
 
 jobs:
   build:
@@ -69,37 +68,33 @@ jobs:
             TAGS+=("${GITHUB_REF_NAME//\//-}")
           fi
           TAGS+=("sha-$SHORT_SHA")
+          DOCKER_TAGS=""
+          for t in "${TAGS[@]}"; do
+            DOCKER_TAGS+="${REGISTRY}/${{ matrix.image }}:$t,"
+          done
+          DOCKER_TAGS="${DOCKER_TAGS%,}"
           {
-            echo "tags<<EOF"
-            printf '%s\n' "${TAGS[@]}"
-            echo "EOF"
+            echo "docker_tags=$DOCKER_TAGS"
           } >> "$GITHUB_OUTPUT"
           echo "Computed tags for ${{ matrix.image }}:"
           printf '  - %s\n' "${TAGS[@]}"
 
-      - name: Azure login (OIDC)
-        uses: azure/login@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: ACR login (scope-map token)
+        uses: docker/login-action@v3
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
 
-      - name: ACR login
-        run: az acr login --name ${REGISTRY%%.*}
-
-      - name: Build & push via az acr build
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG_ARGS=()
-          while IFS= read -r t; do
-            [ -z "$t" ] && continue
-            TAG_ARGS+=( --image "${{ matrix.image }}:$t" )
-          done <<< "${{ steps.tags.outputs.tags }}"
-          echo "Building with tags:"
-          printf '  %s\n' "${TAG_ARGS[@]}"
-          az acr build \
-            --registry ${REGISTRY%%.*} \
-            "${TAG_ARGS[@]}" \
-            --file "${{ matrix.dockerfile }}" \
-            "${{ matrix.context }}"
+      - name: Build & push
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.tags.outputs.docker_tags }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ matrix.image }}:buildcache,mode=max

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ azd up
 - Push to `main` → rebuild with `:stable` + `:sha-<short>`.
 - Push tag `vX.Y.Z` → rebuild with `:stable` + `:vX.Y.Z`.
 
-Required repo secrets for OIDC auth to ACR: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`.
+Required repo secrets: `ACR_USERNAME`, `ACR_PASSWORD` (from an ACR scope-map token with `content/write` on the 5 repos).
 
 ## License
 


### PR DESCRIPTION
Microsoft tenant policy blocks AAD app creation without a ServiceTree ID, so OIDC federation isn't available. Switched CI to an ACR scope-map token (`gh-ci-token`) with `content/read+write` on the 5 image repos.

Workflow now uses `docker/login-action` + `docker/build-push-action` with buildx registry cache on `:buildcache` tag. Secrets `ACR_USERNAME` and `ACR_PASSWORD` already added.