### PR TITLE
fix(hooks): sync functional bug fixes between .sh and .ps1 (parity)

### DIFF
--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -447,7 +447,7 @@ if ($LASTEXITCODE -ne 0) { Write-Host "`e[31mFailed to create namespace docgrok`
 kubectl --context $KUBE_CONTEXT label namespace omnivec app.kubernetes.io/managed-by=Helm --overwrite | Out-Null
 kubectl --context $KUBE_CONTEXT annotate namespace omnivec meta.helm.sh/release-name=omnivec meta.helm.sh/release-namespace=omnivec --overwrite | Out-Null
 
-if ($ENABLE_BLOB_SOURCE -eq "true" -and $STORAGE_ACCOUNT) {
+if ($ENABLE_BLOB_SOURCE -eq "true") {
     kubectl --context $KUBE_CONTEXT create secret generic omnivec-storage `
         --namespace omnivec `
         --from-literal=account-name="$STORAGE_ACCOUNT" `
@@ -555,6 +555,12 @@ if ($KEYVAULT_URI) {
 if ($APPINSIGHTS_CS) {
     $helmArgs += @(
         "--set", "azure.appInsights.connectionString=$APPINSIGHTS_CS"
+    )
+}
+
+if ($LOG_ANALYTICS_WS) {
+    $helmArgs += @(
+        "--set", "azure.appInsights.workspaceId=$LOG_ANALYTICS_WS"
     )
 }
 

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -39,6 +39,28 @@ case "$_env_name" in
     ;;
 esac
 
+# ── Repair .env if prior run left embedded newlines / stray quotes ──────────
+# Symptom: `loading .env: unexpected character "\"" in variable name near "...\n"`
+# Cause: a previous azd env set wrote a multi-line value; subsequent runs can't parse it.
+_env_file=".azure/${_env_name}/.env"
+if [ -f "$_env_file" ] && command -v python3 >/dev/null 2>&1; then
+  python3 - "$_env_file" <<'PYEOF' || true
+import re, sys
+p = sys.argv[1]
+with open(p, 'r', encoding='utf-8', errors='replace') as f:
+    raw = f.read()
+# Collapse CR/LF/TAB inside any quoted value of form KEY="...".
+def clean(m):
+    k = m.group(1); v = re.sub(r'[\r\n\t]+', '', m.group(2)).strip()
+    return f'{k}="{v}"'
+repaired = re.sub(r'(?ms)^([A-Z_][A-Z0-9_]*)="([^"]*)"', clean, raw)
+if repaired != raw:
+    with open(p, 'w', encoding='utf-8', newline='\n') as f:
+        f.write(repaired)
+    print('Repaired corrupt .env (stripped embedded whitespace from values).')
+PYEOF
+fi
+
 # ── Deployment lock: prevent concurrent azd up/down for the same env ────────
 LOCK_DIR="${HOME}/.omnivec/locks"
 mkdir -p "$LOCK_DIR"
@@ -83,9 +105,16 @@ trap 'release_lock' EXIT INT TERM
 
 acquire_lock
 
-# Helper: safely read an azd env value, returns empty string on failure
+# Helper: safely read an azd env value, returns empty string on failure.
+# azd env get-value returns exit 0 even for missing keys and prints
+# "ERROR: key not found..." to stdout, so we must filter that out.
 azd_get() {
-  _val=$(azd env get-value "$1" < /dev/null 2>/dev/null) && printf '%s' "$_val" | tr -d '\r' || printf ''
+  _val=$(azd env get-value "$1" < /dev/null 2>/dev/null) || _val=""
+  _val=$(printf '%s' "$_val" | tr -d '\r')
+  case "$_val" in
+    ERROR*|*"not found"*) _val="" ;;
+  esac
+  printf '%s' "$_val"
 }
 
 # Helper: can we actually prompt the user right now?
@@ -412,7 +441,7 @@ echo ""
 printf "${YELLOW}Configure AKS node pools:${NC}\n"
 echo ""
 
-LOCATION="${AZURE_LOCATION:-centralus}"
+LOCATION="${AZURE_LOCATION:-eastus2}"
 
 # Helper: validate a single SKU in the location
 validate_sku() {


### PR DESCRIPTION
Audit surfaced 9 parity drifts between `postprovision.{sh,ps1}` and `preprovision.{sh,ps1}`. This PR fixes the HIGH-severity functional bugs and defers structural refactors.

### Fixed in this PR

**postprovision.ps1:**
- Add `LOG_ANALYTICS_WS` helm `--set` (missing from helmArgs; present in .sh line 727-729). App Insights workspace wiring was dropped on Windows runs.
- Fix `omnivec-storage` secret condition: drop the redundant `-and $STORAGE_ACCOUNT` guard so it matches .sh behavior (creates secret whenever blob source is enabled).

**preprovision.sh:**
- Filter `ERROR: key not found` from `azd_get` - same bug that bit us in .ps1 (PR #119). azd exits 0 with error text on stdout for missing keys.
- Default region to `eastus2` (matches .ps1 line 412-413).
- Add `.env` repair pre-scan (matches .ps1 PR #117). Uses python3, silently skipped if absent.

### Deferred (not currently blocking)
- Helm retry wrapper, orphan adoption, `OMNIVEC_SKIP_IMPORT`, dedicated kubeconfig wrapper in .ps1
- GPU SKU validation loop, prompt timeout in .sh