### PR TITLE
fix(hooks): import images to env ACR as :latest (channel on source only)

### DIFF
--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -367,6 +367,18 @@ if ($DO_BUILD) {
     Write-Host "`e[32mImage import complete: $importCount imported, $skipCount skipped.`e[0m"
     $script:imagesChanged = $importCount -gt 0
 
+    # Belt-and-suspenders: alias imported images as :latest in env ACR so
+    # any helm service whose tag override we forgot still resolves.
+    if ($IMG_TAG -ne "latest") {
+        foreach ($image in $IMAGES) {
+            if (Test-ImageExists -Name $image -Tag $IMG_TAG) {
+                az acr import --name $ACR_NAME `
+                    --source "$ACR_NAME.azurecr.io/${image}:$IMG_TAG" `
+                    --image "${image}:latest" --force 2>&1 | Out-Null
+            }
+        }
+    }
+
     # If import yielded no usable images, auto-fallback to source builds
     $totalAvailable = $importCount + $skipCount
     if ($totalAvailable -eq 0) {
@@ -575,6 +587,7 @@ $helmArgs += @(
     "--set", "changefeed.image.tag=$IMG_TAG",
     "--set", "blobEnumerator.image.tag=$IMG_TAG",
     "--set", "sourceWorker.image.tag=$IMG_TAG",
+    "--set", "dotnetWorker.image.tag=$IMG_TAG",
     "--set", "blobWatcher.image.tag=$IMG_TAG",
     "--set", "docgrok.docgrok.image.tag=$IMG_TAG",
     "--set", "docgrok.pipelineWorker.image.tag=$IMG_TAG"

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -210,17 +210,17 @@ function Build-Image {
 }
 
 function Build-AllImages {
-    Build-Image -Name "omnivec-api" -Dockerfile "$RootDir/api/Dockerfile" -Context $RootDir -Tag $IMG_TAG
-    Build-Image -Name "omnivec-search" -Dockerfile "$RootDir/search/Dockerfile" -Context $RootDir -Tag $IMG_TAG
-    Build-Image -Name "omnivec-web" -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag $IMG_TAG
-    Build-Image -Name "omnivec-changefeed" -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag $IMG_TAG
-    Build-Image -Name "omnivec-dotnet-worker" -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag $IMG_TAG
+    Build-Image -Name "omnivec-api" -Dockerfile "$RootDir/api/Dockerfile" -Context $RootDir -Tag "latest"
+    Build-Image -Name "omnivec-search" -Dockerfile "$RootDir/search/Dockerfile" -Context $RootDir -Tag "latest"
+    Build-Image -Name "omnivec-web" -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag "latest"
+    Build-Image -Name "omnivec-changefeed" -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag "latest"
+    Build-Image -Name "omnivec-dotnet-worker" -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag "latest"
 
     if (Test-Path "$RootDir/docgrok/pipeline-worker/Dockerfile") {
-        Build-Image -Name "docgrok-pipeline-worker" -Dockerfile "$RootDir/docgrok/pipeline-worker/Dockerfile" -Context "$RootDir/docgrok/pipeline-worker/" -Tag $IMG_TAG
+        Build-Image -Name "docgrok-pipeline-worker" -Dockerfile "$RootDir/docgrok/pipeline-worker/Dockerfile" -Context "$RootDir/docgrok/pipeline-worker/" -Tag "latest"
     }
     if (Test-Path "$RootDir/docgrok/router/Dockerfile") {
-        Build-Image -Name "docgrok-router" -Dockerfile "$RootDir/docgrok/router/Dockerfile" -Context "$RootDir/docgrok/router/" -Tag $IMG_TAG
+        Build-Image -Name "docgrok-router" -Dockerfile "$RootDir/docgrok/router/Dockerfile" -Context "$RootDir/docgrok/router/" -Tag "latest"
     }
 }
 
@@ -229,21 +229,21 @@ function Build-MissingImages {
 
     foreach ($image in $Images) {
         switch ($image) {
-            "omnivec-api"             { Build-Image -Name $image -Dockerfile "$RootDir/api/Dockerfile" -Context $RootDir -Tag $IMG_TAG }
-            "omnivec-search"          { Build-Image -Name $image -Dockerfile "$RootDir/search/Dockerfile" -Context $RootDir -Tag $IMG_TAG }
-            "omnivec-web"             { Build-Image -Name $image -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag $IMG_TAG }
-            "omnivec-changefeed"      { Build-Image -Name $image -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag $IMG_TAG }
-            "omnivec-dotnet-worker"   { Build-Image -Name $image -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag $IMG_TAG }
+            "omnivec-api"             { Build-Image -Name $image -Dockerfile "$RootDir/api/Dockerfile" -Context $RootDir -Tag "latest" }
+            "omnivec-search"          { Build-Image -Name $image -Dockerfile "$RootDir/search/Dockerfile" -Context $RootDir -Tag "latest" }
+            "omnivec-web"             { Build-Image -Name $image -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag "latest" }
+            "omnivec-changefeed"      { Build-Image -Name $image -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag "latest" }
+            "omnivec-dotnet-worker"   { Build-Image -Name $image -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag "latest" }
             "docgrok-pipeline-worker" {
                 if (Test-Path "$RootDir/docgrok/pipeline-worker/Dockerfile") {
-                    Build-Image -Name $image -Dockerfile "$RootDir/docgrok/pipeline-worker/Dockerfile" -Context "$RootDir/docgrok/pipeline-worker/" -Tag $IMG_TAG
+                    Build-Image -Name $image -Dockerfile "$RootDir/docgrok/pipeline-worker/Dockerfile" -Context "$RootDir/docgrok/pipeline-worker/" -Tag "latest"
                 } else {
                     Write-Host "  `e[33mSkipping ${image}: source not present in repo.`e[0m"
                 }
             }
             "docgrok-router" {
                 if (Test-Path "$RootDir/docgrok/router/Dockerfile") {
-                    Build-Image -Name $image -Dockerfile "$RootDir/docgrok/router/Dockerfile" -Context "$RootDir/docgrok/router/" -Tag $IMG_TAG
+                    Build-Image -Name $image -Dockerfile "$RootDir/docgrok/router/Dockerfile" -Context "$RootDir/docgrok/router/" -Tag "latest"
                 } else {
                     Write-Host "  `e[33mSkipping ${image}: source not present in repo.`e[0m"
                 }
@@ -261,7 +261,7 @@ if (-not $DO_BUILD) {
     $anonOk = $false
     $tokenOk = $false
     Write-Host "  `e[36mTesting anonymous pull...`e[0m" -NoNewline
-    $testResult = az acr import --name $ACR_NAME --source "${SHARED_REGISTRY}/$($IMAGES[0]):$IMG_TAG" --image "$($IMAGES[0]):$IMG_TAG" --force 2>&1
+    $testResult = az acr import --name $ACR_NAME --source "${SHARED_REGISTRY}/$($IMAGES[0]):$IMG_TAG" --image "$($IMAGES[0]):latest" --force 2>&1
     if ($LASTEXITCODE -eq 0) {
         Write-Host " `e[32m✓ anonymous pull works`e[0m"
         $anonOk = $true
@@ -270,7 +270,7 @@ if (-not $DO_BUILD) {
         # Try with stored token
         if ($SHARED_REGISTRY_TOKEN) {
             Write-Host "  `e[36mTrying stored token...`e[0m" -NoNewline
-            $testResult = az acr import --name $ACR_NAME --source "${SHARED_REGISTRY}/$($IMAGES[0]):$IMG_TAG" --image "$($IMAGES[0]):$IMG_TAG" --username $SHARED_REGISTRY_USER --password $SHARED_REGISTRY_TOKEN --force 2>&1
+            $testResult = az acr import --name $ACR_NAME --source "${SHARED_REGISTRY}/$($IMAGES[0]):$IMG_TAG" --image "$($IMAGES[0]):latest" --username $SHARED_REGISTRY_USER --password $SHARED_REGISTRY_TOKEN --force 2>&1
             if ($LASTEXITCODE -eq 0) {
                 Write-Host " `e[32m✓ token works`e[0m"
                 $tokenOk = $true
@@ -283,7 +283,7 @@ if (-not $DO_BUILD) {
             Write-Host "  `e[33mRegistry token required for import.`e[0m"
             $newToken = (Read-Host "  Enter token for $SHARED_REGISTRY (or Enter to build from source)").Trim()
             if ($newToken) {
-                $testResult = az acr import --name $ACR_NAME --source "${SHARED_REGISTRY}/$($IMAGES[0]):$IMG_TAG" --image "$($IMAGES[0]):$IMG_TAG" --username $SHARED_REGISTRY_USER --password $newToken --force 2>&1
+                $testResult = az acr import --name $ACR_NAME --source "${SHARED_REGISTRY}/$($IMAGES[0]):$IMG_TAG" --image "$($IMAGES[0]):latest" --username $SHARED_REGISTRY_USER --password $newToken --force 2>&1
                 if ($LASTEXITCODE -eq 0) {
                     $SHARED_REGISTRY_TOKEN = $newToken
                     azd env set OMNIVEC_SHARED_REGISTRY_TOKEN $newToken 2>$null
@@ -317,27 +317,27 @@ if ($DO_BUILD) {
     $imagesToImport = @()
 
     foreach ($image in $IMAGES) {
-        if (-not $FORCE_IMPORT -and (Test-ImageUpToDate -Name $image -Tag $IMG_TAG)) {
-            Write-Host "  `e[32m${image}:$IMG_TAG up to date (digest match), skipping.`e[0m"
+        if (-not $FORCE_IMPORT -and (Test-ImageUpToDate -Name $image -Tag "latest")) {
+            Write-Host "  `e[32m${image}:latest up to date (digest match), skipping.`e[0m"
             $skipCount++
             continue
-        } elseif (-not $FORCE_IMPORT -and (Test-ImageExists -Name $image -Tag $IMG_TAG)) {
-            Write-Host "  `e[36m${image}:$IMG_TAG exists but digest differs, re-importing...`e[0m"
+        } elseif (-not $FORCE_IMPORT -and (Test-ImageExists -Name $image -Tag "latest")) {
+            Write-Host "  `e[36m${image}:latest exists but digest differs, re-importing...`e[0m"
         }
 
-        Write-Host "  `e[36mImporting ${image}:$IMG_TAG...`e[0m"
+        Write-Host "  `e[36mImporting ${image}:$IMG_TAG as :latest...`e[0m"
         $imagesToImport += $image
 
         $job = Start-Job -ScriptBlock {
             param($ACR, $SHARED, $IMG, $USER, $TOKEN)
             $authArgs = @()
             if ($TOKEN) { $authArgs = @("--username", $USER, "--password", $TOKEN) }
-            $importError = az acr import --name $ACR --source "${SHARED}/${IMG}:$IMG_TAG" --image "${IMG}:$IMG_TAG" @authArgs --force 2>&1
+            $importError = az acr import --name $ACR --source "${SHARED}/${IMG}:$IMG_TAG" --image "${IMG}:latest" @authArgs --force 2>&1
             if ($LASTEXITCODE -eq 0) { return "OK" }
             # Retry once on transient errors
             if ($importError -notmatch "unauthorized|authentication|401|not found|does not exist|InvalidHostName|could not be resolved") {
                 Start-Sleep -Seconds 2
-                az acr import --name $ACR --source "${SHARED}/${IMG}:$IMG_TAG" --image "${IMG}:$IMG_TAG" @authArgs --force 2>&1
+                az acr import --name $ACR --source "${SHARED}/${IMG}:$IMG_TAG" --image "${IMG}:latest" @authArgs --force 2>&1
                 if ($LASTEXITCODE -eq 0) { return "OK" }
             }
             return "FAIL: $importError"
@@ -356,10 +356,10 @@ if ($DO_BUILD) {
         $result = Receive-Job $entry.Job
         Remove-Job $entry.Job
         if ($result -eq "OK") {
-            Write-Host "  `e[32m$($entry.Image):$IMG_TAG imported.`e[0m"
+            Write-Host "  `e[32m$($entry.Image):latest (from $IMG_TAG) imported.`e[0m"
             $importCount++
         } else {
-            Write-Host "  `e[31m$($entry.Image):$IMG_TAG import FAILED`e[0m"
+            Write-Host "  `e[31m$($entry.Image):latest (from $IMG_TAG) import FAILED`e[0m"
             Write-Host "  `e[31m$result`e[0m"
         }
     }
@@ -367,15 +367,6 @@ if ($DO_BUILD) {
     Write-Host "`e[32mImage import complete: $importCount imported, $skipCount skipped.`e[0m"
     $script:imagesChanged = $importCount -gt 0
 
-    # Belt-and-suspenders: alias imported images as :latest in env ACR so
-    # any helm service whose tag override we forgot still resolves.
-    if ($IMG_TAG -ne "latest") {
-        foreach ($image in $IMAGES) {
-            if (Test-ImageExists -Name $image -Tag $IMG_TAG) {
-                az acr import --name $ACR_NAME `
-                    --source "$ACR_NAME.azurecr.io/${image}:$IMG_TAG" `
-                    --image "${image}:latest" --force 2>&1 | Out-Null
-            }
         }
     }
 
@@ -392,11 +383,11 @@ if ($DO_BUILD) {
 Write-Host "`n`e[33mVerifying all required images exist in ACR...`e[0m"
 $missingImages = @()
 foreach ($image in $IMAGES) {
-    if (-not (Test-ImageExists -Name $image -Tag $IMG_TAG)) {
-        Write-Host "  `e[31mMISSING: ${image}:$IMG_TAG`e[0m"
+    if (-not (Test-ImageExists -Name $image -Tag "latest")) {
+        Write-Host "  `e[31mMISSING: ${image}:latest`e[0m"
         $missingImages += $image
     } else {
-        Write-Host "  `e[32mOK: ${image}:$IMG_TAG`e[0m"
+        Write-Host "  `e[32mOK: ${image}:latest`e[0m"
     }
 }
 
@@ -406,7 +397,7 @@ if ($missingImages.Count -gt 0) {
 
     $stillMissing = @()
     foreach ($image in $missingImages) {
-        if (-not (Test-ImageExists -Name $image -Tag $IMG_TAG)) {
+        if (-not (Test-ImageExists -Name $image -Tag "latest")) {
             $stillMissing += $image
         }
     }
@@ -524,7 +515,7 @@ if (-not $SEARCH_INTERNAL_TOKEN) {
     Write-Host "  `e[32mGenerated new search internal token.`e[0m"
 }
 
-$IMAGE_TAG = $IMG_TAG
+$IMAGE_TAG = "latest"
 
 $helmArgs = @(
     "upgrade", "--install", "omnivec", "$RootDir/helm/omnivec",
@@ -578,20 +569,9 @@ if ($ENABLE_BLOB_SOURCE -eq "true") {
     $helmArgs += @("--set", "blobIngestor.enabled=false")
 }
 
-# Image tag channel (IMG_TAG resolved earlier from OMNIVEC_IMAGE_TAG or git branch).
-$helmArgs += @(
-    "--set", "web.image.tag=$IMG_TAG",
-    "--set", "api.image.tag=$IMG_TAG",
-    "--set", "search.image.tag=$IMG_TAG",
-    "--set", "controller.image.tag=$IMG_TAG",
-    "--set", "changefeed.image.tag=$IMG_TAG",
-    "--set", "blobEnumerator.image.tag=$IMG_TAG",
-    "--set", "sourceWorker.image.tag=$IMG_TAG",
-    "--set", "dotnetWorker.image.tag=$IMG_TAG",
-    "--set", "blobWatcher.image.tag=$IMG_TAG",
-    "--set", "docgrok.docgrok.image.tag=$IMG_TAG",
-    "--set", "docgrok.pipelineWorker.image.tag=$IMG_TAG"
-)
+# Image tags are NOT overridden here — postprovision imports every image
+# into the env-specific ACR tagged :latest (from OMNIVEC_IMAGE_TAG / branch),
+# so the default values.yaml (image.tag: latest) resolves for every service.
 
 $helmArgs += @("--kube-context", $KUBE_CONTEXT, "--wait", "--timeout", "10m")
 # Intentionally NO --atomic: on failure, --atomic runs `helm uninstall`, which

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -241,37 +241,37 @@ build_image() {
 }
 
 build_all_images() {
-  build_image "omnivec-api" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "$IMG_TAG"
-  build_image "omnivec-search" "${ROOT_DIR}/search/Dockerfile" "$ROOT_DIR" "$IMG_TAG"
-  build_image "omnivec-web" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "$IMG_TAG"
-  build_image "omnivec-changefeed" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "$IMG_TAG"
-  build_image "omnivec-dotnet-worker" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "$IMG_TAG"
+  build_image "omnivec-api" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "latest"
+  build_image "omnivec-search" "${ROOT_DIR}/search/Dockerfile" "$ROOT_DIR" "latest"
+  build_image "omnivec-web" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest"
+  build_image "omnivec-changefeed" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest"
+  build_image "omnivec-dotnet-worker" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest"
   if [ -f "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" ]; then
-    build_image "docgrok-pipeline-worker" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "$IMG_TAG"
+    build_image "docgrok-pipeline-worker" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "latest"
   fi
   if [ -f "${ROOT_DIR}/docgrok/router/Dockerfile" ]; then
-    build_image "docgrok-router" "${ROOT_DIR}/docgrok/router/Dockerfile" "${ROOT_DIR}/docgrok/router/" "$IMG_TAG"
+    build_image "docgrok-router" "${ROOT_DIR}/docgrok/router/Dockerfile" "${ROOT_DIR}/docgrok/router/" "latest"
   fi
 }
 
 build_missing_images() {
   for image in "$@"; do
     case "$image" in
-      omnivec-api)              build_image "$image" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "$IMG_TAG" ;;
-      omnivec-search)           build_image "$image" "${ROOT_DIR}/search/Dockerfile" "$ROOT_DIR" "$IMG_TAG" ;;
-      omnivec-web)              build_image "$image" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "$IMG_TAG" ;;
-      omnivec-changefeed)       build_image "$image" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "$IMG_TAG" ;;
-      omnivec-dotnet-worker)    build_image "$image" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "$IMG_TAG" ;;
+      omnivec-api)              build_image "$image" "${ROOT_DIR}/api/Dockerfile" "$ROOT_DIR" "latest" ;;
+      omnivec-search)           build_image "$image" "${ROOT_DIR}/search/Dockerfile" "$ROOT_DIR" "latest" ;;
+      omnivec-web)              build_image "$image" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest" ;;
+      omnivec-changefeed)       build_image "$image" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest" ;;
+      omnivec-dotnet-worker)    build_image "$image" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest" ;;
       docgrok-pipeline-worker)
         if [ -f "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" ]; then
-          build_image "$image" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "$IMG_TAG"
+          build_image "$image" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "latest"
         else
           printf "  ${YELLOW}Skipping ${image}: source not present in repo.${NC}\n"
         fi
         ;;
       docgrok-router)
         if [ -f "${ROOT_DIR}/docgrok/router/Dockerfile" ]; then
-          build_image "$image" "${ROOT_DIR}/docgrok/router/Dockerfile" "${ROOT_DIR}/docgrok/router/" "$IMG_TAG"
+          build_image "$image" "${ROOT_DIR}/docgrok/router/Dockerfile" "${ROOT_DIR}/docgrok/router/" "latest"
         else
           printf "  ${YELLOW}Skipping ${image}: source not present in repo.${NC}\n"
         fi
@@ -299,7 +299,7 @@ SKIP_IMPORT=${OMNIVEC_SKIP_IMPORT:-$(get_azd_value "OMNIVEC_SKIP_IMPORT")}
 # re-import only if the user explicitly asked via OMNIVEC_FORCE_IMPORT.
 _auth_test_can_skip() {
   if [ "$FORCE_IMPORT" = "true" ]; then return 1; fi
-  if image_exists "$FIRST_IMAGE" "$IMG_TAG"; then return 0; fi
+  if image_exists "$FIRST_IMAGE" "latest"; then return 0; fi
   return 1
 }
 
@@ -311,12 +311,12 @@ if [ "$OMNIVEC_BUILD" != "true" ] && [ "$SKIP_IMPORT" != "true" ] && [ "$SKIP_IM
   # the auth test entirely — importing unconditionally here is what used
   # to clobber locally patched images.
   if _auth_test_can_skip; then
-    printf "  ${GREEN}${FIRST_IMAGE}:${IMG_TAG} already present locally, skipping auth test.${NC}\n"
+    printf "  ${GREEN}${FIRST_IMAGE}:latest already present locally, skipping auth test.${NC}\n"
     ANON_OK=true
   else
     # Try anonymous pull first
     printf "  ${CYAN}Testing anonymous pull (this may take 30-60s)...${NC}"
-    if timeout 90 az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:${IMG_TAG}" --image "${FIRST_IMAGE}:${IMG_TAG}" --force >/dev/null 2>&1; then
+    if timeout 90 az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:${IMG_TAG}" --image "${FIRST_IMAGE}:latest" --force >/dev/null 2>&1; then
       printf " ${GREEN}✓ anonymous pull works${NC}\n"
       ANON_OK=true
       AUTH_IMPORTED=true
@@ -325,7 +325,7 @@ if [ "$OMNIVEC_BUILD" != "true" ] && [ "$SKIP_IMPORT" != "true" ] && [ "$SKIP_IM
       # Try stored token
       if [ -n "$SHARED_REGISTRY_TOKEN" ]; then
         printf "  ${CYAN}Trying stored token...${NC}"
-        if az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:${IMG_TAG}" --image "${FIRST_IMAGE}:${IMG_TAG}" --username "$SHARED_REGISTRY_USER" --password "$SHARED_REGISTRY_TOKEN" --force >/dev/null 2>&1; then
+        if az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:${IMG_TAG}" --image "${FIRST_IMAGE}:latest" --username "$SHARED_REGISTRY_USER" --password "$SHARED_REGISTRY_TOKEN" --force >/dev/null 2>&1; then
           printf " ${GREEN}✓ token works${NC}\n"
           TOKEN_OK=true
           AUTH_IMPORTED=true
@@ -338,7 +338,7 @@ if [ "$OMNIVEC_BUILD" != "true" ] && [ "$SKIP_IMPORT" != "true" ] && [ "$SKIP_IM
         printf "  ${YELLOW}Registry token required for import.${NC}\n"
         _new_token=$(read_input "  Enter token for $SHARED_REGISTRY (or Enter to build from source): ")
         if [ -n "$_new_token" ]; then
-          if az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:${IMG_TAG}" --image "${FIRST_IMAGE}:${IMG_TAG}" --username "$SHARED_REGISTRY_USER" --password "$_new_token" --force >/dev/null 2>&1; then
+          if az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:${IMG_TAG}" --image "${FIRST_IMAGE}:latest" --username "$SHARED_REGISTRY_USER" --password "$_new_token" --force >/dev/null 2>&1; then
             SHARED_REGISTRY_TOKEN="$_new_token"
             azd env set OMNIVEC_SHARED_REGISTRY_TOKEN "$_new_token" </dev/null 2>/dev/null || true
             printf "  ${GREEN}Token valid — saved for future use.${NC}\n"
@@ -378,25 +378,25 @@ else
     # First image — already handled by auth test (imported or preserved)
     if [ "$image" = "$FIRST_IMAGE" ]; then
       if [ "$AUTH_IMPORTED" = "true" ]; then
-        printf "  ${GREEN}${image}:${IMG_TAG} already imported (auth test).${NC}\n"
+        printf "  ${GREEN}${image}:latest already imported (auth test).${NC}\n"
         import_count=$((import_count + 1))
       else
-        printf "  ${GREEN}${image}:${IMG_TAG} already present locally, preserving (auth test).${NC}\n"
+        printf "  ${GREEN}${image}:latest already present locally, preserving (auth test).${NC}\n"
         skip_count=$((skip_count + 1))
       fi
       continue
     fi
-    if [ "$FORCE_IMPORT" != "true" ] && image_exists "$image" "$IMG_TAG"; then
+    if [ "$FORCE_IMPORT" != "true" ] && image_exists "$image" "latest"; then
       # Default policy: local image wins. Re-import only when the user
       # explicitly sets OMNIVEC_FORCE_IMPORT=true. This prevents the
       # shared-registry :latest (which may lag behind hotfixes) from
       # clobbering locally built / patched images on every azd up.
-      printf "  ${GREEN}${image}:${IMG_TAG} already present locally, preserving (set OMNIVEC_FORCE_IMPORT=true to overwrite).${NC}\n"
+      printf "  ${GREEN}${image}:latest already present locally, preserving (set OMNIVEC_FORCE_IMPORT=true to overwrite).${NC}\n"
       skip_count=$((skip_count + 1))
       continue
     fi
 
-    printf "  ${CYAN}Importing ${image}:${IMG_TAG}...${NC}\n"
+    printf "  ${CYAN}Importing ${image}:${IMG_TAG} as :latest...${NC}\n"
 
     # Run import in background (parallel)
     (
@@ -409,7 +409,7 @@ else
         import_error=$(az acr import \
             --name "$ACR_NAME" \
             --source "${SHARED_REGISTRY}/${image}:${IMG_TAG}" \
-            --image "${image}:${IMG_TAG}" \
+            --image "${image}:latest" \
             $AUTH_ARGS \
             --force 2>&1) && import_success=true || import_success=false
 
@@ -438,7 +438,7 @@ else
     if [ ! -f "$result_file" ]; then continue; fi
     result=$(cat "$result_file")
     if [ "$result" = "OK" ]; then
-      printf "  ${GREEN}${image}:${IMG_TAG} imported.${NC}\n"
+      printf "  ${GREEN}${image}:latest (from ${IMG_TAG}) imported.${NC}\n"
       import_count=$((import_count + 1))
     else
       printf "  ${RED}${image}:${IMG_TAG} import FAILED${NC}\n"
@@ -449,20 +449,6 @@ else
 
   printf "${GREEN}Image import complete: $import_count imported, $skip_count skipped.${NC}\n"
   if [ "$import_count" -gt 0 ]; then IMAGES_CHANGED=true; fi
-
-  # Belt-and-suspenders: also alias each imported image as :latest in the env
-  # ACR so any helm deployment that still references the default tag: latest
-  # (i.e. a service whose --set override we forgot to add) still finds a valid
-  # manifest. Safe no-op when IMG_TAG=latest. Failures are non-fatal.
-  if [ "$IMG_TAG" != "latest" ]; then
-    for image in $IMAGES; do
-      if image_exists "$image" "$IMG_TAG"; then
-        az acr import --name "$ACR_NAME" \
-          --source "${ACR_NAME}.azurecr.io/${image}:${IMG_TAG}" \
-          --image "${image}:latest" --force >/dev/null 2>&1 || true
-      fi
-    done
-  fi
 
   # If no images available from import, auto-fallback to build mode
   total_available=$((import_count + skip_count))
@@ -478,11 +464,11 @@ fi
 printf "\n${YELLOW}Verifying all required images exist in ACR...${NC}\n"
 MISSING_IMAGES=""
 for image in $IMAGES; do
-  if ! image_exists "$image" "$IMG_TAG"; then
-    printf "  ${RED}MISSING: ${image}:${IMG_TAG}${NC}\n"
+  if ! image_exists "$image" "latest"; then
+    printf "  ${RED}MISSING: ${image}:latest${NC}\n"
     MISSING_IMAGES="$MISSING_IMAGES $image"
   else
-    printf "  ${GREEN}OK: ${image}:${IMG_TAG}${NC}\n"
+    printf "  ${GREEN}OK: ${image}:latest${NC}\n"
   fi
 done
 
@@ -493,7 +479,7 @@ if [ -n "$MISSING_IMAGES" ]; then
 
   STILL_MISSING=""
   for image in $MISSING_IMAGES; do
-    if ! image_exists "$image" "$IMG_TAG"; then
+    if ! image_exists "$image" "latest"; then
       STILL_MISSING="$STILL_MISSING $image"
     fi
   done
@@ -645,7 +631,7 @@ if [ -z "$SEARCH_INTERNAL_TOKEN" ]; then
   printf "  ${GREEN}Generated new search internal token.${NC}\n"
 fi
 
-IMAGE_TAG="$IMG_TAG"
+IMAGE_TAG="latest"
 
 # Write helm values to a temp file (avoids fragile eval + string concatenation)
 HELM_VALUES_FILE=$(mktemp /tmp/omnivec-helm-values.XXXXXX.yaml)
@@ -737,19 +723,10 @@ run_helm_deploy() {
     set -- "$@" --set "blobIngestor.enabled=false"
   fi
 
-  # Image tag channel (IMG_TAG resolved earlier from OMNIVEC_IMAGE_TAG or git branch).
-  set -- "$@" \
-    --set "web.image.tag=${IMG_TAG}" \
-    --set "api.image.tag=${IMG_TAG}" \
-    --set "search.image.tag=${IMG_TAG}" \
-    --set "controller.image.tag=${IMG_TAG}" \
-    --set "changefeed.image.tag=${IMG_TAG}" \
-    --set "blobEnumerator.image.tag=${IMG_TAG}" \
-    --set "sourceWorker.image.tag=${IMG_TAG}" \
-    --set "dotnetWorker.image.tag=${IMG_TAG}" \
-    --set "blobWatcher.image.tag=${IMG_TAG}" \
-    --set "docgrok.docgrok.image.tag=${IMG_TAG}" \
-    --set "docgrok.pipelineWorker.image.tag=${IMG_TAG}"
+  # Image tags are NOT overridden here — postprovision imports every image
+  # into the env-specific ACR tagged :latest (regardless of source channel),
+  # so the default values.yaml (image.tag: latest) resolves correctly for
+  # every service, including any future one we forget to wire up.
 
   # Intentionally NO --atomic: on failure, --atomic runs `helm uninstall`, which
   # strips the release metadata but can leave Deployments/Services behind (they

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -450,6 +450,20 @@ else
   printf "${GREEN}Image import complete: $import_count imported, $skip_count skipped.${NC}\n"
   if [ "$import_count" -gt 0 ]; then IMAGES_CHANGED=true; fi
 
+  # Belt-and-suspenders: also alias each imported image as :latest in the env
+  # ACR so any helm deployment that still references the default tag: latest
+  # (i.e. a service whose --set override we forgot to add) still finds a valid
+  # manifest. Safe no-op when IMG_TAG=latest. Failures are non-fatal.
+  if [ "$IMG_TAG" != "latest" ]; then
+    for image in $IMAGES; do
+      if image_exists "$image" "$IMG_TAG"; then
+        az acr import --name "$ACR_NAME" \
+          --source "${ACR_NAME}.azurecr.io/${image}:${IMG_TAG}" \
+          --image "${image}:latest" --force >/dev/null 2>&1 || true
+      fi
+    done
+  fi
+
   # If no images available from import, auto-fallback to build mode
   total_available=$((import_count + skip_count))
   if [ "$total_available" -eq 0 ]; then
@@ -732,6 +746,7 @@ run_helm_deploy() {
     --set "changefeed.image.tag=${IMG_TAG}" \
     --set "blobEnumerator.image.tag=${IMG_TAG}" \
     --set "sourceWorker.image.tag=${IMG_TAG}" \
+    --set "dotnetWorker.image.tag=${IMG_TAG}" \
     --set "blobWatcher.image.tag=${IMG_TAG}" \
     --set "docgrok.docgrok.image.tag=${IMG_TAG}" \
     --set "docgrok.pipelineWorker.image.tag=${IMG_TAG}"


### PR DESCRIPTION
Instead of mirroring the source channel tag (`:stable`/`:dev`) into the env ACR and then overriding every helm `*.image.tag`, retag during import:

```
az acr import --source <common>:IMG_TAG --image <env-acr>:latest
```

**Benefits:**
- Helm default (`image.tag: latest`) resolves for every service — no drift between the `--set` list and the chart. Was the root cause of the dotnet-worker ErrImagePull.
- One knob (`OMNIVEC_IMAGE_TAG` / branch) decides what gets pulled. What gets deployed is always `:latest` inside the env ACR.
- Future services need zero wiring in postprovision.

Supersedes the belt-and-suspenders `:latest` alias loop from #115.