### PR TITLE
feat: image and video search end-to-end via CLIP

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -419,6 +419,12 @@ EVENT_QUEUE: asyncio.Queue = None
 # =============================================================================
 
 DOCGROK_URL = os.getenv("DOCGROK_URL", "http://docgrok:80")
+PIPELINE_WORKER_URL = os.getenv("PIPELINE_WORKER_URL", "http://pipeline-worker-svc:8080")
+# When True, all pipeline-worker reads/writes go through the docgrok router so
+# every request leaves api/ via a single hop. The router proxies /transforms*,
+# /pipeline/recipe, /pipeline/stages/catalog, /process, /process/blob.
+ROUTE_PIPELINE_VIA_DOCGROK = os.getenv("ROUTE_PIPELINE_VIA_DOCGROK", "true").lower() == "true"
+PIPELINE_WORKER_BASE = DOCGROK_URL if ROUTE_PIPELINE_VIA_DOCGROK else PIPELINE_WORKER_URL
 SEARCH_SERVICE_URL = os.getenv("SEARCH_SERVICE_URL", "http://omnivec-search").rstrip("/")
 SEARCH_INTERNAL_TOKEN = os.getenv("SEARCH_INTERNAL_TOKEN", "")
 
@@ -1997,7 +2003,183 @@ async def _validate_docgrok_ref(docgrok_ref: str) -> str:
         # Mock pipelines for testing
         return docgrok_ref
     else:
-        raise HTTPException(status_code=400, detail=f"Invalid DocGrok reference '{docgrok_ref}'. Must be a model ID (mdl-ext-*, mdl-native-*) or transform pipeline (trp-*)")
+        # Treat any other ref as a transform-pipeline name (e.g. built-ins
+        # like image-transform / video-transform / text-transform). Validate
+        # by asking the docgrok router.
+        try:
+            resp = await http_client.get(f"{PIPELINE_WORKER_BASE}/transforms/{docgrok_ref}", timeout=5.0)
+            if resp.status_code != 200:
+                raise HTTPException(status_code=400, detail=f"Invalid DocGrok reference '{docgrok_ref}'. Must be a model ID (mdl-*), trp-*, or known transform-pipeline name.")
+        except httpx.RequestError as e:
+            raise HTTPException(status_code=503, detail=f"Cannot connect to docgrok: {str(e)}")
+        return docgrok_ref
+
+
+async def _resolve_docgrok_output_dim(docgrok_ref: str) -> Optional[int]:
+    """Resolve the embedding dimension that the given pipeline ref will emit.
+
+    Returns None when the dim cannot be determined (e.g. a text/pdf transform
+    whose embed-stage model_id is decided at runtime). When None, the caller
+    should not enforce a dim match at pipeline-creation time."""
+    if docgrok_ref.startswith("mdl-"):
+        store = get_store()
+        try:
+            doc = await asyncio.to_thread(store.get, docgrok_ref, "docgrok_model")
+            if doc:
+                d = doc.get("dimensions") or doc.get("embedding_dim")
+                if d:
+                    return int(d)
+        except Exception:
+            pass
+        return None
+    if docgrok_ref in ("mock-embedding", "mock-1536"):
+        try:
+            return int(os.getenv("MOCK_EMBEDDING_DIM", "1536"))
+        except Exception:
+            return 1536
+    # Transform pipeline by name — ask the router. Built-ins like
+    # image-transform / video-transform declare `output_dimensions: 768`.
+    try:
+        resp = await http_client.get(f"{PIPELINE_WORKER_BASE}/transforms/{docgrok_ref}", timeout=5.0)
+        if resp.status_code == 200:
+            tdef = resp.json() or {}
+            d = tdef.get("output_dimensions")
+            if d:
+                return int(d)
+    except Exception:
+        pass
+    return None
+
+
+def _resolve_destination_dim(dest_doc: Optional[dict], vector_index_path: Optional[str]) -> Optional[int]:
+    """Return the declared dim of a destination's vector_index_path (or
+    its top-level vector_dimensions). None if not declared."""
+    if not dest_doc:
+        return None
+    cfg = dest_doc.get("config", {}) or {}
+    if vector_index_path:
+        target = vector_index_path.lstrip("/")
+        for vi in cfg.get("vector_indexes", []) or []:
+            if (vi.get("path") or "").lstrip("/") == target:
+                d = vi.get("dimensions")
+                if d:
+                    return int(d)
+    d = cfg.get("vector_dimensions")
+    return int(d) if d else None
+
+
+async def _enforce_pipeline_dim_match(docgrok_ref: str, dest_doc: dict, vector_index_path: str) -> None:
+    """Raise 400 if the model/transform output dim is known and conflicts with
+    the destination's declared vector dim. If either side is unknown, allow
+    (worker's runtime check will skip mismatched rows)."""
+    pipe_dim = await _resolve_docgrok_output_dim(docgrok_ref)
+    dest_dim = _resolve_destination_dim(dest_doc, vector_index_path)
+    if pipe_dim and dest_dim and int(pipe_dim) != int(dest_dim):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Embedding-dim mismatch: model/transform '{docgrok_ref}' emits "
+                f"{pipe_dim}-dim vectors but destination's vector index "
+                f"'/{(vector_index_path or '').lstrip('/')}' expects {dest_dim}-dim. "
+                f"Pick a destination/index whose dimensions match, or use a different "
+                f"model/transform."
+            ),
+        )
+
+
+def _is_inline_compatible(store, pipeline_sources, dest_doc) -> bool:
+    """Return True iff every source points at the same physical store as the destination."""
+    if not dest_doc:
+        return False
+    dtype = dest_doc.get("type")
+    dcfg = dest_doc.get("config", {}) or {}
+    for ps in pipeline_sources or []:
+        sid = ps.source_id if hasattr(ps, "source_id") else (ps.get("source_id") if isinstance(ps, dict) else None)
+        if not sid:
+            return False
+        src_doc = store.get(sid, "source")
+        if not src_doc:
+            return False
+        stype = src_doc.get("type")
+        scfg = src_doc.get("config", {}) or {}
+        if dtype == "cosmosdb-vector" and stype == "cosmosdb":
+            if not (
+                (scfg.get("endpoint") or "").rstrip("/") == (dcfg.get("endpoint") or "").rstrip("/")
+                and scfg.get("database") == dcfg.get("database")
+                and scfg.get("container") == dcfg.get("container")
+            ):
+                return False
+        elif dtype == "pgvector" and stype == "pgvector":
+            if not (
+                scfg.get("host") == dcfg.get("host")
+                and scfg.get("database") == dcfg.get("database")
+                and scfg.get("table") == dcfg.get("table")
+            ):
+                return False
+        else:
+            return False
+    return True
+
+
+def _require_inline_compatible(store, pipeline_sources, dest_doc):
+    """Raise 400 unless every source points at the same physical store as the
+    destination. Inline processing writes embeddings back into the source docs
+    in-place, so the source container/table must equal the destination's."""
+    if not dest_doc:
+        return
+    dtype = dest_doc.get("type")
+    dcfg = dest_doc.get("config", {}) or {}
+    for ps in pipeline_sources or []:
+        sid = ps.source_id if hasattr(ps, "source_id") else (ps.get("source_id") if isinstance(ps, dict) else None)
+        if not sid:
+            continue
+        src_doc = store.get(sid, "source")
+        if not src_doc:
+            continue
+        stype = src_doc.get("type")
+        scfg = src_doc.get("config", {}) or {}
+
+        if dtype == "cosmosdb-vector" and stype == "cosmosdb":
+            same = (
+                (scfg.get("endpoint") or "").rstrip("/") == (dcfg.get("endpoint") or "").rstrip("/")
+                and scfg.get("database") == dcfg.get("database")
+                and scfg.get("container") == dcfg.get("container")
+            )
+            if not same:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Inline processing mode requires the source and destination to point at the same "
+                        f"Cosmos DB container. Source '{sid}' -> {scfg.get('database')}/{scfg.get('container')} "
+                        f"differs from destination {dcfg.get('database')}/{dcfg.get('container')}. "
+                        "Use 'queue' mode, or align source/destination to the same container."
+                    ),
+                )
+        elif dtype == "pgvector" and stype == "pgvector":
+            same = (
+                scfg.get("host") == dcfg.get("host")
+                and scfg.get("database") == dcfg.get("database")
+                and scfg.get("table") == dcfg.get("table")
+            )
+            if not same:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Inline processing mode requires source and destination to point at the same "
+                        f"pgvector table. Source '{sid}' -> {scfg.get('database')}.{scfg.get('table')} "
+                        f"differs from destination {dcfg.get('database')}.{dcfg.get('table')}."
+                    ),
+                )
+        else:
+            # Cross-store combinations (e.g., cosmosdb source -> pgvector dest,
+            # blob source -> anything) cannot be inline.
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Inline processing mode is not supported when source type '{stype}' differs from "
+                    f"destination type '{dtype}'. Use 'queue' processing mode instead."
+                ),
+            )
 
 
 @app.post("/api/pipelines")
@@ -2013,7 +2195,6 @@ async def create_pipeline(req: CreatePipelineRequest):
     # Reject queue mode when Service Bus wasn't provisioned (blob source disabled)
     if str(req.processing_mode or "").lower() == "queue":
         _require_blob_source_enabled("queue-mode pipeline")
-
     # Validate sources exist
     for ps in req.sources:
         if not store.get(ps.source_id, "source"):
@@ -2030,6 +2211,24 @@ async def create_pipeline(req: CreatePipelineRequest):
             detail=f"Destination '{req.destination_id}' not found"
         )
 
+    # Reject inline mode when source and destination are different stores.
+    # Inline mode writes embeddings back to source docs in-place, so the source
+    # container/table must be the same physical location as the destination.
+    if str(req.processing_mode or "").lower() == "inline":
+        _require_inline_compatible(store, req.sources, dest_doc)
+
+    # Reject queue mode when source and destination ARE the same store.
+    # Same-store pipelines must use inline (queue would be redundant).
+    if str(req.processing_mode or "").lower() == "queue":
+        if _is_inline_compatible(store, req.sources, dest_doc):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Queue processing mode cannot be used when source and destination point at the "
+                    "same container/table. Use 'inline' mode instead."
+                ),
+            )
+
     # Validate vector_index_path exists in destination's vector policies
     dest_config = dest_doc.get("config", {})
     vector_indexes = dest_config.get("vector_indexes", [])
@@ -2043,6 +2242,10 @@ async def create_pipeline(req: CreatePipelineRequest):
 
     # Validate docgrok_pipeline (must be a valid model ID or transform pipeline)
     resolved_pipeline = await _validate_docgrok_ref(req.docgrok_pipeline)
+
+    # Enforce dim match between model/transform output and destination.
+    dest_doc = await asyncio.to_thread(store.get, req.destination_id, "destination")
+    await _enforce_pipeline_dim_match(resolved_pipeline, dest_doc, req.vector_index_path)
 
     # Validate content strategy and chunk config
     content_strategy = req.content_strategy if req.content_strategy in ("truncate", "chunk") else "truncate"
@@ -2094,6 +2297,23 @@ async def update_pipeline(pipeline_id: str, req: CreatePipelineRequest):
     if str(req.processing_mode or "").lower() == "queue":
         _require_blob_source_enabled("queue-mode pipeline")
 
+    # Reject inline mode when source/destination aren't the same store.
+    if str(req.processing_mode or "").lower() == "inline":
+        dest_doc_for_mode = await asyncio.to_thread(store.get, req.destination_id, "destination")
+        _require_inline_compatible(store, req.sources, dest_doc_for_mode)
+
+    # Reject queue mode when source/destination ARE the same store.
+    if str(req.processing_mode or "").lower() == "queue":
+        dest_doc_for_queue = await asyncio.to_thread(store.get, req.destination_id, "destination")
+        if _is_inline_compatible(store, req.sources, dest_doc_for_queue):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Queue processing mode cannot be used when source and destination point at the "
+                    "same container/table. Use 'inline' mode instead."
+                ),
+            )
+
     resolved_pipeline = await _validate_docgrok_ref(req.docgrok_pipeline)
 
     # Validate vector_index_path against destination if provided
@@ -2108,6 +2328,9 @@ async def update_pipeline(pipeline_id: str, req: CreatePipelineRequest):
                     status_code=400,
                     detail=f"Vector index path '/{req.vector_index_path}' not found in destination. Available: {[f'/{p}' for p in valid_paths]}"
                 )
+
+    # Enforce dim match between model/transform output and destination.
+    await _enforce_pipeline_dim_match(resolved_pipeline, dest_doc, req.vector_index_path)
 
     pipeline = _pipeline_from_doc(doc)
 
@@ -2188,6 +2411,19 @@ def set_processing_mode(pipeline_id: str, mode: str):
     if mode == "queue":
         _require_blob_source_enabled("queue-mode pipeline")
     pipeline = _pipeline_from_doc(doc)
+    if mode == "inline":
+        dest_doc_for_mode = store.get(pipeline.destination_id, "destination")
+        _require_inline_compatible(store, pipeline.sources, dest_doc_for_mode)
+    if mode == "queue":
+        dest_doc_for_queue = store.get(pipeline.destination_id, "destination")
+        if _is_inline_compatible(store, pipeline.sources, dest_doc_for_queue):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Queue processing mode cannot be used when source and destination point at the "
+                    "same container/table. Use 'inline' mode instead."
+                ),
+            )
     pipeline.processing_mode = mode
     pipeline.updated_at = datetime.utcnow()
     store.upsert(_to_doc(pipeline, "pipeline"))
@@ -3964,6 +4200,226 @@ async def assistant_chat(assistant_id: str, req: AssistantChatRequest):
 
 
 # =============================================================================
+# PLAYGROUND SEARCH
+# =============================================================================
+
+class PlaygroundSearchRequest(BaseModel):
+    query: Optional[str] = None
+    query_image_b64: Optional[str] = None
+    destination_ids: List[str]
+    top_k: int = 5
+    merge_strategy: str = "rrf"  # rrf | interleave | score
+
+
+async def _build_index_specs(destination_ids: List[str]) -> tuple[List[Dict[str, Any]], List[str]]:
+    """Build IndexSpec[] for a set of destination ids by joining with pipelines.
+    Returns (indexes, warnings)."""
+    warnings: List[str] = []
+    indexes: List[Dict[str, Any]] = []
+    store = get_store()
+    pipeline_docs = await asyncio.to_thread(store.list, "pipeline")
+    for dest_id in destination_ids:
+        dest_doc = await asyncio.to_thread(store.get, dest_id, "destination")
+        if not dest_doc:
+            warnings.append(f"destination {dest_id} not found")
+            continue
+        matched_pip = next((pd for pd in pipeline_docs if pd.get("destination_id") == dest_id), None)
+        if not matched_pip:
+            warnings.append(f"destination {dest_id} has no pipeline (cannot embed query)")
+            continue
+        model_ref = matched_pip.get("docgrok_pipeline")
+        if not model_ref:
+            warnings.append(f"pipeline for {dest_id} has no model/pipeline reference")
+            continue
+
+        cf = ["content"]
+        sources = matched_pip.get("sources", [])
+        if sources and isinstance(sources[0], dict):
+            cf = sources[0].get("content_fields", ["content"]) or ["content"]
+
+        if model_ref.startswith("mdl-"):
+            embedding = {"policy": "model", "model_id": model_ref}
+        else:
+            embedding = {"policy": "pipeline", "pipeline": model_ref}
+        # Tag image/video transforms so the search layer routes the query
+        # through the image-embedding path (CLIP) instead of text.
+        if model_ref in ("image-transform", "video-transform"):
+            embedding["input_modality"] = "image"
+
+        dtype = dest_doc.get("type")
+        cfg = dest_doc.get("config", {}) or {}
+        # Inline processing writes embeddings to the SOURCE container in-place;
+        # the destination container stays empty. Redirect the search at the source.
+        pmode = (matched_pip.get("processing_mode") or "").lower()
+        inline_override_container = None
+        inline_override_endpoint = None
+        inline_override_database = None
+        if pmode == "inline" and dtype == "cosmosdb-vector":
+            try:
+                pip_sources = matched_pip.get("sources", []) or []
+                src_id = pip_sources[0].get("source_id") if pip_sources else None
+                if src_id:
+                    src_doc = await asyncio.to_thread(store.get, src_id, "source")
+                    scfg = (src_doc or {}).get("config", {}) or {}
+                    if (src_doc or {}).get("type") == "cosmosdb" and scfg.get("container"):
+                        inline_override_container = scfg.get("container")
+                        inline_override_endpoint = scfg.get("endpoint") or cfg.get("endpoint", "")
+                        inline_override_database = scfg.get("database") or cfg.get("database", "")
+            except Exception as e:
+                warnings.append(f"inline source lookup failed for {dest_id}: {e}")
+        if dtype == "cosmosdb-vector":
+            vf = (matched_pip.get("vector_index_path") or "").lstrip("/") or cfg.get("vector_field", "embedding")
+            # Resolve dims: prefer top-level vector_dimensions, fall back to the
+            # matching vector_indexes[].dimensions entry (that's where the UI
+            # actually stores dims for cosmosdb-vector destinations).
+            dims = cfg.get("vector_dimensions")
+            if not dims:
+                for vi in (cfg.get("vector_indexes") or []):
+                    vi_path = (vi.get("path") or "").lstrip("/")
+                    if vi_path == vf or not dims:
+                        d = vi.get("dimensions")
+                        if d:
+                            dims = d
+                            if vi_path == vf:
+                                break
+            dims = dims or 1024
+            indexes.append({
+                "id": dest_id,
+                "store": {
+                    "type": "cosmosdb",
+                    "endpoint": inline_override_endpoint or cfg.get("endpoint", ""),
+                    "database": inline_override_database or cfg.get("database", ""),
+                    "container": inline_override_container or cfg.get("container", ""),
+                    "auth": {"mode": "managed_identity"},
+                },
+                "vector": {"field": vf, "dims": dims, "metric": "cosine"},
+                "embedding": embedding,
+                "content_fields": cf,
+            })
+        elif dtype == "pgvector":
+            indexes.append({
+                "id": dest_id,
+                "store": {
+                    "type": "pgvector",
+                    "host": cfg.get("host", ""),
+                    "port": cfg.get("port", 5432),
+                    "database": cfg.get("database", ""),
+                    "user": cfg.get("user"),
+                    "password": cfg.get("password"),
+                    "ssl_mode": cfg.get("ssl_mode", "require"),
+                    "table": cfg.get("table", ""),
+                    "id_column": cfg.get("id_column", "id"),
+                    "content_column": cfg.get("content_column", "content"),
+                },
+                "vector": {"field": cfg.get("vector_column", "embedding"), "dims": cfg.get("vector_dimensions", 1024), "metric": "cosine"},
+                "embedding": embedding,
+                "content_fields": cf,
+            })
+        else:
+            warnings.append(f"destination {dest_id} has unsupported type '{dtype}' for search")
+    return indexes, warnings
+
+
+@app.post("/api/playground/search")
+async def playground_search(req: PlaygroundSearchRequest):
+    """Vector search playground. Resolves destination_ids to IndexSpec[] and
+    delegates to the omnivec-search service."""
+    import time
+    has_text = bool(req.query and req.query.strip())
+    has_image = bool(req.query_image_b64)
+    if not has_text and not has_image:
+        raise HTTPException(status_code=400, detail="query or query_image_b64 is required")
+    if not req.destination_ids:
+        raise HTTPException(status_code=400, detail="destination_ids is required")
+    if not SEARCH_INTERNAL_TOKEN:
+        raise HTTPException(status_code=503, detail="Search service not configured (SEARCH_INTERNAL_TOKEN missing)")
+
+    indexes, warnings = await _build_index_specs(req.destination_ids)
+    if not indexes:
+        raise HTTPException(
+            status_code=400,
+            detail="No searchable indexes resolved from destination_ids: " + "; ".join(warnings))
+
+    # Map UI merge strategy to search-service merge spec.
+    # Search service accepts: rrf | score | round_robin | per_index
+    # UI uses "interleave" as an alias for round_robin.
+    ui_strategy = (req.merge_strategy or "rrf").lower()
+    strategy_map = {
+        "rrf": "rrf",
+        "score": "score",
+        "interleave": "round_robin",
+        "round_robin": "round_robin",
+        "per_index": "per_index",
+    }
+    merge_strategy = strategy_map.get(ui_strategy, "rrf")
+    merge_spec = {"strategy": merge_strategy}
+
+    # Build lookup of destination metadata for enriching the response with names.
+    store = get_store()
+    dest_name_map: Dict[str, str] = {}
+    for dest_id in req.destination_ids:
+        dd = await asyncio.to_thread(store.get, dest_id, "destination")
+        if dd:
+            dest_name_map[dest_id] = dd.get("name") or dest_id
+
+    payload = {
+        "query": req.query,
+        "query_image_b64": req.query_image_b64,
+        "top_k": req.top_k,
+        "indexes": indexes,
+        "merge": merge_spec,
+        "include": {"vectors": False, "scores": True},
+        "request_id": f"pg-{int(time.time())}",
+    }
+
+    try:
+        sresp = await http_client.post(
+            f"{SEARCH_SERVICE_URL}/search",
+            json=payload,
+            headers={"Authorization": f"Bearer {SEARCH_INTERNAL_TOKEN}"},
+            timeout=30.0,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Search service unreachable: {e}")
+
+    if sresp.status_code != 200:
+        raise HTTPException(
+            status_code=sresp.status_code,
+            detail=f"Search service error: {sresp.text[:500]}")
+
+    data = sresp.json() or {}
+    results = data.get("results", []) or []
+    per_index = data.get("per_index", []) or []
+    timing = data.get("timing_ms", {}) or {}
+
+    # Enrich each result with a friendly index_name (destination name).
+    for r in results:
+        idx_id = r.get("index_id")
+        if idx_id and idx_id in dest_name_map:
+            r["index_name"] = dest_name_map[idx_id]
+
+    indexes_searched = [
+        {
+            "index_id": pi.get("index_id"),
+            "index_name": dest_name_map.get(pi.get("index_id"), pi.get("index_id")),
+            "result_count": pi.get("result_count", 0),
+            "search_time_ms": pi.get("search_ms", 0),
+            "error": pi.get("error"),
+        }
+        for pi in per_index
+    ]
+
+    merged_warnings = warnings + (data.get("warnings") or [])
+
+    return {
+        "results": results,
+        "indexes_searched": indexes_searched,
+        "total_search_time_ms": timing.get("total", 0),
+        "warnings": merged_warnings,
+    }
+
+
+# =============================================================================
 # DOCGROK PROXY
 # =============================================================================
 
@@ -3985,6 +4441,206 @@ async def get_docgrok_pipeline_options():
         return resp.json()
     except Exception as e:
         raise HTTPException(status_code=503, detail=f"DocGrok error: {str(e)}")
+
+
+@app.get("/api/docgrok/pipelines/default-recipe")
+async def get_docgrok_default_recipe():
+    """Return the built-in pipeline-worker default declarative pipeline.
+
+    A pipeline is an ordered list of high-level stages (filter, extract,
+    chunk, embed, …) drawn from /api/docgrok/pipelines/stage-catalog,
+    each with its own config block.
+    """
+    try:
+        resp = await http_client.get(f"{PIPELINE_WORKER_BASE}/pipeline/recipe", timeout=5.0)
+        if resp.status_code != 200:
+            raise HTTPException(status_code=resp.status_code,
+                                detail=f"pipeline-worker /pipeline/recipe returned {resp.status_code}")
+        return resp.json()
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"pipeline-worker error: {str(e)}")
+
+
+@app.get("/api/docgrok/pipelines/stage-catalog")
+async def get_docgrok_stage_catalog():
+    """Return the catalog of reusable transformation stage types and
+    their config schemas (filter, extract, chunk, embed)."""
+    try:
+        resp = await http_client.get(f"{PIPELINE_WORKER_BASE}/pipeline/stages/catalog", timeout=5.0)
+        if resp.status_code != 200:
+            raise HTTPException(status_code=resp.status_code,
+                                detail=f"pipeline-worker /pipeline/stages/catalog returned {resp.status_code}")
+        return resp.json()
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"pipeline-worker error: {str(e)}")
+
+
+@app.get("/api/docgrok/transforms")
+async def list_docgrok_transforms():
+    """Return all transform pipelines: built-ins from pipeline-worker
+    merged with user-defined transforms persisted in Cosmos.
+
+    Each transform is atomic — single input shape (`applies_to`),
+    terminal `embed` stage, one vector schema. Ingestion pipelines bind
+    an ordered list of transforms; the dispatcher picks the first
+    matching one for each blob.
+    """
+    builtins: list = []
+    try:
+        resp = await http_client.get(f"{PIPELINE_WORKER_BASE}/transforms", timeout=5.0)
+        if resp.status_code == 200:
+            j = resp.json()
+            builtins = j.get("transforms") or []
+            for t in builtins:
+                t["source"] = "builtin"
+    except Exception as e:
+        logger.warning("pipeline-worker /transforms unreachable: %s", e)
+
+    user: list = []
+    try:
+        store = get_store()
+        docs = await asyncio.to_thread(store.list, "docgrok_transform")
+        for d in docs or []:
+            d.pop("doc_type", None)
+            d["source"] = "user"
+            user.append(d)
+    except Exception as e:
+        logger.warning("Cosmos list docgrok_transform failed: %s", e)
+
+    return {"transforms": builtins + user, "builtin_count": len(builtins), "user_count": len(user)}
+
+
+@app.get("/api/docgrok/transforms/stage-catalog")
+async def get_docgrok_transform_stage_catalog():
+    """Catalog of reusable stage types available to transform pipelines."""
+    try:
+        resp = await http_client.get(f"{PIPELINE_WORKER_BASE}/pipeline/stages/catalog", timeout=5.0)
+        if resp.status_code != 200:
+            raise HTTPException(status_code=resp.status_code, detail=f"stage-catalog HTTP {resp.status_code}")
+        return resp.json()
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"pipeline-worker error: {str(e)}")
+
+
+@app.get("/api/docgrok/transforms/{name}")
+async def get_docgrok_transform(name: str):
+    """Return a single transform by name (built-in or user-defined)."""
+    try:
+        resp = await http_client.get(f"{PIPELINE_WORKER_BASE}/transforms/{name}", timeout=5.0)
+        if resp.status_code == 200:
+            t = resp.json()
+            t["source"] = "builtin"
+            return t
+    except Exception:
+        pass
+    try:
+        store = get_store()
+        doc = await asyncio.to_thread(store.get, name, "docgrok_transform")
+        if doc:
+            doc.pop("doc_type", None)
+            doc["source"] = "user"
+            return doc
+    except Exception as e:
+        logger.warning("Cosmos get docgrok_transform '%s' failed: %s", name, e)
+    raise HTTPException(status_code=404, detail=f"Transform '{name}' not found")
+
+
+async def _validate_user_transform(payload: dict) -> dict:
+    """Send the payload to pipeline-worker for canonical validation."""
+    try:
+        resp = await http_client.post(
+            f"{PIPELINE_WORKER_BASE}/transforms/validate", json=payload, timeout=5.0,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"pipeline-worker validate unreachable: {str(e)}")
+    if resp.status_code != 200:
+        try:
+            detail = resp.json().get("detail", resp.text)
+        except Exception:
+            detail = resp.text
+        raise HTTPException(status_code=400, detail=f"Invalid transform: {detail}")
+    return resp.json().get("transform") or payload
+
+
+@app.post("/api/docgrok/transforms")
+async def create_docgrok_transform(payload: dict):
+    """Create a user-defined transform pipeline. Validated by the worker
+    (last stage must be `embed`, all stage types must exist) and
+    persisted to Cosmos with doc_type=docgrok_transform."""
+    name = (payload.get("name") or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="name is required")
+    # Reject collisions with built-ins.
+    try:
+        resp = await http_client.get(f"{PIPELINE_WORKER_BASE}/transforms/{name}", timeout=5.0)
+        if resp.status_code == 200:
+            raise HTTPException(status_code=409, detail=f"'{name}' is a built-in transform; pick a different name")
+    except HTTPException:
+        raise
+    except Exception:
+        pass
+    validated = await _validate_user_transform(payload)
+    try:
+        store = get_store()
+        doc = {
+            **validated, "id": name, "doc_type": "docgrok_transform",
+            "stored_at": datetime.utcnow().isoformat(),
+        }
+        await asyncio.to_thread(store.upsert, doc)
+        logger.info("Created user transform '%s'", name)
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"persist failed: {str(e)}")
+    return {**validated, "source": "user"}
+
+
+@app.put("/api/docgrok/transforms/{name}")
+async def update_docgrok_transform(name: str, payload: dict):
+    """Update a user-defined transform. Built-ins are read-only."""
+    try:
+        resp = await http_client.get(f"{PIPELINE_WORKER_BASE}/transforms/{name}", timeout=5.0)
+        if resp.status_code == 200:
+            raise HTTPException(status_code=409, detail=f"'{name}' is built-in and read-only")
+    except HTTPException:
+        raise
+    except Exception:
+        pass
+    payload = {**payload, "name": name}
+    validated = await _validate_user_transform(payload)
+    try:
+        store = get_store()
+        doc = {
+            **validated, "id": name, "doc_type": "docgrok_transform",
+            "stored_at": datetime.utcnow().isoformat(),
+        }
+        await asyncio.to_thread(store.upsert, doc)
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"persist failed: {str(e)}")
+    return {**validated, "source": "user"}
+
+
+@app.delete("/api/docgrok/transforms/{name}")
+async def delete_docgrok_transform(name: str):
+    """Delete a user-defined transform. Built-ins cannot be deleted."""
+    try:
+        resp = await http_client.get(f"{PIPELINE_WORKER_BASE}/transforms/{name}", timeout=5.0)
+        if resp.status_code == 200:
+            raise HTTPException(status_code=409, detail=f"'{name}' is built-in and cannot be deleted")
+    except HTTPException:
+        raise
+    except Exception:
+        pass
+    try:
+        store = get_store()
+        await asyncio.to_thread(store.delete, name, "docgrok_transform")
+    except Exception as e:
+        raise HTTPException(status_code=503, detail=f"delete failed: {str(e)}")
+    return {"deleted": name}
 
 
 @app.get("/api/docgrok/pipelines/{name}")

--- a/search/schemas.py
+++ b/search/schemas.py
@@ -88,12 +88,14 @@ class ModelEmbedding(BaseModel):
     policy: Literal["model"] = "model"
     model_id: str  # e.g. "mdl-bge-large" — routed to DocGrok by model_id
     normalize: bool = False
+    input_modality: Literal["text", "image"] = "text"
 
 
 class PipelineEmbedding(BaseModel):
     policy: Literal["pipeline"] = "pipeline"
     pipeline: str  # named DocGrok pipeline
     normalize: bool = False
+    input_modality: Literal["text", "image"] = "text"
 
 
 class PrecomputedEmbedding(BaseModel):
@@ -162,6 +164,8 @@ class IncludeOptions(BaseModel):
 
 class SearchRequest(BaseModel):
     query: Optional[str] = None
+    # Base64-encoded image bytes to use as query for image-modality indexes.
+    query_image_b64: Optional[str] = None
     top_k: int = Field(default=10, ge=1, le=100)
     merge: MergeConfig = Field(default_factory=MergeConfig)
     indexes: List[IndexSpec] = Field(..., min_length=1, max_length=10)
@@ -173,11 +177,13 @@ class SearchRequest(BaseModel):
 
     @model_validator(mode="after")
     def _require_query_when_needed(self):
-        needs_query = any(
-            not isinstance(i.embedding, PrecomputedEmbedding) for i in self.indexes
-        )
-        if needs_query and not self.query:
-            raise ValueError("`query` is required when any index uses model/pipeline embedding")
+        # Need at least one query input.
+        if not (self.query or self.query_image_b64):
+            raise ValueError("provide either 'query' (text) or 'query_image_b64' (image)")
+        # Image-modality indexes accept either a text query (embedded via
+        # CLIP text encoder) or an image query. Text-modality indexes
+        # require a text query — they will be skipped at search time
+        # if only an image is provided.
         return self
 
 
@@ -193,6 +199,9 @@ class SearchResult(BaseModel):
     vector: Optional[List[float]] = None
     source: Optional[str] = None
     source_ref: Optional[str] = None
+    # "text" | "image" | "video" — derived from the index's embedding modality
+    # and from per-doc hints (e.g. blob filename extension, frame markers).
+    entity_type: str = "text"
 
 
 class PerIndexInfo(BaseModel):

--- a/search/searcher.py
+++ b/search/searcher.py
@@ -82,11 +82,74 @@ async def resolve_secret_ref(ref: str) -> str:
 
 
 async def embed_query(
-    http: httpx.AsyncClient, policy: EmbeddingPolicy, query: str, request_id: str
+    http: httpx.AsyncClient,
+    policy: EmbeddingPolicy,
+    query: str,
+    request_id: str,
+    query_image_b64: Optional[str] = None,
 ) -> Tuple[List[float], str]:
     """Return (vector, model_label) for an embedding policy."""
     if isinstance(policy, PrecomputedEmbedding):
         return list(policy.vector), "precomputed"
+
+    modality = getattr(policy, "input_modality", "text")
+    is_image = modality == "image"
+
+    if is_image:
+        # Decide payload: image bytes preferred, else fall back to the
+        # text query (CLIP is multi-modal — text and image vectors share
+        # the same space, so a text query against an image/video index
+        # is valid via the CLIP text encoder).
+        if isinstance(policy, ModelEmbedding):
+            label = policy.model_id
+            transform_name = "image-transform"
+        elif isinstance(policy, PipelineEmbedding):
+            label = policy.pipeline
+            # For text queries we always embed via image-transform (the
+            # CLIP text/image encoder pair). The pipeline used at
+            # ingestion (e.g. video-transform = extract_frames →
+            # image_embed) lives in the same 768-dim CLIP vector space,
+            # so search-time embedding via image-transform is valid and
+            # avoids running stages like extract_frames on text input.
+            transform_name = policy.pipeline if query_image_b64 else "image-transform"
+        else:
+            raise ValueError(f"Unknown embedding policy: {policy!r}")
+        if query_image_b64:
+            body = {
+                "data": query_image_b64,
+                "transform_name": transform_name,
+                "requestId": request_id,
+            }
+        elif query:
+            body = {
+                "text": query,
+                "transform_name": transform_name,
+                "requestId": request_id,
+            }
+        else:
+            raise RuntimeError("image-modality index requires either text query or query_image_b64")
+        resp = await http.post(f"{DOCGROK_URL}/embed", json=body, timeout=EMBED_TIMEOUT_S)
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"embedding service returned {resp.status_code}: {resp.text[:200]}"
+            )
+        data = resp.json()
+        chunks = data.get("chunks") or []
+        vec = (chunks[0].get("embedding") if chunks else None) or []
+        if not vec:
+            # Legacy text shape fallback (defensive).
+            pages = data.get("pages") or data.get("output") or [[]]
+            vec = pages[0] if pages else []
+        if not vec:
+            raise RuntimeError("image embedding service returned empty vector")
+        if getattr(policy, "normalize", False):
+            n = math.sqrt(sum(x * x for x in vec)) or 1.0
+            vec = [x / n for x in vec]
+        return list(vec), label
+
+    # Text index, image-only query → skip with informative error.
+    if not query:
+        raise RuntimeError("text-modality index requires a text query (set query)")
 
     if isinstance(policy, ModelEmbedding):
         body = {"model_id": policy.model_id, "text": query, "requestId": request_id}
@@ -178,7 +241,7 @@ async def search_cosmos(
                     params.append({"name": name, "value": v})
 
         query = (
-            f"SELECT TOP @top_k c, VectorDistance(c.{vf}, {embedding_str}) AS distance "
+            f"SELECT TOP @top_k c, VectorDistance(c.{vf}, {embedding_str}) AS similarity "
             f"FROM c {where} ORDER BY VectorDistance(c.{vf}, {embedding_str})"
         )
 
@@ -186,7 +249,9 @@ async def search_cosmos(
         for item in container.query_items(
             query=query, parameters=params, enable_cross_partition_query=True
         ):
-            distance = float(item.get("distance", 0) or 0)
+            # Cosmos VectorDistance with cosine returns similarity in [0,1] (1 = identical).
+            # Order by VectorDistance returns most-similar first regardless of ASC/DESC.
+            similarity = float(item.get("similarity", 0) or 0)
             doc = item.get("c", {}) or {}
             text, text_parts = _extract_text(doc, content_fields)
 
@@ -197,8 +262,8 @@ async def search_cosmos(
 
             hit: Dict[str, Any] = {
                 "id": doc.get("id"),
-                "score": 1 - distance,
-                "distance": distance,
+                "score": similarity,
+                "distance": 1 - similarity,
                 "text": text,
                 "text_parts": text_parts,
                 "metadata": metadata,
@@ -222,6 +287,7 @@ async def search_pgvector(
     return_fields: List[str],
     index_filter: Optional[IndexFilter],
     include_vector: bool,
+    metric: str = "cosine",
 ) -> List[dict]:
     import asyncpg  # type: ignore
 
@@ -239,15 +305,29 @@ async def search_pgvector(
     id_col = store.id_column
     content_col = store.content_column
     vcol = vec_field
+    if not isinstance(metric, str):
+        metric = "cosine"
+    metric = metric.lower()
+
+    def q(c: str) -> str:
+        return '"' + c.replace('"', '""') + '"'
+
+    # Map metric → operator + similarity expression
+    if metric in ("l2", "euclidean"):
+        op = "<->"
+        sim_expr = f"1.0 / (1.0 + ({q(vcol)} <-> $1::vector))"
+    elif metric in ("dot", "inner_product", "ip"):
+        op = "<#>"
+        sim_expr = f"-({q(vcol)} <#> $1::vector)"
+    else:
+        op = "<=>"
+        sim_expr = f"1 - ({q(vcol)} <=> $1::vector)"
 
     select_cols = [id_col, content_col]
     extra_cols = list(dict.fromkeys([*content_fields, *return_fields, *store.metadata_columns]))
     for c in extra_cols:
         if c not in select_cols:
             select_cols.append(c)
-
-    def q(c: str) -> str:
-        return '"' + c.replace('"', '""') + '"'
 
     col_list = ", ".join(q(c) for c in select_cols)
 
@@ -264,9 +344,9 @@ async def search_pgvector(
             )
 
     sql = (
-        f"SELECT {col_list}, 1 - ({q(vcol)} <=> $1::vector) AS similarity "
+        f"SELECT {col_list}, {sim_expr} AS similarity "
         f"FROM {q(table)} {where_clause} "
-        f"ORDER BY {q(vcol)} <=> $1::vector LIMIT $2"
+        f"ORDER BY {q(vcol)} {op} $1::vector LIMIT $2"
     )
 
     conn = await asyncpg.connect(dsn, ssl=ssl if ssl else None)
@@ -315,6 +395,7 @@ async def _search_one_index(
     query: Optional[str],
     request_id: str,
     include_vector: bool,
+    query_image_b64: Optional[str] = None,
 ) -> Tuple[PerIndexInfo, List[dict]]:
     """Embed (if needed) + search one index. Never raises."""
     info = PerIndexInfo(index_id=idx.id)
@@ -323,7 +404,9 @@ async def _search_one_index(
     # Embed
     t0 = time.time()
     try:
-        embedding, label = await embed_query(http, idx.embedding, query or "", request_id)
+        embedding, label = await embed_query(
+            http, idx.embedding, query or "", request_id, query_image_b64=query_image_b64
+        )
     except Exception as e:
         info.error = f"embed: {str(e)[:180]}"
         return info, []
@@ -353,6 +436,7 @@ async def _search_one_index(
                 search_pgvector(
                     idx.store, idx.vector.field, embedding, per_top_k,
                     idx.content_fields, idx.return_fields, idx.filter, include_vector,
+                    metric=idx.vector.metric,
                 ),
                 timeout=PER_INDEX_TIMEOUT_S,
             )
@@ -459,6 +543,7 @@ async def run_search(http: httpx.AsyncClient, req: SearchRequest) -> SearchRespo
         _search_one_index(
             http, idx, req.merge.per_index_top_k, req.query, request_id,
             include_vector=req.include.vectors,
+            query_image_b64=req.query_image_b64,
         )
         for idx in req.indexes
     ]
@@ -498,6 +583,22 @@ async def run_search(http: httpx.AsyncClient, req: SearchRequest) -> SearchRespo
     merged = _merge(per_index_hits, req.merge, req.top_k)
     merge_ms = int((time.time() - t_merge) * 1000)
 
+    # Build index_id -> input_modality map for entity_type tagging.
+    idx_modality: Dict[str, str] = {}
+    for ix in req.indexes:
+        mod = getattr(ix.embedding, "input_modality", "text")
+        idx_modality[ix.id] = mod
+
+    def _classify(hit: dict) -> str:
+        ref = (hit.get("source_ref") or hit.get("id") or "").lower()
+        if any(ref.endswith(ext) for ext in (".mp4", ".mov", ".m4v", ".avi", ".mkv", ".webm")):
+            return "video"
+        if any(ref.endswith(ext) for ext in (".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp")):
+            return "image"
+        # Fall back to the index's declared modality.
+        mod = idx_modality.get(hit.get("index_id"), "text")
+        return "image" if mod == "image" else "text"
+
     out_results: List[SearchResult] = []
     for h in merged:
         out_results.append(SearchResult(
@@ -512,6 +613,7 @@ async def run_search(http: httpx.AsyncClient, req: SearchRequest) -> SearchRespo
             vector=(h.get("vector") if req.include.vectors else None),
             source=h.get("source"),
             source_ref=h.get("source_ref"),
+            entity_type=_classify(h),
         ))
 
     timing = SearchTiming(

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1240,19 +1240,41 @@
                 <header class="header">
                     <h2 class="header-title">Transform Pipelines</h2>
                     <div class="header-actions">
-                        <button class="btn btn-primary" disabled style="opacity:0.5;cursor:not-allowed;" title="Transform pipeline creation is disabled. Use models directly.">
+                        <button class="btn btn-primary" onclick="openDgTransformCreate()">
                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M12 5v14"/><path d="M5 12h14"/>
                             </svg>
-                            Create Pipeline
+                            Create Transform
                         </button>
                     </div>
                 </header>
 
                 <div class="content">
-                    <div id="dg-pipelines-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 20px;">
-                        <div style="text-align: center; padding: 60px; color: var(--text-tertiary);">Loading pipelines...</div>
+                    <div id="dg-pipelines-list-view">
+                        <div class="card">
+                            <div class="card-body" style="padding: 0;">
+                                <div class="table-container">
+                                    <table>
+                                        <thead>
+                                            <tr>
+                                                <th>Transform</th>
+                                                <th>Source</th>
+                                                <th>Applies To</th>
+                                                <th>Stages</th>
+                                                <th>Version</th>
+                                                <th>Description</th>
+                                                <th></th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="dg-pipelines-tbody">
+                                            <tr><td colspan="7" style="text-align:center;color:var(--text-tertiary);">Loading transforms...</td></tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
                     </div>
+                    <div id="dg-pipelines-detail-view" style="display:none;"></div>
                 </div>
             </section>
 
@@ -1373,6 +1395,12 @@
                                         <option value="round_robin">Round Robin</option>
                                         <option value="per_index">Per-Index Cap</option>
                                     </select>
+                                </div>
+                                <div class="form-group" style="margin-bottom: 0; display: flex; align-items: center; gap: 8px;">
+                                    <label class="form-label" style="margin-bottom: 0; white-space: nowrap;">Image:</label>
+                                    <input type="file" id="playground-image-file" accept="image/*" style="font-size: 12px;" onchange="onPlaygroundImageChange(event)">
+                                    <span id="playground-image-status" style="font-size: 12px; color: var(--text-tertiary);"></span>
+                                    <button type="button" class="btn btn-ghost" style="padding: 4px 10px; font-size: 12px;" onclick="clearPlaygroundImage()">Clear</button>
                                 </div>
                                 <div id="playground-status" style="color: var(--text-tertiary); font-size: 13px;"></div>
                             </div>
@@ -1966,6 +1994,12 @@
                             </svg>
                             <span>Destination</span>
                         </div>
+                        <div class="pipeline-step" onclick="showPipelineStep('options')" id="step-options" style="padding: 12px 20px; cursor: pointer; display: flex; align-items: center; gap: 10px; color: var(--text-secondary); border-left: 3px solid transparent;">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18">
+                                <path d="M12 20v-6M6 20V10M18 20V4"/>
+                            </svg>
+                            <span>Options</span>
+                        </div>
                     </div>
 
                     <!-- Right Content Area -->
@@ -1979,71 +2013,6 @@
                             <div class="form-group">
                                 <label class="form-label">Description (optional)</label>
                                 <textarea class="form-input" name="description" placeholder="Describe what this pipeline does..." rows="3" style="resize: vertical;"></textarea>
-                            </div>
-                            <div class="form-group">
-                                <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
-                                    <input type="checkbox" name="process_existing" checked>
-                                    <span>Process existing documents on creation</span>
-                                </label>
-                                <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
-                                    If enabled, all existing documents in the source will be processed immediately
-                                </small>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label">Content Strategy</label>
-                                <select class="form-input" name="content_strategy" onchange="toggleChunkConfig(this.value)">
-                                    <option value="truncate">Truncate (single vector per document)</option>
-                                    <option value="chunk">Chunk (split into overlapping chunks)</option>
-                                </select>
-                                <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
-                                    Truncate embeds full text as one vector. Chunk splits text and creates multiple vector documents.
-                                </small>
-                            </div>
-                            <div id="chunk-config-section" style="display: none; padding: 12px; background: var(--bg-tertiary); border-radius: var(--radius-md); margin-top: 8px;">
-                                <div style="font-size: 11px; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 10px; font-weight: 600; letter-spacing: 0.5px;">Chunk Settings</div>
-                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px;">
-                                    <div class="form-group" style="margin-bottom: 0;">
-                                        <label class="form-label">Chunk Size (chars)</label>
-                                        <input type="number" class="form-input" name="chunk_size" value="1000" min="100" max="10000">
-                                    </div>
-                                    <div class="form-group" style="margin-bottom: 0;">
-                                        <label class="form-label">Chunk Overlap (chars)</label>
-                                        <input type="number" class="form-input" name="chunk_overlap" value="200" min="0" max="2000">
-                                    </div>
-                                </div>
-                                <div class="form-group" style="margin-top: 12px; margin-bottom: 0;">
-                                    <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
-                                        <input type="checkbox" name="store_text">
-                                        <span>Store extracted text in vector documents</span>
-                                    </label>
-                                    <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
-                                        Each chunk document will include the chunk text alongside the embedding vector
-                                    </small>
-                                </div>
-                                <div class="form-group" style="margin-top: 12px; margin-bottom: 0;">
-                                    <label class="form-label">Chunk Doc ID Pattern</label>
-                                    <input type="text" class="form-input" name="chunk_doc_id_pattern" value="{source}-chunk-{chunk}" placeholder="{source}-chunk-{chunk}">
-                                    <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
-                                        Variables: <code>{source}</code> (filename), <code>{chunk}</code> (index), <code>{source_hash}</code>, <code>{pipeline}</code>
-                                    </small>
-                                </div>
-                            </div>
-                            <div class="form-group" style="margin-top: 16px;">
-                                <label class="form-label">Processing Mode</label>
-                                <select class="form-input" name="processing_mode" id="pipeline-processing-mode">
-                                    <option value="inline">Inline (changefeed embeds directly — recommended)</option>
-                                    <option value="queue">Queue (jobs created, worker processes)</option>
-                                </select>
-                                <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
-                                    Queue mode: Change feed creates jobs, pipeline worker processes them. Inline mode: Change feed patches documents directly (faster for same source/destination).
-                                </small>
-                            </div>
-                            <div class="form-group" id="doc-id-pattern-group" style="display: none;">
-                                <label class="form-label">Document ID Pattern</label>
-                                <input type="text" class="form-input" name="doc_id_pattern" value="{source}" placeholder="{source}">
-                                <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
-                                    Target doc name in destination. Variables: <code>{source}</code> (filename), <code>{source_hash}</code>, <code>{pipeline}</code>, <code>{job}</code>
-                                </small>
                             </div>
                         </div>
 
@@ -2268,6 +2237,75 @@
                                         <div id="pl-dest-test-result" style="margin-top: 8px; flex: 1; overflow-y: auto; max-height: 120px; font-size: 12px;"></div>
                                     </div>
                                 </div>
+                            </div>
+                        </div>
+
+                        <!-- Options Step -->
+                        <div id="pipeline-step-options" class="pipeline-content" style="display: none;">
+                            <div class="form-group">
+                                <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                                    <input type="checkbox" name="process_existing" checked>
+                                    <span>Process existing documents on creation</span>
+                                </label>
+                                <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
+                                    If enabled, all existing documents in the source will be processed immediately
+                                </small>
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">Content Strategy</label>
+                                <select class="form-input" name="content_strategy" onchange="toggleChunkConfig(this.value)">
+                                    <option value="truncate">Truncate (single vector per document)</option>
+                                    <option value="chunk">Chunk (split into overlapping chunks)</option>
+                                </select>
+                                <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
+                                    Truncate embeds full text as one vector. Chunk splits text and creates multiple vector documents.
+                                </small>
+                            </div>
+                            <div id="chunk-config-section" style="display: none; padding: 12px; background: var(--bg-tertiary); border-radius: var(--radius-md); margin-top: 8px;">
+                                <div style="font-size: 11px; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 10px; font-weight: 600; letter-spacing: 0.5px;">Chunk Settings</div>
+                                <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px;">
+                                    <div class="form-group" style="margin-bottom: 0;">
+                                        <label class="form-label">Chunk Size (chars)</label>
+                                        <input type="number" class="form-input" name="chunk_size" value="1000" min="100" max="10000">
+                                    </div>
+                                    <div class="form-group" style="margin-bottom: 0;">
+                                        <label class="form-label">Chunk Overlap (chars)</label>
+                                        <input type="number" class="form-input" name="chunk_overlap" value="200" min="0" max="2000">
+                                    </div>
+                                </div>
+                                <div class="form-group" style="margin-top: 12px; margin-bottom: 0;">
+                                    <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                                        <input type="checkbox" name="store_text">
+                                        <span>Store extracted text in vector documents</span>
+                                    </label>
+                                    <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
+                                        Each chunk document will include the chunk text alongside the embedding vector
+                                    </small>
+                                </div>
+                                <div class="form-group" style="margin-top: 12px; margin-bottom: 0;">
+                                    <label class="form-label">Chunk Doc ID Pattern</label>
+                                    <input type="text" class="form-input" name="chunk_doc_id_pattern" value="{source}-chunk-{chunk}" placeholder="{source}-chunk-{chunk}">
+                                    <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
+                                        Variables: <code>{source}</code> (filename), <code>{chunk}</code> (index), <code>{source_hash}</code>, <code>{pipeline}</code>
+                                    </small>
+                                </div>
+                            </div>
+                            <div class="form-group" style="margin-top: 16px;">
+                                <label class="form-label">Processing Mode</label>
+                                <select class="form-input" name="processing_mode" id="pipeline-processing-mode">
+                                    <option value="inline">Inline (changefeed embeds directly — recommended)</option>
+                                    <option value="queue">Queue (jobs created, worker processes)</option>
+                                </select>
+                                <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
+                                    Queue mode: Change feed creates jobs, pipeline worker processes them. Inline mode: Change feed patches documents directly (faster for same source/destination).
+                                </small>
+                            </div>
+                            <div class="form-group" id="doc-id-pattern-group" style="display: none;">
+                                <label class="form-label">Document ID Pattern</label>
+                                <input type="text" class="form-input" name="doc_id_pattern" value="{source}" placeholder="{source}">
+                                <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
+                                    Target doc name in destination. Variables: <code>{source}</code> (filename), <code>{source_hash}</code>, <code>{pipeline}</code>, <code>{job}</code>
+                                </small>
                             </div>
                         </div>
                     </div>
@@ -2558,6 +2596,48 @@
             <div class="modal-footer">
                 <button class="btn btn-secondary" onclick="closeModal('dg-pipeline-modal')">Cancel</button>
                 <button class="btn btn-primary" onclick="saveDgPipeline()">Save Pipeline</button>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal-overlay" id="dg-transform-modal">
+        <div class="modal" style="max-width: 760px;">
+            <div class="modal-header">
+                <h3 class="modal-title" id="dg-tx-modal-title">Create Transform Pipeline</h3>
+                <button class="modal-close" onclick="closeModal('dg-transform-modal')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="18" height="18">
+                        <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="modal-body">
+                <form id="dg-transform-form" onsubmit="event.preventDefault();saveDgTransform();">
+                    <div class="form-group">
+                        <label class="form-label">Name <span style="color:var(--danger);">*</span></label>
+                        <input type="text" class="form-input" id="dg-tx-name" placeholder="e.g. my-pdf-transform" required>
+                        <div style="font-size:11px;color:var(--text-tertiary);margin-top:4px;">Lowercase letters, digits and dashes. Must not collide with a built-in. Cannot be changed after creation.</div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Description</label>
+                        <input type="text" class="form-input" id="dg-tx-description" placeholder="What does this transform do?">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Applies to (file extensions)</label>
+                        <input type="text" class="form-input" id="dg-tx-extensions" placeholder=".pdf, .txt, .md">
+                        <div style="font-size:11px;color:var(--text-tertiary);margin-top:4px;">Comma-separated. Each must start with a dot. The dispatcher picks the first transform whose list matches the input file.</div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Stages</label>
+                        <div id="dg-tx-stages" style="display:flex;flex-direction:column;gap:10px;"></div>
+                        <button type="button" class="btn btn-secondary" style="width:100%;margin-top:10px;border-style:dashed;" onclick="addDgTxStage()">+ Add Stage</button>
+                        <div style="font-size:11px;color:var(--text-tertiary);margin-top:6px;">The last stage must be of type <code>embed</code>. Stage order = execution order.</div>
+                    </div>
+                    <div id="dg-tx-error" style="display:none;color:var(--danger);font-size:13px;margin-top:8px;padding:8px 12px;background:rgba(239,68,68,0.1);border-radius:6px;"></div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-secondary" onclick="closeModal('dg-transform-modal')">Cancel</button>
+                <button class="btn btn-primary" id="dg-tx-save-btn" onclick="saveDgTransform()">Create Transform</button>
             </div>
         </div>
     </div>
@@ -5769,11 +5849,19 @@
             // Both must be selected to evaluate
             const bothSelected = srcObj && destObj;
 
-            const sameContainer = bothSelected &&
+            const sameCosmosContainer = bothSelected &&
                 srcObj.type === 'cosmosdb' && destObj.type === 'cosmosdb-vector' &&
-                srcObj.config?.endpoint === destObj.config?.endpoint &&
+                (srcObj.config?.endpoint || '').replace(/\/$/,'') === (destObj.config?.endpoint || '').replace(/\/$/,'') &&
                 srcObj.config?.database === destObj.config?.database &&
                 srcObj.config?.container === destObj.config?.container;
+
+            const samePgvectorTable = bothSelected &&
+                srcObj.type === 'postgresql' && destObj.type === 'pgvector' &&
+                srcObj.config?.host === destObj.config?.host &&
+                srcObj.config?.database === destObj.config?.database &&
+                srcObj.config?.table === destObj.config?.table;
+
+            const sameContainer = sameCosmosContainer || samePgvectorTable;
 
             indicator.style.display = sameContainer ? 'block' : 'none';
 
@@ -5784,6 +5872,28 @@
                     docIdGroup.style.display = 'none';  // Hide until both selected
                 } else {
                     docIdGroup.style.display = sameContainer ? 'none' : 'block';
+                }
+            }
+
+            // Enforce processing-mode compatibility based on source/destination:
+            //   not both selected -> leave both enabled (user hasn't decided yet)
+            //   same store        -> only 'inline' allowed (queue is redundant)
+            //   diff stores       -> only 'queue' allowed (inline cannot move data)
+            const pmSelect = document.getElementById('pipeline-processing-mode');
+            if (pmSelect) {
+                const inlineOpt = pmSelect.querySelector('option[value="inline"]');
+                const queueOpt = pmSelect.querySelector('option[value="queue"]');
+                if (!bothSelected) {
+                    if (inlineOpt) inlineOpt.disabled = false;
+                    if (queueOpt) queueOpt.disabled = false;
+                } else if (sameContainer) {
+                    if (inlineOpt) inlineOpt.disabled = false;
+                    if (queueOpt) queueOpt.disabled = true;
+                    if (pmSelect.value !== 'inline') pmSelect.value = 'inline';
+                } else {
+                    if (inlineOpt) inlineOpt.disabled = true;
+                    if (queueOpt) queueOpt.disabled = false;
+                    if (pmSelect.value !== 'queue') pmSelect.value = 'queue';
                 }
             }
         }
@@ -6081,8 +6191,13 @@
 
             // Update buttons
             document.getElementById('pipeline-prev-btn').style.display = step === 'general' ? 'none' : 'inline-flex';
-            document.getElementById('pipeline-next-btn').style.display = step === 'destination' ? 'none' : 'inline-flex';
-            document.getElementById('pipeline-create-btn').style.display = step === 'destination' ? 'inline-flex' : 'none';
+            document.getElementById('pipeline-next-btn').style.display = step === 'options' ? 'none' : 'inline-flex';
+            document.getElementById('pipeline-create-btn').style.display = step === 'options' ? 'inline-flex' : 'none';
+
+            // Re-apply source/destination compatibility rules whenever the
+            // user lands on any step — this keeps the processing-mode dropdown
+            // correct even if the user backtracks from destination to general.
+            try { updateSameContainerIndicator(); } catch (_) {}
         }
 
         function nextPipelineStep() {
@@ -6110,10 +6225,15 @@
                 // After showing destination step, check for same container indicator
                 updateSameContainerIndicator();
             }
+            else if (currentPipelineStep === 'destination') {
+                showPipelineStep('options');
+                updateSameContainerIndicator();
+            }
         }
 
         function prevPipelineStep() {
-            if (currentPipelineStep === 'destination') showPipelineStep('transform');
+            if (currentPipelineStep === 'options') showPipelineStep('destination');
+            else if (currentPipelineStep === 'destination') showPipelineStep('transform');
             else if (currentPipelineStep === 'transform') showPipelineStep('source');
             else if (currentPipelineStep === 'source') showPipelineStep('general');
         }
@@ -6236,7 +6356,9 @@
                     id_column: formData.get('id_column') || 'id',
                     timestamp_column: formData.get('timestamp_column') || 'updated_at',
                     poll_interval_seconds: parseInt(formData.get('poll_interval_seconds')) || 60,
-                    ssl_mode: 'require'
+                    user: formData.get('user') || '',
+                    password: formData.get('password') || '',
+                    ssl_mode: formData.get('ssl_mode') || 'require'
                 };
             }
 
@@ -6283,8 +6405,10 @@
                     database: formData.get('database'),
                     table: formData.get('table'),
                     vector_column: formData.get('vector_column') || 'embedding',
-                    vector_dimensions: parseInt(formData.get('vector_dimensions')) || 1024,
-                    index_type: formData.get('index_type') || 'ivfflat',
+                    content_column: formData.get('content_column') || 'content',
+                    id_column: formData.get('id_column') || 'id',
+                    vector_dimensions: parseInt(formData.get('vector_dimensions')) || 1536,
+                    index_type: formData.get('index_type') || 'hnsw',
                     user: formData.get('user') || '',
                     password: formData.get('password') || '',
                     ssl_mode: formData.get('ssl_mode') || 'require'
@@ -6690,6 +6814,25 @@
                         <label class="form-label">Poll Interval (seconds)</label>
                         <input type="number" class="form-input" name="poll_interval_seconds" value="60" placeholder="60">
                     </div>
+                    <hr style="border: 0; border-top: 1px solid var(--border-primary); margin: 16px 0;">
+                    <h5 style="margin: 0 0 12px 0; font-size: 14px;">Authentication</h5>
+                    <div class="form-group">
+                        <label class="form-label">Username</label>
+                        <input type="text" class="form-input" name="user" placeholder="postgres">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Password</label>
+                        <input type="password" class="form-input" name="password" placeholder="Enter password">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">SSL Mode</label>
+                        <select class="form-input" name="ssl_mode">
+                            <option value="require" selected>Require (recommended)</option>
+                            <option value="verify-full">Verify Full</option>
+                            <option value="prefer">Prefer</option>
+                            <option value="disable">Disable</option>
+                        </select>
+                    </div>
                 `;
             }
             // Reset test result when config changes
@@ -7079,14 +7222,25 @@
                         <input type="text" class="form-input" name="vector_column" value="embedding" placeholder="embedding">
                     </div>
                     <div class="form-group">
+                        <label class="form-label">Content Column</label>
+                        <input type="text" class="form-input" name="content_column" value="content" placeholder="content">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">ID Column</label>
+                        <input type="text" class="form-input" name="id_column" value="id" placeholder="id">
+                    </div>
+                    <div class="form-group">
                         <label class="form-label">Vector Dimensions</label>
-                        <input type="number" class="form-input" name="vector_dimensions" value="1024" placeholder="1024">
+                        <input type="number" class="form-input" name="vector_dimensions" value="1536" placeholder="1536">
+                        <small style="color: var(--text-tertiary); font-size: 11px; margin-top: 4px; display: block;">
+                            Must match your embedding model (e.g. 1536 for text-embedding-3-small, 3072 for text-embedding-3-large).
+                        </small>
                     </div>
                     <div class="form-group">
                         <label class="form-label">Index Type</label>
                         <select class="form-input" name="index_type">
+                            <option value="hnsw" selected>HNSW (faster, more memory)</option>
                             <option value="ivfflat">IVFFlat (good balance)</option>
-                            <option value="hnsw">HNSW (faster, more memory)</option>
                         </select>
                     </div>
                     <hr style="border: 0; border-top: 1px solid var(--border-primary); margin: 16px 0;">
@@ -7997,63 +8151,507 @@
         }
 
         // DocGrok Transform Pipelines
+        let dgDefaultRecipe = null;
+        let dgStageCatalog = null;
+        let dgTransforms = [];
+
         async function loadDgTransformPipelines() {
             try {
-                const res = await apiFetch(`${DOCGROK_API}/pipelines`);
+                const res = await apiFetch(`${DOCGROK_API}/transforms`);
                 const data = await res.json();
-                dgTransformPipelines = data.pipelines || [];
+                dgTransforms = Array.isArray(data.transforms) ? data.transforms : [];
+
+                // Stage catalog (reusable building blocks; used by detail wizard
+                // and the create modal)
+                try {
+                    const catRes = await apiFetch(`${DOCGROK_API}/transforms/stage-catalog`);
+                    if (catRes.ok) dgStageCatalog = await catRes.json();
+                } catch (e) { dgStageCatalog = null; }
+
                 renderDgTransformPipelines();
 
-                // Also load pipeline options
                 try {
                     const optRes = await apiFetch(`${DOCGROK_API}/pipelines/options`);
                     dgPipelineOptions = await optRes.json();
                 } catch (e) {}
             } catch (err) {
-                console.error('Error loading DocGrok pipelines:', err);
+                console.error('Error loading DocGrok transforms:', err);
+                const tbody = document.getElementById('dg-pipelines-tbody');
+                if (tbody) tbody.innerHTML = `<tr><td colspan="7" style="text-align:center;padding:24px;color:var(--danger);">Failed to load transforms: ${_escape(err.message || err)}</td></tr>`;
             }
         }
 
-        function renderDgTransformPipelines() {
-            const grid = document.getElementById('dg-pipelines-grid');
+        // Tiny helpers
+        function _escape(s) {
+            return String(s == null ? '' : s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+        }
+        function _fmtVal(v) {
+            if (v === null || v === undefined) return '<span style="color:var(--text-tertiary)">null</span>';
+            if (Array.isArray(v)) return v.length ? v.map(x => `<code style="background:var(--bg-secondary);padding:1px 5px;border-radius:3px;font-size:11px;">${_escape(x)}</code>`).join(' ') : '<span style="color:var(--text-tertiary)">[]</span>';
+            if (typeof v === 'object') return `<code style="background:var(--bg-secondary);padding:1px 5px;border-radius:3px;font-size:11px;">${_escape(JSON.stringify(v))}</code>`;
+            return `<code style="background:var(--bg-secondary);padding:1px 5px;border-radius:3px;font-size:11px;">${_escape(v)}</code>`;
+        }
+        function _appliesToBadges(t) {
+            const exts = ((t.applies_to || {}).extensions) || [];
+            if (!exts.length) return '<span style="color:var(--text-tertiary);font-size:12px;">any</span>';
+            const shown = exts.slice(0, 4).map(e => `<code style="background:var(--bg-secondary);padding:1px 6px;border-radius:3px;font-size:11px;">${_escape(e)}</code>`).join(' ');
+            const more = exts.length > 4 ? ` <span style="font-size:11px;color:var(--text-tertiary);">+${exts.length - 4}</span>` : '';
+            return shown + more;
+        }
 
-            if (!dgTransformPipelines.length) {
-                grid.innerHTML = `
-                    <div style="text-align: center; padding: 60px; color: var(--text-tertiary); grid-column: 1 / -1;">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="64" height="64" style="margin-bottom: 16px; opacity: 0.5;">
-                            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
-                        </svg>
-                        <h3 style="margin-bottom: 8px;">No transform pipelines</h3>
-                        <p style="margin-bottom: 16px;">Create a pipeline to define document processing workflows</p>
-                        <button class="btn btn-primary" disabled style="opacity:0.5;cursor:not-allowed;" title="Disabled">Create Pipeline</button>
-                    </div>
-                `;
-                return;
+        function renderDgTransformPipelines() {
+            const listEl = document.getElementById('dg-pipelines-list-view');
+            const detailEl = document.getElementById('dg-pipelines-detail-view');
+            if (listEl) listEl.style.display = '';
+            if (detailEl) { detailEl.style.display = 'none'; detailEl.innerHTML = ''; }
+
+            const tbody = document.getElementById('dg-pipelines-tbody');
+            const rows = [];
+
+            for (const t of dgTransforms) {
+                const stageCount = (t.stages || []).length;
+                const isBuiltin = t.source === 'builtin';
+                const sourceBadge = isBuiltin
+                    ? '<span class="badge badge-info">System</span>'
+                    : '<span class="badge badge-success">User</span>';
+                const gradient = isBuiltin
+                    ? 'linear-gradient(135deg,var(--accent-primary,#3b82f6),#8b5cf6)'
+                    : 'linear-gradient(135deg,#10b981,#059669)';
+                const delBtn = isBuiltin ? '' :
+                    `<button class="btn btn-ghost btn-sm" onclick="event.stopPropagation();openDgTransformEdit('${_escape(t.name)}')" title="Edit">✎</button>
+                     <button class="btn btn-ghost btn-sm" onclick="event.stopPropagation();deleteDgTransform('${_escape(t.name)}')" title="Delete">✕</button>`;
+                rows.push(`
+                    <tr onclick="openDgPipelineWizard('${_escape(t.name)}')" style="cursor:pointer;">
+                        <td>
+                            <div style="display:flex;align-items:center;gap:12px;">
+                                <div style="width:40px;height:40px;border-radius:10px;background:${gradient};display:flex;align-items:center;justify-content:center;color:#fff;font-weight:600;">&#9881;</div>
+                                <div>
+                                    <strong>${_escape(t.name)}</strong>
+                                    <div style="font-size:11px;color:var(--text-tertiary);font-family:var(--font-mono);">${_escape(t.name)}</div>
+                                </div>
+                            </div>
+                        </td>
+                        <td>${sourceBadge}</td>
+                        <td>${_appliesToBadges(t)}</td>
+                        <td><span class="mono">${stageCount}</span></td>
+                        <td>v${_escape(t.version || '1')}</td>
+                        <td style="color:var(--text-secondary);font-size:13px;max-width:380px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${_escape(t.description || '')}</td>
+                        <td style="text-align:right;">${delBtn}</td>
+                    </tr>
+                `);
             }
 
-            grid.innerHTML = dgTransformPipelines.map(p => {
-                const stepsHtml = (p.steps || []).map((s, i) => {
-                    const label = s.function || s.model_id || s.model || 'unknown';
-                    const stepClass = s.type === 'local' ? 'badge-success' : s.type === 'api' ? 'badge-info' : 'badge-warning';
-                    return `<span class="badge ${stepClass}">${label}</span>` +
-                           (i < p.steps.length - 1 ? '<span style="color: var(--text-tertiary); margin: 0 4px;">→</span>' : '');
-                }).join('');
+            if (rows.length === 0) {
+                tbody.innerHTML = `<tr><td colspan="7" style="text-align:center;padding:40px;color:var(--text-tertiary);">No transforms available. Click "Create Transform" to add one.</td></tr>`;
+            } else {
+                tbody.innerHTML = rows.join('');
+            }
+        }
 
+        async function deleteDgTransform(name) {
+            if (!confirm(`Delete transform '${name}'? This cannot be undone.`)) return;
+            try {
+                const res = await apiFetch(`${DOCGROK_API}/transforms/${encodeURIComponent(name)}`, { method: 'DELETE' });
+                if (!res.ok) {
+                    const j = await res.json().catch(() => ({}));
+                    throw new Error(j.detail || `HTTP ${res.status}`);
+                }
+                await loadDgTransformPipelines();
+            } catch (e) {
+                alert(`Failed to delete: ${e.message || e}`);
+            }
+        }
+
+        // -------- Pipeline detail wizard --------
+        let dgWizardPipeline = null;
+        let dgWizardStep = 0;
+
+        function _normalizePipeline(name) {
+            const t = dgTransforms.find(x => x.name === name);
+            if (!t) return null;
+            return {
+                name: t.name,
+                version: t.version || '1.0.0',
+                description: t.description || '',
+                source: t.source || 'user',
+                applies_to: t.applies_to || {},
+                stages: (t.stages || []).map(s => ({
+                    type: s.type || 'step',
+                    name: s.name || s.type || 'step',
+                    config: s.config || {},
+                })),
+            };
+        }
+
+        function openDgPipelineWizard(name) {
+            const norm = _normalizePipeline(name);
+            if (!norm) return;
+            dgWizardPipeline = norm;
+            dgWizardStep = 1;
+            document.getElementById('dg-pipelines-list-view').style.display = 'none';
+            const detailEl = document.getElementById('dg-pipelines-detail-view');
+            detailEl.style.display = '';
+            renderDgPipelineWizard();
+        }
+
+        // -------- Create / Edit Transform modal --------
+        let dgTxStages = [];
+        let dgTxEditingName = null;  // null = create, else = edit existing user transform
+
+        function openDgTransformCreate() {
+            dgTxEditingName = null;
+            dgTxStages = [
+                { type: 'extract', config: {} },
+                { type: 'chunk', config: {} },
+                { type: 'embed', config: {} },
+            ];
+            const titleEl = document.getElementById('dg-tx-modal-title');
+            const btnEl = document.getElementById('dg-tx-save-btn');
+            if (titleEl) titleEl.textContent = 'Create Transform Pipeline';
+            if (btnEl) btnEl.textContent = 'Create Transform';
+            const nameEl = document.getElementById('dg-tx-name');
+            nameEl.value = '';
+            nameEl.disabled = false;
+            document.getElementById('dg-tx-description').value = '';
+            document.getElementById('dg-tx-extensions').value = '.pdf';
+            const errEl = document.getElementById('dg-tx-error');
+            if (errEl) { errEl.style.display = 'none'; errEl.textContent = ''; }
+            renderDgTxStages();
+            showModal('dg-transform-modal');
+        }
+
+        function openDgTransformEdit(name) {
+            const t = dgTransforms.find(x => x.name === name);
+            if (!t) { alert(`Transform '${name}' not found`); return; }
+            if (t.source === 'builtin') {
+                alert('Built-in transforms are read-only. Create a new transform to customize.');
+                return;
+            }
+            dgTxEditingName = name;
+            dgTxStages = (t.stages || []).map(s => ({
+                type: s.type || 'extract',
+                config: s.config || {},
+            }));
+            const titleEl = document.getElementById('dg-tx-modal-title');
+            const btnEl = document.getElementById('dg-tx-save-btn');
+            if (titleEl) titleEl.textContent = `Edit Transform: ${name}`;
+            if (btnEl) btnEl.textContent = 'Save Changes';
+            const nameEl = document.getElementById('dg-tx-name');
+            nameEl.value = t.name;
+            nameEl.disabled = true;
+            document.getElementById('dg-tx-description').value = t.description || '';
+            const exts = ((t.applies_to || {}).extensions) || [];
+            document.getElementById('dg-tx-extensions').value = exts.join(', ');
+            const errEl = document.getElementById('dg-tx-error');
+            if (errEl) { errEl.style.display = 'none'; errEl.textContent = ''; }
+            renderDgTxStages();
+            showModal('dg-transform-modal');
+        }
+
+        function _stageTypeOptions(selected) {
+            const types = (dgStageCatalog && dgStageCatalog.stages) ? Object.keys(dgStageCatalog.stages) : ['extract', 'caption', 'chunk', 'embed'];
+            return types.map(t => `<option value="${_escape(t)}" ${t === selected ? 'selected' : ''}>${_escape(t)}</option>`).join('');
+        }
+
+        function renderDgTxStages() {
+            const host = document.getElementById('dg-tx-stages');
+            if (!host) return;
+            host.innerHTML = dgTxStages.map((s, i) => {
+                const summary = (dgStageCatalog && dgStageCatalog.stages && dgStageCatalog.stages[s.type] && dgStageCatalog.stages[s.type].summary) || '';
+                const cfgJson = JSON.stringify(s.config || {}, null, 2);
+                const isLast = i === dgTxStages.length - 1;
                 return `
-                    <div class="card" style="cursor: pointer;" onclick="editDgPipeline('${p.name}')">
-                        <div class="card-body">
-                            <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 12px;">
-                                <strong style="font-size: 16px;">${p.name}</strong>
-                                <button class="btn btn-ghost btn-sm" onclick="event.stopPropagation(); deleteDgPipeline('${p.name}')" style="color: var(--error);">Delete</button>
-                            </div>
-                            <p style="color: var(--text-secondary); font-size: 13px; margin-bottom: 16px;">${p.description || ''}</p>
-                            <div style="display: flex; align-items: center; flex-wrap: wrap; gap: 4px;">
-                                ${stepsHtml}
-                            </div>
+                    <div style="border:1px solid var(--border-primary);border-radius:8px;padding:12px;background:var(--bg-secondary);">
+                        <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
+                            <span style="font-size:12px;color:var(--text-tertiary);min-width:40px;">#${i + 1}</span>
+                            <select class="form-input" style="flex:1;" onchange="dgTxSetType(${i}, this.value)">${_stageTypeOptions(s.type)}</select>
+                            <button class="btn btn-ghost btn-sm" onclick="dgTxMove(${i}, -1)" ${i === 0 ? 'disabled style=\"opacity:0.4;\"' : ''}>↑</button>
+                            <button class="btn btn-ghost btn-sm" onclick="dgTxMove(${i}, 1)" ${isLast ? 'disabled style=\"opacity:0.4;\"' : ''}>↓</button>
+                            <button class="btn btn-ghost btn-sm" onclick="dgTxRemove(${i})" title="Remove">✕</button>
                         </div>
+                        ${summary ? `<div style="font-size:12px;color:var(--text-secondary);margin-bottom:8px;">${_escape(summary)}</div>` : ''}
+                        <label style="font-size:11px;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.5px;">Config (JSON, leave {} for defaults)</label>
+                        <textarea id="dg-tx-cfg-${i}" class="form-input" style="font-family:var(--font-mono);font-size:12px;min-height:60px;margin-top:4px;" oninput="dgTxSetConfig(${i}, this.value)">${_escape(cfgJson)}</textarea>
                     </div>
                 `;
             }).join('');
+        }
+
+        function dgTxSetType(i, t) {
+            if (!dgTxStages[i]) return;
+            dgTxStages[i].type = t;
+            renderDgTxStages();
+        }
+        function dgTxSetConfig(i, raw) {
+            // Best-effort: store raw text; parse on save.
+            if (!dgTxStages[i]) return;
+            dgTxStages[i]._rawConfig = raw;
+        }
+        function dgTxMove(i, delta) {
+            const j = i + delta;
+            if (j < 0 || j >= dgTxStages.length) return;
+            // Persist the unsaved config text before re-render
+            for (let k = 0; k < dgTxStages.length; k++) {
+                const ta = document.getElementById(`dg-tx-cfg-${k}`);
+                if (ta) dgTxStages[k]._rawConfig = ta.value;
+            }
+            const tmp = dgTxStages[i]; dgTxStages[i] = dgTxStages[j]; dgTxStages[j] = tmp;
+            renderDgTxStages();
+        }
+        function dgTxRemove(i) {
+            for (let k = 0; k < dgTxStages.length; k++) {
+                const ta = document.getElementById(`dg-tx-cfg-${k}`);
+                if (ta) dgTxStages[k]._rawConfig = ta.value;
+            }
+            dgTxStages.splice(i, 1);
+            renderDgTxStages();
+        }
+        function addDgTxStage() {
+            for (let k = 0; k < dgTxStages.length; k++) {
+                const ta = document.getElementById(`dg-tx-cfg-${k}`);
+                if (ta) dgTxStages[k]._rawConfig = ta.value;
+            }
+            dgTxStages.push({ type: 'chunk', config: {} });
+            renderDgTxStages();
+        }
+
+        function _showTxError(msg) {
+            const el = document.getElementById('dg-tx-error');
+            if (!el) { alert(msg); return; }
+            el.textContent = msg;
+            el.style.display = '';
+        }
+
+        async function saveDgTransform() {
+            const name = (document.getElementById('dg-tx-name').value || '').trim();
+            const description = (document.getElementById('dg-tx-description').value || '').trim();
+            const extsRaw = (document.getElementById('dg-tx-extensions').value || '').trim();
+            const errEl = document.getElementById('dg-tx-error');
+            if (errEl) { errEl.style.display = 'none'; errEl.textContent = ''; }
+
+            if (!name) return _showTxError('Name is required.');
+            if (!/^[a-z0-9][a-z0-9-]*$/i.test(name)) return _showTxError('Name must be alphanumeric with optional dashes.');
+
+            const extensions = extsRaw
+                ? extsRaw.split(',').map(s => s.trim()).filter(Boolean)
+                : [];
+            for (const e of extensions) {
+                if (!e.startsWith('.')) return _showTxError(`Extension '${e}' must start with a dot.`);
+            }
+
+            // Materialize stages from form (parse pending JSON edits)
+            const stages = [];
+            for (let i = 0; i < dgTxStages.length; i++) {
+                const s = dgTxStages[i];
+                let cfg = s.config || {};
+                const ta = document.getElementById(`dg-tx-cfg-${i}`);
+                const raw = ta ? ta.value : (s._rawConfig || JSON.stringify(cfg));
+                if (raw && raw.trim()) {
+                    try { cfg = JSON.parse(raw); }
+                    catch (e) { return _showTxError(`Stage #${i + 1} config is not valid JSON: ${e.message}`); }
+                }
+                if (cfg === null || typeof cfg !== 'object' || Array.isArray(cfg)) {
+                    return _showTxError(`Stage #${i + 1} config must be a JSON object.`);
+                }
+                stages.push({ type: s.type, name: s.type, config: cfg });
+            }
+            if (stages.length === 0) return _showTxError('At least one stage is required.');
+            if (stages[stages.length - 1].type !== 'embed') {
+                return _showTxError("The last stage must be of type 'embed'.");
+            }
+
+            const payload = {
+                name, description,
+                version: '1.0.0',
+                applies_to: { extensions },
+                priority: 50,
+                stages,
+            };
+
+            const isEdit = !!dgTxEditingName;
+            const url = isEdit
+                ? `${DOCGROK_API}/transforms/${encodeURIComponent(dgTxEditingName)}`
+                : `${DOCGROK_API}/transforms`;
+            const method = isEdit ? 'PUT' : 'POST';
+            try {
+                const res = await apiFetch(url, {
+                    method,
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                if (!res.ok) {
+                    const j = await res.json().catch(() => ({}));
+                    return _showTxError(j.detail || `HTTP ${res.status}`);
+                }
+                closeModal('dg-transform-modal');
+                await loadDgTransformPipelines();
+            } catch (e) {
+                _showTxError(`Save failed: ${e.message || e}`);
+            }
+        }
+
+        function closeDgPipelineWizard() {
+            dgWizardPipeline = null;
+            const detailEl = document.getElementById('dg-pipelines-detail-view');
+            detailEl.style.display = 'none';
+            detailEl.innerHTML = '';
+            document.getElementById('dg-pipelines-list-view').style.display = '';
+        }
+
+        function dgWizardGoto(idx) {
+            if (!dgWizardPipeline) return;
+            const total = (dgWizardPipeline.stages || []).length;
+            if (idx < 0) idx = 0;
+            if (idx > total) idx = total;
+            dgWizardStep = idx;
+            renderDgPipelineWizard();
+        }
+
+        function renderDgPipelineWizard() {
+            const detailEl = document.getElementById('dg-pipelines-detail-view');
+            if (!dgWizardPipeline) { closeDgPipelineWizard(); return; }
+            const r = dgWizardPipeline;
+            const total = (r.stages || []).length;
+            const stageBadge = { filter: 'badge-warning', extract: 'badge-info',
+                                 chunk: 'badge-success', embed: 'badge-primary',
+                                 local: 'badge-success', api: 'badge-info' };
+
+            // ---------- Section 1: General Info (always visible) ----------
+            const sourceLabel = r.source === 'builtin' || r.source === 'system' ? 'System (built-in)' : 'User-created';
+            const exts = ((r.applies_to || {}).extensions) || [];
+            const appliesHtml = exts.length
+                ? exts.map(e => `<code style="background:var(--bg-secondary);padding:1px 6px;border-radius:3px;font-size:11px;">${_escape(e)}</code>`).join(' ')
+                : '<span style="color:var(--text-tertiary);font-size:12px;">any input</span>';
+            const generalInfo = `
+                <div class="card" style="margin-bottom:20px;">
+                    <div class="card-body">
+                        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:16px;">
+                            <strong style="font-size:15px;">General info</strong>
+                            <span class="badge badge-success">Active</span>
+                        </div>
+                        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:16px;">
+                            <div><div style="font-size:11px;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px;">Name</div><div style="font-size:14px;">${_escape(r.name)}</div></div>
+                            <div><div style="font-size:11px;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px;">Version</div><div style="font-size:14px;">${_escape(r.version)}</div></div>
+                            <div><div style="font-size:11px;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px;">Source</div><div style="font-size:14px;">${sourceLabel}</div></div>
+                            <div><div style="font-size:11px;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px;">Stages</div><div style="font-size:14px;">${total}</div></div>
+                            <div><div style="font-size:11px;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px;">Topology</div><div style="font-size:14px;color:var(--text-secondary);">DAG · topological order</div></div>
+                            <div><div style="font-size:11px;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px;">Status</div><div style="font-size:14px;color:var(--text-secondary);">Ready</div></div>
+                            <div style="grid-column:1 / -1;"><div style="font-size:11px;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px;">Applies to</div><div style="font-size:14px;">${appliesHtml}</div></div>
+                        </div>
+                        ${r.description ? `<div style="margin-top:16px;padding-top:16px;border-top:1px solid var(--border-primary);">
+                            <div style="font-size:11px;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px;">Description</div>
+                            <div style="font-size:13px;color:var(--text-secondary);line-height:1.6;">${_escape(r.description)}</div>
+                        </div>` : ''}
+                    </div>
+                </div>
+            `;
+
+            // ---------- Section 2: Stages wizard ----------
+            // Wizard step is 1..N (only stages — no overview step)
+            if (dgWizardStep < 1) dgWizardStep = 1;
+            if (dgWizardStep > total) dgWizardStep = total;
+
+            // Step indicator (clickable dots) — only for stages
+            const indicator = r.stages.map((s, i) => {
+                const stepIdx = i + 1;
+                const active = stepIdx === dgWizardStep;
+                const done = stepIdx < dgWizardStep;
+                const bg = active ? 'var(--accent)' : (done ? 'var(--success, #16a34a)' : 'var(--bg-secondary)');
+                const color = (active || done) ? '#fff' : 'var(--text-tertiary)';
+                return `<button onclick="dgWizardGoto(${stepIdx})" style="border:none;background:transparent;cursor:pointer;display:flex;flex-direction:column;align-items:center;gap:4px;flex:1;min-width:0;">
+                    <div style="width:28px;height:28px;border-radius:50%;background:${bg};color:${color};display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:600;">${stepIdx}</div>
+                    <span style="font-size:11px;color:${active ? 'var(--text-primary)' : 'var(--text-tertiary)'};white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:100%;">${_escape(s.name || s.type)}</span>
+                </button>` + (i < r.stages.length - 1
+                    ? `<div style="flex:0 0 12px;height:2px;background:${stepIdx < dgWizardStep ? 'var(--success,#16a34a)' : 'var(--bg-secondary)'};margin-top:13px;"></div>`
+                    : '');
+            }).join('');
+
+            // Current stage detail
+            const s = r.stages[dgWizardStep - 1];
+            const cls = stageBadge[s.type] || 'badge-info';
+            const cfg = s.config || {};
+            const catDef = (dgStageCatalog && dgStageCatalog.stages && dgStageCatalog.stages[s.type]) || null;
+            const catalogParams = catDef ? (catDef.params || {}) : {};
+
+            const allKeys = Array.from(new Set([
+                ...Object.keys(cfg),
+                ...Object.keys(catalogParams),
+            ]));
+            const rows = allKeys.length === 0
+                ? '<div style="color:var(--text-tertiary);font-size:13px;padding:12px 0;">This stage has no configurable params.</div>'
+                : allKeys.map(k => {
+                    const meta = catalogParams[k] || {};
+                    const v = (k in cfg) ? cfg[k] : (meta.default !== undefined ? meta.default : null);
+                    const isDefault = !(k in cfg);
+                    return `
+                        <div style="padding:12px 0;border-top:1px solid var(--border-primary);">
+                            <div style="display:flex;gap:8px;align-items:baseline;flex-wrap:wrap;">
+                                <code style="color:var(--accent);font-weight:600;">${_escape(k)}</code>
+                                ${meta.type ? `<span style="font-size:11px;color:var(--text-tertiary);">${_escape(meta.type)}</span>` : ''}
+                                ${isDefault ? '<span class="badge badge-info" style="font-size:10px;">default</span>' : '<span class="badge badge-success" style="font-size:10px;">configured</span>'}
+                                <span style="margin-left:auto;">${_fmtVal(v)}</span>
+                            </div>
+                            ${meta.description ? `<div style="font-size:12px;color:var(--text-secondary);margin-top:6px;line-height:1.5;">${_escape(meta.description)}</div>` : ''}
+                        </div>
+                    `;
+                }).join('');
+
+            const stageBody = `
+                <div style="display:flex;gap:10px;align-items:center;margin-bottom:8px;flex-wrap:wrap;">
+                    <span class="badge ${cls}">${_escape(s.type)}</span>
+                    <strong style="font-size:18px;">${_escape(s.name || s.type)}</strong>
+                    <span style="font-size:12px;color:var(--text-tertiary);margin-left:auto;">Stage ${dgWizardStep} of ${total}</span>
+                </div>
+                ${catDef && catDef.summary ? `<p style="color:var(--text-secondary);font-size:13px;line-height:1.6;margin-bottom:20px;">${_escape(catDef.summary)}</p>` : ''}
+                <div style="background:var(--bg-secondary);border-radius:8px;padding:8px 16px;">
+                    <div style="font-size:11px;color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.5px;padding:8px 0 4px;">Configuration</div>
+                    ${rows}
+                </div>
+            `;
+
+            const prevDisabled = dgWizardStep <= 1;
+            const nextDisabled = dgWizardStep >= total;
+            const nav = `
+                <div style="display:flex;justify-content:space-between;align-items:center;margin-top:24px;padding-top:16px;border-top:1px solid var(--border-primary);">
+                    <button class="btn btn-ghost" ${prevDisabled ? 'disabled style="opacity:0.4;cursor:not-allowed;"' : ''} onclick="dgWizardGoto(${dgWizardStep - 1})">← Previous</button>
+                    <span style="font-size:12px;color:var(--text-tertiary);">${dgWizardStep} / ${total}</span>
+                    <button class="btn btn-primary" ${nextDisabled ? 'disabled style="opacity:0.4;cursor:not-allowed;"' : ''} onclick="dgWizardGoto(${dgWizardStep + 1})">Next →</button>
+                </div>
+            `;
+
+            const stagesSection = total === 0 ? `
+                <div class="card">
+                    <div class="card-body">
+                        <strong style="font-size:15px;">Stages</strong>
+                        <p style="color:var(--text-tertiary);font-size:13px;margin-top:8px;">This pipeline has no stages.</p>
+                    </div>
+                </div>
+            ` : `
+                <div class="card">
+                    <div class="card-body">
+                        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:20px;">
+                            <strong style="font-size:15px;">Stages</strong>
+                            <span style="font-size:12px;color:var(--text-tertiary);">Click a step to jump</span>
+                        </div>
+                        <div style="display:flex;align-items:flex-start;gap:6px;margin-bottom:24px;overflow-x:auto;">${indicator}</div>
+                        ${stageBody}
+                        ${nav}
+                    </div>
+                </div>
+            `;
+
+            const isUser = !(r.source === 'builtin' || r.source === 'system');
+            const editBtn = isUser
+                ? `<button class="btn btn-primary btn-sm" onclick="openDgTransformEdit('${_escape(r.name)}')" style="margin-left:8px;">Edit</button>`
+                : '';
+            detailEl.innerHTML = `
+                <div style="margin-bottom:16px;display:flex;align-items:center;">
+                    <button class="btn btn-ghost btn-sm" onclick="closeDgPipelineWizard()">← Back to pipelines</button>
+                    ${editBtn}
+                </div>
+                ${generalInfo}
+                ${stagesSection}
+            `;
         }
 
         function showAddDgPipelineModal() {
@@ -9683,6 +10281,38 @@
             }
         }
 
+        function entityBadge(kind) {
+            const k = (kind || 'text').toLowerCase();
+            const palette = {
+                text:  { bg:'#3b82f620', fg:'#3b82f6', label:'TEXT' },
+                image: { bg:'#10b98120', fg:'#10b981', label:'IMAGE' },
+                video: { bg:'#f59e0b20', fg:'#f59e0b', label:'VIDEO' },
+            };
+            const p = palette[k] || palette.text;
+            return `<span style="padding:2px 8px;border-radius:10px;font-size:10px;font-weight:600;background:${p.bg};color:${p.fg};border:1px solid ${p.fg}40;">${p.label}</span>`;
+        }
+
+        let _playgroundImageB64 = null;
+        function onPlaygroundImageChange(ev) {
+            const f = ev.target.files && ev.target.files[0];
+            const status = document.getElementById('playground-image-status');
+            if (!f) { _playgroundImageB64 = null; status.textContent = ''; return; }
+            const r = new FileReader();
+            r.onload = () => {
+                const s = String(r.result || '');
+                const i = s.indexOf(',');
+                _playgroundImageB64 = i >= 0 ? s.substring(i + 1) : s;
+                status.textContent = `${f.name} (${Math.round(f.size/1024)} KB)`;
+            };
+            r.readAsDataURL(f);
+        }
+        function clearPlaygroundImage() {
+            _playgroundImageB64 = null;
+            const inp = document.getElementById('playground-image-file');
+            if (inp) inp.value = '';
+            document.getElementById('playground-image-status').textContent = '';
+        }
+
         async function performVectorSearch() {
             const query = document.getElementById('playground-query').value.trim();
             const destIds = getSelectedDestIds();
@@ -9692,8 +10322,8 @@
             const statusEl = document.getElementById('playground-status');
             const resultsEl = document.getElementById('playground-results');
 
-            if (!query) {
-                alert('Please enter a search query');
+            if (!query && !_playgroundImageB64) {
+                alert('Please enter a search query or upload an image');
                 return;
             }
             if (destIds.length === 0) {
@@ -9711,6 +10341,7 @@
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         query: query,
+                        query_image_b64: _playgroundImageB64,
                         destination_ids: destIds,
                         top_k: topK,
                         merge_strategy: mergeStrategy
@@ -9787,6 +10418,7 @@
                                     </div>
                                 </div>
                                 <div style="display:flex;align-items:center;gap:8px;">
+                                    ${entityBadge(r.entity_type)}
                                     ${indexBadge}
                                     <div style="text-align: right;">
                                         <span class="badge badge-success" style="font-family: 'JetBrains Mono', monospace;">${(r.score * 100).toFixed(1)}%</span>


### PR DESCRIPTION
Adds image and video search to OmniVec end-to-end. Pairs with [DocGrok #2](https://github.com/AzureCosmosDB/DocGrok/pull/2) which lands the worker/router side.

## What this does
- Ingest images and videos via the new `image-transform` and `video-transform` recipes.
- Search image/video indexes by text (CLIP text encoder) or by image upload (CLIP image encoder).
- Show typed (TEXT/IMAGE/VIDEO) results in the Playground UI.

## Changes
**api/api.py**
- Pipeline-creation dim-match enforcement: resolve docgrok `output_dimensions` and destination `vector_indexes[].dimensions`; reject mismatches at create/update.
- `ROUTE_PIPELINE_VIA_DOCGROK`: send all pipeline-worker traffic through the router. Validates transform refs via router `/transforms`.
- Tags image/video indexes with `input_modality` so the searcher knows how to embed the query.
- Playground accepts `query_image_b64`.

**search/**
- `query_image_b64` on `SearchRequest`; `input_modality` on embedding policies; `entity_type` on each result.
- `embed_query` routes image/video indexes through the router: image bytes when provided, else text via `image-transform` (CLIP text encoder — same vector space).
- Hits classified into text/image/video by file extension + index modality.

**web/static/index.html**
- Image upload control in Playground; per-result TEXT/IMAGE/VIDEO badge.

## Verified on omnivec-video deployment
- 5 images ingested → top-1 image matches the text query (e.g. \\ed apple fruit\\ → red_apple.jpg, score 0.246).
- 1 video (12s, 6 scenes) → 10 frame embeddings → each scene-related query retrieves the matching frame (e.g. \\lue ocean water\\ → chunk1, \\yellow sun\\ → chunk9).
- All requests flow through the router (\\_routed_to: pipeline-worker\\).
- Dim-mismatch protection: pipelines whose declared output dim does not match the destination's vector index dim are rejected at create-time.