### PR TITLE
fix(hooks): import+deploy use IMG_TAG not :latest

### DIFF
--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -1,4 +1,4 @@
-﻿# OmniVec — postprovision hook (PowerShell)
+# OmniVec — postprovision hook (PowerShell)
 # Pushes images to ACR, configures AKS, creates K8s secrets, deploys via Helm
 
 $ErrorActionPreference = "Stop"
@@ -134,6 +134,22 @@ $IMAGES = @(
     "docgrok-router"
 )
 
+# Release channel tag — resolved once, used for BOTH import and helm overrides.
+# 1. Explicit OMNIVEC_IMAGE_TAG (azd env) wins.
+# 2. Auto-detect from current git branch: dev -> dev, main -> stable.
+# 3. Fallback -> stable.
+$IMG_TAG = (& azd env get-value OMNIVEC_IMAGE_TAG 2>$null)
+if ([string]::IsNullOrWhiteSpace($IMG_TAG)) {
+    $_branch = ""
+    try { $_branch = (git -C "$PSScriptRoot\.." rev-parse --abbrev-ref HEAD 2>$null) } catch {}
+    switch ($_branch) {
+        "dev"  { $IMG_TAG = "dev" }
+        "main" { $IMG_TAG = "stable" }
+        default { $IMG_TAG = "stable" }
+    }
+    Write-Host "`e[36mAuto-detected branch '$($_branch -replace '^$','unknown')' -> image tag '$IMG_TAG'`e[0m"
+}
+
 function Test-ImageExists {
     param($Name, $Tag)
     try {
@@ -194,17 +210,17 @@ function Build-Image {
 }
 
 function Build-AllImages {
-    Build-Image -Name "omnivec-api" -Dockerfile "$RootDir/api/Dockerfile" -Context $RootDir -Tag "latest"
-    Build-Image -Name "omnivec-search" -Dockerfile "$RootDir/search/Dockerfile" -Context $RootDir -Tag "latest"
-    Build-Image -Name "omnivec-web" -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag "latest"
-    Build-Image -Name "omnivec-changefeed" -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag "latest"
-    Build-Image -Name "omnivec-dotnet-worker" -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag "latest"
+    Build-Image -Name "omnivec-api" -Dockerfile "$RootDir/api/Dockerfile" -Context $RootDir -Tag $IMG_TAG
+    Build-Image -Name "omnivec-search" -Dockerfile "$RootDir/search/Dockerfile" -Context $RootDir -Tag $IMG_TAG
+    Build-Image -Name "omnivec-web" -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag $IMG_TAG
+    Build-Image -Name "omnivec-changefeed" -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag $IMG_TAG
+    Build-Image -Name "omnivec-dotnet-worker" -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag $IMG_TAG
 
     if (Test-Path "$RootDir/docgrok/pipeline-worker/Dockerfile") {
-        Build-Image -Name "docgrok-pipeline-worker" -Dockerfile "$RootDir/docgrok/pipeline-worker/Dockerfile" -Context "$RootDir/docgrok/pipeline-worker/" -Tag "latest"
+        Build-Image -Name "docgrok-pipeline-worker" -Dockerfile "$RootDir/docgrok/pipeline-worker/Dockerfile" -Context "$RootDir/docgrok/pipeline-worker/" -Tag $IMG_TAG
     }
     if (Test-Path "$RootDir/docgrok/router/Dockerfile") {
-        Build-Image -Name "docgrok-router" -Dockerfile "$RootDir/docgrok/router/Dockerfile" -Context "$RootDir/docgrok/router/" -Tag "latest"
+        Build-Image -Name "docgrok-router" -Dockerfile "$RootDir/docgrok/router/Dockerfile" -Context "$RootDir/docgrok/router/" -Tag $IMG_TAG
     }
 }
 
@@ -213,21 +229,21 @@ function Build-MissingImages {
 
     foreach ($image in $Images) {
         switch ($image) {
-            "omnivec-api"             { Build-Image -Name $image -Dockerfile "$RootDir/api/Dockerfile" -Context $RootDir -Tag "latest" }
-            "omnivec-search"          { Build-Image -Name $image -Dockerfile "$RootDir/search/Dockerfile" -Context $RootDir -Tag "latest" }
-            "omnivec-web"             { Build-Image -Name $image -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag "latest" }
-            "omnivec-changefeed"      { Build-Image -Name $image -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag "latest" }
-            "omnivec-dotnet-worker"   { Build-Image -Name $image -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag "latest" }
+            "omnivec-api"             { Build-Image -Name $image -Dockerfile "$RootDir/api/Dockerfile" -Context $RootDir -Tag $IMG_TAG }
+            "omnivec-search"          { Build-Image -Name $image -Dockerfile "$RootDir/search/Dockerfile" -Context $RootDir -Tag $IMG_TAG }
+            "omnivec-web"             { Build-Image -Name $image -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag $IMG_TAG }
+            "omnivec-changefeed"      { Build-Image -Name $image -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag $IMG_TAG }
+            "omnivec-dotnet-worker"   { Build-Image -Name $image -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag $IMG_TAG }
             "docgrok-pipeline-worker" {
                 if (Test-Path "$RootDir/docgrok/pipeline-worker/Dockerfile") {
-                    Build-Image -Name $image -Dockerfile "$RootDir/docgrok/pipeline-worker/Dockerfile" -Context "$RootDir/docgrok/pipeline-worker/" -Tag "latest"
+                    Build-Image -Name $image -Dockerfile "$RootDir/docgrok/pipeline-worker/Dockerfile" -Context "$RootDir/docgrok/pipeline-worker/" -Tag $IMG_TAG
                 } else {
                     Write-Host "  `e[33mSkipping ${image}: source not present in repo.`e[0m"
                 }
             }
             "docgrok-router" {
                 if (Test-Path "$RootDir/docgrok/router/Dockerfile") {
-                    Build-Image -Name $image -Dockerfile "$RootDir/docgrok/router/Dockerfile" -Context "$RootDir/docgrok/router/" -Tag "latest"
+                    Build-Image -Name $image -Dockerfile "$RootDir/docgrok/router/Dockerfile" -Context "$RootDir/docgrok/router/" -Tag $IMG_TAG
                 } else {
                     Write-Host "  `e[33mSkipping ${image}: source not present in repo.`e[0m"
                 }
@@ -245,7 +261,7 @@ if (-not $DO_BUILD) {
     $anonOk = $false
     $tokenOk = $false
     Write-Host "  `e[36mTesting anonymous pull...`e[0m" -NoNewline
-    $testResult = az acr import --name $ACR_NAME --source "${SHARED_REGISTRY}/$($IMAGES[0]):latest" --image "$($IMAGES[0]):latest" --force 2>&1
+    $testResult = az acr import --name $ACR_NAME --source "${SHARED_REGISTRY}/$($IMAGES[0]):$IMG_TAG" --image "$($IMAGES[0]):$IMG_TAG" --force 2>&1
     if ($LASTEXITCODE -eq 0) {
         Write-Host " `e[32m✓ anonymous pull works`e[0m"
         $anonOk = $true
@@ -254,7 +270,7 @@ if (-not $DO_BUILD) {
         # Try with stored token
         if ($SHARED_REGISTRY_TOKEN) {
             Write-Host "  `e[36mTrying stored token...`e[0m" -NoNewline
-            $testResult = az acr import --name $ACR_NAME --source "${SHARED_REGISTRY}/$($IMAGES[0]):latest" --image "$($IMAGES[0]):latest" --username $SHARED_REGISTRY_USER --password $SHARED_REGISTRY_TOKEN --force 2>&1
+            $testResult = az acr import --name $ACR_NAME --source "${SHARED_REGISTRY}/$($IMAGES[0]):$IMG_TAG" --image "$($IMAGES[0]):$IMG_TAG" --username $SHARED_REGISTRY_USER --password $SHARED_REGISTRY_TOKEN --force 2>&1
             if ($LASTEXITCODE -eq 0) {
                 Write-Host " `e[32m✓ token works`e[0m"
                 $tokenOk = $true
@@ -267,7 +283,7 @@ if (-not $DO_BUILD) {
             Write-Host "  `e[33mRegistry token required for import.`e[0m"
             $newToken = (Read-Host "  Enter token for $SHARED_REGISTRY (or Enter to build from source)").Trim()
             if ($newToken) {
-                $testResult = az acr import --name $ACR_NAME --source "${SHARED_REGISTRY}/$($IMAGES[0]):latest" --image "$($IMAGES[0]):latest" --username $SHARED_REGISTRY_USER --password $newToken --force 2>&1
+                $testResult = az acr import --name $ACR_NAME --source "${SHARED_REGISTRY}/$($IMAGES[0]):$IMG_TAG" --image "$($IMAGES[0]):$IMG_TAG" --username $SHARED_REGISTRY_USER --password $newToken --force 2>&1
                 if ($LASTEXITCODE -eq 0) {
                     $SHARED_REGISTRY_TOKEN = $newToken
                     azd env set OMNIVEC_SHARED_REGISTRY_TOKEN $newToken 2>$null
@@ -301,27 +317,27 @@ if ($DO_BUILD) {
     $imagesToImport = @()
 
     foreach ($image in $IMAGES) {
-        if (-not $FORCE_IMPORT -and (Test-ImageUpToDate -Name $image -Tag "latest")) {
-            Write-Host "  `e[32m${image}:latest up to date (digest match), skipping.`e[0m"
+        if (-not $FORCE_IMPORT -and (Test-ImageUpToDate -Name $image -Tag $IMG_TAG)) {
+            Write-Host "  `e[32m${image}:$IMG_TAG up to date (digest match), skipping.`e[0m"
             $skipCount++
             continue
-        } elseif (-not $FORCE_IMPORT -and (Test-ImageExists -Name $image -Tag "latest")) {
-            Write-Host "  `e[36m${image}:latest exists but digest differs, re-importing...`e[0m"
+        } elseif (-not $FORCE_IMPORT -and (Test-ImageExists -Name $image -Tag $IMG_TAG)) {
+            Write-Host "  `e[36m${image}:$IMG_TAG exists but digest differs, re-importing...`e[0m"
         }
 
-        Write-Host "  `e[36mImporting ${image}:latest...`e[0m"
+        Write-Host "  `e[36mImporting ${image}:$IMG_TAG...`e[0m"
         $imagesToImport += $image
 
         $job = Start-Job -ScriptBlock {
             param($ACR, $SHARED, $IMG, $USER, $TOKEN)
             $authArgs = @()
             if ($TOKEN) { $authArgs = @("--username", $USER, "--password", $TOKEN) }
-            $importError = az acr import --name $ACR --source "${SHARED}/${IMG}:latest" --image "${IMG}:latest" @authArgs --force 2>&1
+            $importError = az acr import --name $ACR --source "${SHARED}/${IMG}:$IMG_TAG" --image "${IMG}:$IMG_TAG" @authArgs --force 2>&1
             if ($LASTEXITCODE -eq 0) { return "OK" }
             # Retry once on transient errors
             if ($importError -notmatch "unauthorized|authentication|401|not found|does not exist|InvalidHostName|could not be resolved") {
                 Start-Sleep -Seconds 2
-                az acr import --name $ACR --source "${SHARED}/${IMG}:latest" --image "${IMG}:latest" @authArgs --force 2>&1
+                az acr import --name $ACR --source "${SHARED}/${IMG}:$IMG_TAG" --image "${IMG}:$IMG_TAG" @authArgs --force 2>&1
                 if ($LASTEXITCODE -eq 0) { return "OK" }
             }
             return "FAIL: $importError"
@@ -340,10 +356,10 @@ if ($DO_BUILD) {
         $result = Receive-Job $entry.Job
         Remove-Job $entry.Job
         if ($result -eq "OK") {
-            Write-Host "  `e[32m$($entry.Image):latest imported.`e[0m"
+            Write-Host "  `e[32m$($entry.Image):$IMG_TAG imported.`e[0m"
             $importCount++
         } else {
-            Write-Host "  `e[31m$($entry.Image):latest import FAILED`e[0m"
+            Write-Host "  `e[31m$($entry.Image):$IMG_TAG import FAILED`e[0m"
             Write-Host "  `e[31m$result`e[0m"
         }
     }
@@ -364,11 +380,11 @@ if ($DO_BUILD) {
 Write-Host "`n`e[33mVerifying all required images exist in ACR...`e[0m"
 $missingImages = @()
 foreach ($image in $IMAGES) {
-    if (-not (Test-ImageExists -Name $image -Tag "latest")) {
-        Write-Host "  `e[31mMISSING: ${image}:latest`e[0m"
+    if (-not (Test-ImageExists -Name $image -Tag $IMG_TAG)) {
+        Write-Host "  `e[31mMISSING: ${image}:$IMG_TAG`e[0m"
         $missingImages += $image
     } else {
-        Write-Host "  `e[32mOK: ${image}:latest`e[0m"
+        Write-Host "  `e[32mOK: ${image}:$IMG_TAG`e[0m"
     }
 }
 
@@ -378,7 +394,7 @@ if ($missingImages.Count -gt 0) {
 
     $stillMissing = @()
     foreach ($image in $missingImages) {
-        if (-not (Test-ImageExists -Name $image -Tag "latest")) {
+        if (-not (Test-ImageExists -Name $image -Tag $IMG_TAG)) {
             $stillMissing += $image
         }
     }
@@ -496,7 +512,7 @@ if (-not $SEARCH_INTERNAL_TOKEN) {
     Write-Host "  `e[32mGenerated new search internal token.`e[0m"
 }
 
-$IMAGE_TAG = "latest"
+$IMAGE_TAG = $IMG_TAG
 
 $helmArgs = @(
     "upgrade", "--install", "omnivec", "$RootDir/helm/omnivec",
@@ -550,22 +566,18 @@ if ($ENABLE_BLOB_SOURCE -eq "true") {
     $helmArgs += @("--set", "blobIngestor.enabled=false")
 }
 
-# Image tag channel: stable (default, for testers) or dev (for active work).
-# Users select via: azd env set OMNIVEC_IMAGE_TAG dev
-$imgTag = (& azd env get-value OMNIVEC_IMAGE_TAG 2>$null)
-if (-not $imgTag -or "$imgTag" -match "ERROR") { $imgTag = "stable" }
-$imgTag = "$imgTag".Trim()
+# Image tag channel (IMG_TAG resolved earlier from OMNIVEC_IMAGE_TAG or git branch).
 $helmArgs += @(
-    "--set", "web.image.tag=$imgTag",
-    "--set", "api.image.tag=$imgTag",
-    "--set", "search.image.tag=$imgTag",
-    "--set", "controller.image.tag=$imgTag",
-    "--set", "changefeed.image.tag=$imgTag",
-    "--set", "blobEnumerator.image.tag=$imgTag",
-    "--set", "sourceWorker.image.tag=$imgTag",
-    "--set", "blobWatcher.image.tag=$imgTag",
-    "--set", "docgrok.docgrok.image.tag=$imgTag",
-    "--set", "docgrok.pipelineWorker.image.tag=$imgTag"
+    "--set", "web.image.tag=$IMG_TAG",
+    "--set", "api.image.tag=$IMG_TAG",
+    "--set", "search.image.tag=$IMG_TAG",
+    "--set", "controller.image.tag=$IMG_TAG",
+    "--set", "changefeed.image.tag=$IMG_TAG",
+    "--set", "blobEnumerator.image.tag=$IMG_TAG",
+    "--set", "sourceWorker.image.tag=$IMG_TAG",
+    "--set", "blobWatcher.image.tag=$IMG_TAG",
+    "--set", "docgrok.docgrok.image.tag=$IMG_TAG",
+    "--set", "docgrok.pipelineWorker.image.tag=$IMG_TAG"
 )
 
 $helmArgs += @("--kube-context", $KUBE_CONTEXT, "--wait", "--timeout", "10m")

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -167,6 +167,26 @@ FORCE_IMPORT=${OMNIVEC_FORCE_IMPORT:-false}
 # Images to import/build
 IMAGES="omnivec-api omnivec-search omnivec-web omnivec-changefeed omnivec-dotnet-worker docgrok-pipeline-worker docgrok-router"
 
+# Release channel tag (stable / dev / sha-xxxxxxx / vX.Y.Z / latest).
+# Used for BOTH the acr import step AND the helm --set overrides so the
+# imported tag matches what the pods try to pull.
+# Resolution order:
+#   1. Explicit OMNIVEC_IMAGE_TAG (env or azd) wins  — e.g. sha-xxxxxxx / vX.Y.Z
+#   2. Auto-detect from current git branch:
+#        dev  -> dev
+#        main -> stable
+#   3. Fallback -> stable
+IMG_TAG=$(get_azd_value "OMNIVEC_IMAGE_TAG")
+if [ -z "$IMG_TAG" ]; then
+  _branch=$(git -C "$(dirname "$0")/.." rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  case "$_branch" in
+    dev)  IMG_TAG=dev ;;
+    main) IMG_TAG=stable ;;
+    *)    IMG_TAG=stable ;;
+  esac
+  printf "${CYAN}Auto-detected branch '${_branch:-unknown}' -> image tag '${IMG_TAG}'${NC}\n" >&2
+fi
+
 image_exists() {
   name=$1
   tag=$2
@@ -221,37 +241,37 @@ build_image() {
 }
 
 build_all_images() {
-  build_image "omnivec-api" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "latest"
-  build_image "omnivec-search" "${ROOT_DIR}/search/Dockerfile" "$ROOT_DIR" "latest"
-  build_image "omnivec-web" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest"
-  build_image "omnivec-changefeed" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest"
-  build_image "omnivec-dotnet-worker" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest"
+  build_image "omnivec-api" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "$IMG_TAG"
+  build_image "omnivec-search" "${ROOT_DIR}/search/Dockerfile" "$ROOT_DIR" "$IMG_TAG"
+  build_image "omnivec-web" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "$IMG_TAG"
+  build_image "omnivec-changefeed" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "$IMG_TAG"
+  build_image "omnivec-dotnet-worker" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "$IMG_TAG"
   if [ -f "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" ]; then
-    build_image "docgrok-pipeline-worker" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "latest"
+    build_image "docgrok-pipeline-worker" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "$IMG_TAG"
   fi
   if [ -f "${ROOT_DIR}/docgrok/router/Dockerfile" ]; then
-    build_image "docgrok-router" "${ROOT_DIR}/docgrok/router/Dockerfile" "${ROOT_DIR}/docgrok/router/" "latest"
+    build_image "docgrok-router" "${ROOT_DIR}/docgrok/router/Dockerfile" "${ROOT_DIR}/docgrok/router/" "$IMG_TAG"
   fi
 }
 
 build_missing_images() {
   for image in "$@"; do
     case "$image" in
-      omnivec-api)              build_image "$image" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "latest" ;;
-      omnivec-search)           build_image "$image" "${ROOT_DIR}/search/Dockerfile" "$ROOT_DIR" "latest" ;;
-      omnivec-web)              build_image "$image" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest" ;;
-      omnivec-changefeed)       build_image "$image" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest" ;;
-      omnivec-dotnet-worker)    build_image "$image" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest" ;;
+      omnivec-api)              build_image "$image" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "$IMG_TAG" ;;
+      omnivec-search)           build_image "$image" "${ROOT_DIR}/search/Dockerfile" "$ROOT_DIR" "$IMG_TAG" ;;
+      omnivec-web)              build_image "$image" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "$IMG_TAG" ;;
+      omnivec-changefeed)       build_image "$image" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "$IMG_TAG" ;;
+      omnivec-dotnet-worker)    build_image "$image" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "$IMG_TAG" ;;
       docgrok-pipeline-worker)
         if [ -f "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" ]; then
-          build_image "$image" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "latest"
+          build_image "$image" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "$IMG_TAG"
         else
           printf "  ${YELLOW}Skipping ${image}: source not present in repo.${NC}\n"
         fi
         ;;
       docgrok-router)
         if [ -f "${ROOT_DIR}/docgrok/router/Dockerfile" ]; then
-          build_image "$image" "${ROOT_DIR}/docgrok/router/Dockerfile" "${ROOT_DIR}/docgrok/router/" "latest"
+          build_image "$image" "${ROOT_DIR}/docgrok/router/Dockerfile" "${ROOT_DIR}/docgrok/router/" "$IMG_TAG"
         else
           printf "  ${YELLOW}Skipping ${image}: source not present in repo.${NC}\n"
         fi
@@ -279,7 +299,7 @@ SKIP_IMPORT=${OMNIVEC_SKIP_IMPORT:-$(get_azd_value "OMNIVEC_SKIP_IMPORT")}
 # re-import only if the user explicitly asked via OMNIVEC_FORCE_IMPORT.
 _auth_test_can_skip() {
   if [ "$FORCE_IMPORT" = "true" ]; then return 1; fi
-  if image_exists "$FIRST_IMAGE" "latest"; then return 0; fi
+  if image_exists "$FIRST_IMAGE" "$IMG_TAG"; then return 0; fi
   return 1
 }
 
@@ -291,12 +311,12 @@ if [ "$OMNIVEC_BUILD" != "true" ] && [ "$SKIP_IMPORT" != "true" ] && [ "$SKIP_IM
   # the auth test entirely — importing unconditionally here is what used
   # to clobber locally patched images.
   if _auth_test_can_skip; then
-    printf "  ${GREEN}${FIRST_IMAGE}:latest already present locally, skipping auth test.${NC}\n"
+    printf "  ${GREEN}${FIRST_IMAGE}:${IMG_TAG} already present locally, skipping auth test.${NC}\n"
     ANON_OK=true
   else
     # Try anonymous pull first
     printf "  ${CYAN}Testing anonymous pull (this may take 30-60s)...${NC}"
-    if timeout 90 az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:latest" --image "${FIRST_IMAGE}:latest" --force >/dev/null 2>&1; then
+    if timeout 90 az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:${IMG_TAG}" --image "${FIRST_IMAGE}:${IMG_TAG}" --force >/dev/null 2>&1; then
       printf " ${GREEN}✓ anonymous pull works${NC}\n"
       ANON_OK=true
       AUTH_IMPORTED=true
@@ -305,7 +325,7 @@ if [ "$OMNIVEC_BUILD" != "true" ] && [ "$SKIP_IMPORT" != "true" ] && [ "$SKIP_IM
       # Try stored token
       if [ -n "$SHARED_REGISTRY_TOKEN" ]; then
         printf "  ${CYAN}Trying stored token...${NC}"
-        if az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:latest" --image "${FIRST_IMAGE}:latest" --username "$SHARED_REGISTRY_USER" --password "$SHARED_REGISTRY_TOKEN" --force >/dev/null 2>&1; then
+        if az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:${IMG_TAG}" --image "${FIRST_IMAGE}:${IMG_TAG}" --username "$SHARED_REGISTRY_USER" --password "$SHARED_REGISTRY_TOKEN" --force >/dev/null 2>&1; then
           printf " ${GREEN}✓ token works${NC}\n"
           TOKEN_OK=true
           AUTH_IMPORTED=true
@@ -318,7 +338,7 @@ if [ "$OMNIVEC_BUILD" != "true" ] && [ "$SKIP_IMPORT" != "true" ] && [ "$SKIP_IM
         printf "  ${YELLOW}Registry token required for import.${NC}\n"
         _new_token=$(read_input "  Enter token for $SHARED_REGISTRY (or Enter to build from source): ")
         if [ -n "$_new_token" ]; then
-          if az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:latest" --image "${FIRST_IMAGE}:latest" --username "$SHARED_REGISTRY_USER" --password "$_new_token" --force >/dev/null 2>&1; then
+          if az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:${IMG_TAG}" --image "${FIRST_IMAGE}:${IMG_TAG}" --username "$SHARED_REGISTRY_USER" --password "$_new_token" --force >/dev/null 2>&1; then
             SHARED_REGISTRY_TOKEN="$_new_token"
             azd env set OMNIVEC_SHARED_REGISTRY_TOKEN "$_new_token" </dev/null 2>/dev/null || true
             printf "  ${GREEN}Token valid — saved for future use.${NC}\n"
@@ -358,25 +378,25 @@ else
     # First image — already handled by auth test (imported or preserved)
     if [ "$image" = "$FIRST_IMAGE" ]; then
       if [ "$AUTH_IMPORTED" = "true" ]; then
-        printf "  ${GREEN}${image}:latest already imported (auth test).${NC}\n"
+        printf "  ${GREEN}${image}:${IMG_TAG} already imported (auth test).${NC}\n"
         import_count=$((import_count + 1))
       else
-        printf "  ${GREEN}${image}:latest already present locally, preserving (auth test).${NC}\n"
+        printf "  ${GREEN}${image}:${IMG_TAG} already present locally, preserving (auth test).${NC}\n"
         skip_count=$((skip_count + 1))
       fi
       continue
     fi
-    if [ "$FORCE_IMPORT" != "true" ] && image_exists "$image" "latest"; then
+    if [ "$FORCE_IMPORT" != "true" ] && image_exists "$image" "$IMG_TAG"; then
       # Default policy: local image wins. Re-import only when the user
       # explicitly sets OMNIVEC_FORCE_IMPORT=true. This prevents the
       # shared-registry :latest (which may lag behind hotfixes) from
       # clobbering locally built / patched images on every azd up.
-      printf "  ${GREEN}${image}:latest already present locally, preserving (set OMNIVEC_FORCE_IMPORT=true to overwrite).${NC}\n"
+      printf "  ${GREEN}${image}:${IMG_TAG} already present locally, preserving (set OMNIVEC_FORCE_IMPORT=true to overwrite).${NC}\n"
       skip_count=$((skip_count + 1))
       continue
     fi
 
-    printf "  ${CYAN}Importing ${image}:latest...${NC}\n"
+    printf "  ${CYAN}Importing ${image}:${IMG_TAG}...${NC}\n"
 
     # Run import in background (parallel)
     (
@@ -388,8 +408,8 @@ else
         fi
         import_error=$(az acr import \
             --name "$ACR_NAME" \
-            --source "${SHARED_REGISTRY}/${image}:latest" \
-            --image "${image}:latest" \
+            --source "${SHARED_REGISTRY}/${image}:${IMG_TAG}" \
+            --image "${image}:${IMG_TAG}" \
             $AUTH_ARGS \
             --force 2>&1) && import_success=true || import_success=false
 
@@ -418,10 +438,10 @@ else
     if [ ! -f "$result_file" ]; then continue; fi
     result=$(cat "$result_file")
     if [ "$result" = "OK" ]; then
-      printf "  ${GREEN}${image}:latest imported.${NC}\n"
+      printf "  ${GREEN}${image}:${IMG_TAG} imported.${NC}\n"
       import_count=$((import_count + 1))
     else
-      printf "  ${RED}${image}:latest import FAILED${NC}\n"
+      printf "  ${RED}${image}:${IMG_TAG} import FAILED${NC}\n"
       printf "  ${RED}${result}${NC}\n"
     fi
   done
@@ -444,11 +464,11 @@ fi
 printf "\n${YELLOW}Verifying all required images exist in ACR...${NC}\n"
 MISSING_IMAGES=""
 for image in $IMAGES; do
-  if ! image_exists "$image" "latest"; then
-    printf "  ${RED}MISSING: ${image}:latest${NC}\n"
+  if ! image_exists "$image" "$IMG_TAG"; then
+    printf "  ${RED}MISSING: ${image}:${IMG_TAG}${NC}\n"
     MISSING_IMAGES="$MISSING_IMAGES $image"
   else
-    printf "  ${GREEN}OK: ${image}:latest${NC}\n"
+    printf "  ${GREEN}OK: ${image}:${IMG_TAG}${NC}\n"
   fi
 done
 
@@ -459,7 +479,7 @@ if [ -n "$MISSING_IMAGES" ]; then
 
   STILL_MISSING=""
   for image in $MISSING_IMAGES; do
-    if ! image_exists "$image" "latest"; then
+    if ! image_exists "$image" "$IMG_TAG"; then
       STILL_MISSING="$STILL_MISSING $image"
     fi
   done
@@ -611,7 +631,7 @@ if [ -z "$SEARCH_INTERNAL_TOKEN" ]; then
   printf "  ${GREEN}Generated new search internal token.${NC}\n"
 fi
 
-IMAGE_TAG="latest"
+IMAGE_TAG="$IMG_TAG"
 
 # Write helm values to a temp file (avoids fragile eval + string concatenation)
 HELM_VALUES_FILE=$(mktemp /tmp/omnivec-helm-values.XXXXXX.yaml)
@@ -703,10 +723,7 @@ run_helm_deploy() {
     set -- "$@" --set "blobIngestor.enabled=false"
   fi
 
-  # Image tag channel: stable (default, for testers) or dev (for active work).
-  # Users select via: azd env set OMNIVEC_IMAGE_TAG dev
-  IMG_TAG=$(get_azd_value "OMNIVEC_IMAGE_TAG")
-  IMG_TAG=${IMG_TAG:-stable}
+  # Image tag channel (IMG_TAG resolved earlier from OMNIVEC_IMAGE_TAG or git branch).
   set -- "$@" \
     --set "web.image.tag=${IMG_TAG}" \
     --set "api.image.tag=${IMG_TAG}" \


### PR DESCRIPTION
Fixes ImagePullBackOff on fresh deploys: postprovision was importing :latest but helm was being told to pull :stable/:dev. Now resolves IMG_TAG once (from OMNIVEC_IMAGE_TAG or auto-detect git branch) and uses it consistently for import and helm overrides. main->stable, dev->dev auto-detected.