### PR TITLE
ci: init docgrok submodule via ssh shell step

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -50,15 +50,20 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.DOCGROK_DEPLOY_KEY }}
 
-      - name: Rewrite github.com URLs to SSH for submodule fetch
-        if: matrix.needs_submodule
-        run: |
-          git config --global url."git@github.com:".insteadOf "https://github.com/"
-
       - name: Checkout OmniVec
         uses: actions/checkout@v4
         with:
-          submodules: ${{ matrix.needs_submodule && 'recursive' || 'false' }}
+          submodules: false
+
+      - name: Init docgrok submodule via SSH
+        if: matrix.needs_submodule
+        run: |
+          set -euxo pipefail
+          git config --global url."git@github.com:".insteadOf "https://github.com/"
+          # Replace relative URL with absolute SSH URL for this checkout only
+          git config -f .gitmodules submodule.docgrok.url git@github.com:AzureCosmosDB/DocGrok.git
+          git submodule sync --recursive
+          git -c core.sshCommand="ssh -o StrictHostKeyChecking=no" submodule update --init --recursive --depth=1
 
       - name: Compute tags
         id: tags


### PR DESCRIPTION
Fix for deploy-key auth being ignored by actions/checkout.