### PR TITLE
fix(hooks): robust azd env handling, IMG_TAG validation, token whitespace strip

### DIFF
--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -138,7 +138,7 @@ $IMAGES = @(
 # 1. Explicit OMNIVEC_IMAGE_TAG (azd env) wins.
 # 2. Auto-detect from current git branch: dev -> dev, main -> stable.
 # 3. Fallback -> stable.
-$IMG_TAG = (& azd env get-value OMNIVEC_IMAGE_TAG 2>$null)
+$IMG_TAG = Get-AzdValue "OMNIVEC_IMAGE_TAG"
 if ([string]::IsNullOrWhiteSpace($IMG_TAG)) {
     $_branch = ""
     try { $_branch = (git -C "$PSScriptRoot\.." rev-parse --abbrev-ref HEAD 2>$null) } catch {}
@@ -148,6 +148,12 @@ if ([string]::IsNullOrWhiteSpace($IMG_TAG)) {
         default { $IMG_TAG = "stable" }
     }
     Write-Host "`e[36mAuto-detected branch '$($_branch -replace '^$','unknown')' -> image tag '$IMG_TAG'`e[0m"
+}
+# Validate: docker tag = alnum + . _ -
+if ($IMG_TAG -notmatch '^[A-Za-z0-9._-]+$') {
+    Write-Host "`e[31mERROR: OMNIVEC_IMAGE_TAG='$IMG_TAG' is not a valid image tag.`e[0m"
+    Write-Host "`e[31mFix: azd env set OMNIVEC_IMAGE_TAG stable  (or 'dev')`e[0m"
+    exit 1
 }
 
 function Test-ImageExists {
@@ -281,7 +287,9 @@ if (-not $DO_BUILD) {
         # Prompt for token if nothing worked
         if (-not $tokenOk) {
             Write-Host "  `e[33mRegistry token required for import.`e[0m"
-            $newToken = (Read-Host "  Enter token for $SHARED_REGISTRY (or Enter to build from source)").Trim()
+            $newToken = (Read-Host "  Enter token for $SHARED_REGISTRY (or Enter to build from source)")
+            # Strip ALL whitespace (paste can inject CR/LF/tabs/spaces). Valid tokens have none.
+            $newToken = ("$newToken" -replace '\s', '')
             if ($newToken) {
                 $testResult = az acr import --name $ACR_NAME --source "${SHARED_REGISTRY}/$($IMAGES[0]):$IMG_TAG" --image "$($IMAGES[0]):latest" --username $SHARED_REGISTRY_USER --password $newToken --force 2>&1
                 if ($LASTEXITCODE -eq 0) {

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -69,8 +69,13 @@ get_azd_value() {
   val=$(eval echo "\${$key:-}")
   val=$(printf '%s' "$val" | tr -d '\r')
   if [ -n "$val" ]; then echo "$val"; return 0; fi
-  # Fallback: read from azd env store (use && to suppress stdout errors)
-  val=$(azd env get-value "$key" < /dev/null 2>/dev/null) && val=$(printf '%s' "$val" | tr -d '\r') || val=""
+  # Fallback: read from azd env store. azd returns exit 0 even for missing
+  # keys and prints "ERROR: key not found..." to stdout, so we must filter.
+  val=$(azd env get-value "$key" < /dev/null 2>/dev/null) || val=""
+  val=$(printf '%s' "$val" | tr -d '\r')
+  case "$val" in
+    ERROR*|*"not found"*) val="" ;;
+  esac
   if [ -n "$val" ]; then echo "$val"; return 0; fi
   echo ""
 }
@@ -186,6 +191,15 @@ if [ -z "$IMG_TAG" ]; then
   esac
   printf "${CYAN}Auto-detected branch '${_branch:-unknown}' -> image tag '${IMG_TAG}'${NC}\n" >&2
 fi
+# Validate IMG_TAG: must be a valid docker tag (alnum, dash, dot, underscore).
+# Prevents garbage values (e.g. error messages) from being spliced into commands.
+case "$IMG_TAG" in
+  *[!A-Za-z0-9._-]*|'')
+    printf "${RED}ERROR: OMNIVEC_IMAGE_TAG='%s' is not a valid image tag.${NC}\n" "$IMG_TAG" >&2
+    printf "${RED}Fix: azd env set OMNIVEC_IMAGE_TAG stable (or 'dev')${NC}\n" >&2
+    exit 1
+    ;;
+esac
 
 image_exists() {
   name=$1
@@ -337,6 +351,9 @@ if [ "$OMNIVEC_BUILD" != "true" ] && [ "$SKIP_IMPORT" != "true" ] && [ "$SKIP_IM
       if [ "$TOKEN_OK" = "false" ]; then
         printf "  ${YELLOW}Registry token required for import.${NC}\n"
         _new_token=$(read_input "  Enter token for $SHARED_REGISTRY (or Enter to build from source): ")
+        # Strip ALL whitespace (leading, trailing, and any embedded CR/LF/tabs/spaces from paste).
+        # Valid ACR tokens are base64-ish and contain no whitespace.
+        _new_token=$(printf '%s' "$_new_token" | tr -d '[:space:]')
         if [ -n "$_new_token" ]; then
           if az acr import --name "$ACR_NAME" --source "${SHARED_REGISTRY}/${FIRST_IMAGE}:${IMG_TAG}" --image "${FIRST_IMAGE}:latest" --username "$SHARED_REGISTRY_USER" --password "$_new_token" --force >/dev/null 2>&1; then
             SHARED_REGISTRY_TOKEN="$_new_token"

--- a/hooks/preprovision.ps1
+++ b/hooks/preprovision.ps1
@@ -608,13 +608,14 @@ $envKeys = @("OMNIVEC_SYSTEM_NODE_VM_SIZE", "OMNIVEC_SYSTEM_NODE_COUNT", "OMNIVE
 foreach ($key in $envKeys) {
     $ErrorActionPreference = "SilentlyContinue"
     $raw = azd env get-value $key 2>$null
+    $ec = $LASTEXITCODE
     $ErrorActionPreference = "Stop"
-    if ($raw) {
-        $clean = $raw -replace '[\t\r]','' -replace '^\xEF\xBB\xBF','' -replace '^\s+|\s+$',''
-        if ($clean -ne $raw) {
-            azd env set $key $clean
-            Write-Host "  `e[33mCleaned ${key}: removed hidden characters`e[0m"
-        }
+    # Skip missing keys or azd error-text responses
+    if ($ec -ne 0 -or -not $raw -or "$raw" -match "^\s*ERROR" -or "$raw" -match "not found") { continue }
+    $clean = $raw -replace '[\t\r\n]','' -replace '^\xEF\xBB\xBF','' -replace '^"|"$','' -replace '^\s+|\s+$',''
+    if ($clean -ne $raw) {
+        azd env set $key $clean
+        Write-Host "  `e[33mCleaned ${key}: removed hidden characters`e[0m"
     }
 }
 


### PR DESCRIPTION
**Three related robustness fixes for the hooks:**

### 1. `azd env get-value` error-text leaks into values (postprovision.sh + .ps1)
azd returns exit 0 even for missing keys and prints `ERROR: key not found...` to stdout. Callers that didn't filter got the error text as the value, which was then spliced into `az acr import --source <registry>/<ERROR_TEXT>...`.

### 2. Strict IMG_TAG validation (postprovision.sh + .ps1)
After resolving IMG_TAG, reject anything that isn't a valid docker tag regex (`^[A-Za-z0-9._-]+$`). Fails fast with a clear message instead of silently splicing garbage:
```
ERROR: OMNIVEC_IMAGE_TAG='...' is not a valid image tag.
Fix: azd env set OMNIVEC_IMAGE_TAG stable
```

### 3. Registry token whitespace (postprovision.sh + .ps1)
Pasted tokens can carry invisible CR/LF/tabs/spaces from terminals. Valid ACR tokens contain no whitespace, so strip all of it before use. Previously `.sh` didn't trim at all and `.ps1` only did leading/trailing.

Also hardens preprovision.ps1 sanitize loop to filter ERROR text.