### PR TITLE
fix(postprovision.ps1): remove dangling braces from alias-loop cleanup

### DIFF
--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -367,9 +367,6 @@ if ($DO_BUILD) {
     Write-Host "`e[32mImage import complete: $importCount imported, $skipCount skipped.`e[0m"
     $script:imagesChanged = $importCount -gt 0
 
-        }
-    }
-
     # If import yielded no usable images, auto-fallback to source builds
     $totalAvailable = $importCount + $skipCount
     if ($totalAvailable -eq 0) {


### PR DESCRIPTION
PR #116's regex removal left two orphan } at lines 370-371, causing 'Try statement is missing its Catch or Finally block'. PS tokenizer now confirms clean parse.