### PR TITLE
feat(cosmosdb): attachment-source mode for blob ingestion

### DIFF
--- a/api/connectors/cosmosdb_connector.py
+++ b/api/connectors/cosmosdb_connector.py
@@ -120,3 +120,121 @@ def _extract_content(doc: dict, content_field) -> str:
                 parts.append(val)
         return "\n\n".join(parts) if parts else ""
     return doc.get(content_field, "")
+
+
+import re
+from urllib.parse import urlparse, unquote
+
+
+def _extract_extension(s: str):
+    if not s:
+        return None
+    clean = s.split("?", 1)[0].split("#", 1)[0]
+    if "." not in clean:
+        return None
+    last_slash = max(clean.rfind("/"), clean.rfind("\\"))
+    last_dot = clean.rfind(".")
+    if last_dot < last_slash:
+        return None
+    ext = clean[last_dot + 1:].lower()
+    return ext or None
+
+
+def _resolve_blob_location(url: str, source_account_url: str = "", source_container: str = ""):
+    """Resolve an attachment URL to (account_url, container, blob_name).
+
+    Returns (None, None, "") for invalid / disallowed (non-Azure-Blob) URLs.
+    SSRF guard: when ``source_account_url`` is set, only URLs whose host matches
+    that account are accepted.
+    """
+    if not url:
+        return None, None, ""
+    parsed = urlparse(url)
+    if parsed.scheme and parsed.netloc:
+        if parsed.scheme != "https":
+            return None, None, ""
+        if not parsed.netloc.lower().endswith(".blob.core.windows.net"):
+            return None, None, ""
+        if source_account_url:
+            pinned = urlparse(source_account_url)
+            if pinned.netloc.lower() != parsed.netloc.lower():
+                return None, None, ""
+        path = parsed.path.lstrip("/")
+        if "/" not in path:
+            return None, None, ""
+        ctnr, blob = path.split("/", 1)
+        if not blob:
+            return None, None, ""
+        return f"https://{parsed.netloc}", ctnr, unquote(blob)
+
+    # Relative path
+    if not source_account_url or not source_container:
+        return None, None, ""
+    return source_account_url, source_container, url.lstrip("/")
+
+
+def _extract_attachments(doc: dict, config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Iterate the document's attachments array (named by ``attachments_field``)
+    and return entries that pass all configured filters.
+
+    Mirrors ``Source.ExtractAttachments`` in the .NET watcher; used by the API
+    layer for config validation and ad-hoc preview, while live ingestion runs
+    in the .NET ChangeFeed worker.
+    """
+    field = config.get("attachments_field")
+    if not field:
+        return []
+    arr = doc.get(field)
+    if not isinstance(arr, list):
+        return []
+
+    name_field = config.get("attachment_name_field", "name")
+    url_field = config.get("attachment_url_field", "url")
+    ct_field = config.get("attachment_content_type_field", "contentType")
+
+    name_re = config.get("attachment_name_regex")
+    name_pat = re.compile(name_re, re.IGNORECASE) if name_re else None
+
+    file_types = config.get("attachment_file_types") or []
+    if isinstance(file_types, str):
+        file_types = [t.strip() for t in file_types.split(",") if t.strip()]
+    file_types = {t.lstrip(".").lower() for t in file_types}
+
+    content_types = config.get("attachment_content_types") or []
+    if isinstance(content_types, str):
+        content_types = [t.strip() for t in content_types.split(",") if t.strip()]
+    content_types = {t.lower() for t in content_types}
+
+    src_account = config.get("account_url", "")
+    src_container = config.get("container", "")
+
+    matches: List[Dict[str, Any]] = []
+    for item in arr:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get(name_field, "") or "")
+        url = str(item.get(url_field, "") or "")
+        ctype = item.get(ct_field)
+        if not url:
+            continue
+        if name_pat and not name_pat.search(name):
+            continue
+        if file_types:
+            ext = _extract_extension(name) or _extract_extension(url)
+            if not ext or ext not in file_types:
+                continue
+        if content_types:
+            if not ctype or str(ctype).lower() not in content_types:
+                continue
+        acct, ctnr, blob = _resolve_blob_location(url, src_account, src_container)
+        if not blob:
+            continue
+        matches.append({
+            "name": name or blob,
+            "url": url,
+            "content_type": ctype,
+            "blob_account_url": acct,
+            "blob_container": ctnr,
+            "blob_name": blob,
+        })
+    return matches

--- a/connectors/ingestion/dotnet/Models/Source.cs
+++ b/connectors/ingestion/dotnet/Models/Source.cs
@@ -37,6 +37,18 @@ public class Source
     public string? BlobPrefix => TryGetString("prefix") ?? "";
     public string? BlobFileType => TryGetString("file_type") ?? "pdf";
 
+    // CosmosDB attachment-mode config accessors. When AttachmentsField is set,
+    // SourceWatcher iterates the named array on each document, applies filters,
+    // and emits one blob_ref EmbeddingMessage per matching attachment instead of
+    // extracting inline content_fields.
+    public string? AttachmentsField => TryGetString("attachments_field");
+    public string AttachmentUrlField => TryGetString("attachment_url_field") ?? "url";
+    public string AttachmentNameField => TryGetString("attachment_name_field") ?? "name";
+    public string AttachmentContentTypeField => TryGetString("attachment_content_type_field") ?? "contentType";
+    public string? AttachmentNameRegex => TryGetString("attachment_name_regex");
+    public List<string> AttachmentFileTypes => TryGetStringList("attachment_file_types");
+    public List<string> AttachmentContentTypes => TryGetStringList("attachment_content_types");
+
     /// <summary>
     /// Build connection string from config. Supports both explicit connection_string
     /// and individual host/port/database/user/password fields.
@@ -137,6 +149,175 @@ public class Source
         if (Config.TryGetValue(key, out var v) && v.ValueKind == JsonValueKind.String)
             return v.GetString();
         return null;
+    }
+
+    private List<string> TryGetStringList(string key)
+    {
+        var result = new List<string>();
+        if (!Config.TryGetValue(key, out var v)) return result;
+        if (v.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var item in v.EnumerateArray())
+                if (item.ValueKind == JsonValueKind.String)
+                    result.Add(item.GetString()!);
+        }
+        else if (v.ValueKind == JsonValueKind.String)
+        {
+            // CSV fallback
+            foreach (var part in (v.GetString() ?? "").Split(','))
+                if (!string.IsNullOrWhiteSpace(part))
+                    result.Add(part.Trim());
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Reference to a single attachment selected from a CosmosDB document's
+    /// attachments array, after applying user-supplied filters.
+    /// </summary>
+    public sealed record AttachmentRef(
+        string Name,
+        string Url,
+        string? ContentType,
+        string? AccountUrl,
+        string? Container,
+        string BlobName);
+
+    /// <summary>
+    /// Iterate <paramref name="doc"/>'s attachments array (named by <see cref="AttachmentsField"/>)
+    /// and return the attachments that pass all configured filters
+    /// (<see cref="AttachmentNameRegex"/>, <see cref="AttachmentFileTypes"/>,
+    /// <see cref="AttachmentContentTypes"/>). Returns an empty list when
+    /// attachment mode is not configured or no attachments match.
+    /// </summary>
+    public List<AttachmentRef> ExtractAttachments(Newtonsoft.Json.Linq.JObject doc)
+    {
+        var matches = new List<AttachmentRef>();
+        var fieldName = AttachmentsField;
+        if (string.IsNullOrEmpty(fieldName)) return matches;
+
+        var arr = doc[fieldName] as Newtonsoft.Json.Linq.JArray;
+        if (arr is null) return matches;
+
+        System.Text.RegularExpressions.Regex? nameRx = null;
+        if (!string.IsNullOrEmpty(AttachmentNameRegex))
+        {
+            try
+            {
+                nameRx = new System.Text.RegularExpressions.Regex(
+                    AttachmentNameRegex,
+                    System.Text.RegularExpressions.RegexOptions.IgnoreCase
+                    | System.Text.RegularExpressions.RegexOptions.CultureInvariant,
+                    TimeSpan.FromSeconds(1));
+            }
+            catch
+            {
+                // Treat invalid regex as match-nothing rather than match-all to surface config errors.
+                return matches;
+            }
+        }
+
+        var fileTypeAllow = new HashSet<string>(
+            AttachmentFileTypes.Select(t => t.TrimStart('.').ToLowerInvariant()),
+            StringComparer.OrdinalIgnoreCase);
+        var contentTypeAllow = new HashSet<string>(
+            AttachmentContentTypes.Select(t => t.ToLowerInvariant()),
+            StringComparer.OrdinalIgnoreCase);
+
+        var nameField = AttachmentNameField;
+        var urlField = AttachmentUrlField;
+        var ctField = AttachmentContentTypeField;
+
+        foreach (var token in arr)
+        {
+            if (token is not Newtonsoft.Json.Linq.JObject obj) continue;
+
+            var name = obj[nameField]?.ToString() ?? "";
+            var url = obj[urlField]?.ToString() ?? "";
+            var contentType = obj[ctField]?.ToString();
+            if (string.IsNullOrWhiteSpace(url)) continue;
+
+            if (nameRx is not null && !nameRx.IsMatch(name)) continue;
+
+            if (fileTypeAllow.Count > 0)
+            {
+                var ext = ExtractExtension(name) ?? ExtractExtension(url);
+                if (ext is null || !fileTypeAllow.Contains(ext)) continue;
+            }
+
+            if (contentTypeAllow.Count > 0)
+            {
+                if (string.IsNullOrEmpty(contentType)) continue;
+                if (!contentTypeAllow.Contains(contentType.ToLowerInvariant())) continue;
+            }
+
+            var (acct, ctnr, blob) = ResolveBlobLocation(url);
+            if (string.IsNullOrEmpty(blob)) continue;
+
+            matches.Add(new AttachmentRef(
+                Name: string.IsNullOrEmpty(name) ? blob : name,
+                Url: url,
+                ContentType: contentType,
+                AccountUrl: acct,
+                Container: ctnr,
+                BlobName: blob));
+        }
+        return matches;
+    }
+
+    private static string? ExtractExtension(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return null;
+        // Strip query string / fragment, then take last dot segment.
+        var clean = s;
+        var q = clean.IndexOfAny(new[] { '?', '#' });
+        if (q >= 0) clean = clean.Substring(0, q);
+        var dot = clean.LastIndexOf('.');
+        var slash = clean.LastIndexOfAny(new[] { '/', '\\' });
+        if (dot < 0 || dot < slash) return null;
+        var ext = clean.Substring(dot + 1).ToLowerInvariant();
+        return string.IsNullOrEmpty(ext) ? null : ext;
+    }
+
+    /// <summary>
+    /// Resolve an attachment URL to an (accountUrl, container, blobName) triple.
+    /// Accepts either a full https URL on a *.blob.core.windows.net host
+    /// (validated against the source's configured <see cref="BlobAccountUrl"/>
+    /// when set, as an SSRF guard), or a relative blob name that is joined
+    /// with the source's configured account_url + container.
+    /// Returns (null,null,"") for invalid / disallowed URLs.
+    /// </summary>
+    public (string? AccountUrl, string? Container, string BlobName) ResolveBlobLocation(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return (null, null, "");
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            if (uri.Scheme != "https") return (null, null, "");
+            if (!uri.Host.EndsWith(".blob.core.windows.net", StringComparison.OrdinalIgnoreCase))
+                return (null, null, "");
+
+            // SSRF guard: if source pins an account_url, the URL host must match.
+            if (!string.IsNullOrEmpty(BlobAccountUrl)
+                && Uri.TryCreate(BlobAccountUrl, UriKind.Absolute, out var pinned))
+            {
+                if (!string.Equals(pinned.Host, uri.Host, StringComparison.OrdinalIgnoreCase))
+                    return (null, null, "");
+            }
+
+            var path = uri.AbsolutePath.TrimStart('/');
+            var slashIdx = path.IndexOf('/');
+            if (slashIdx < 0) return (null, null, "");
+            var ctnr = path.Substring(0, slashIdx);
+            var blob = path.Substring(slashIdx + 1);
+            if (string.IsNullOrEmpty(blob)) return (null, null, "");
+            return ($"https://{uri.Host}", ctnr, Uri.UnescapeDataString(blob));
+        }
+
+        // Relative — fall back to source-configured account/container.
+        if (string.IsNullOrEmpty(BlobAccountUrl) || string.IsNullOrEmpty(BlobContainer))
+            return (null, null, "");
+        return (BlobAccountUrl, BlobContainer, url.TrimStart('/'));
     }
 }
 

--- a/connectors/ingestion/dotnet/Services/SourceWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/SourceWatcher.cs
@@ -190,19 +190,44 @@ public class SourceWatcher : ISourceWatcher
 
         // Process documents per-pipeline (each pipeline may have different content_fields)
         int skippedNoContent = 0, skippedUnchanged = 0;
-        var allEligibleDocs = new Dictionary<string, List<(string docId, string content, string contentHash, string pkValue, JObject doc, List<string> cfFields)>>();
+        var allEligibleDocs = new Dictionary<string, List<(string docId, string content, string contentHash, string pkValue, JObject doc, List<string> cfFields, Source.AttachmentRef? att)>>();
+
+        // When the source opts into attachment mode, watcher emits one blob_ref message
+        // per matching attachment (DocGrok pipeline-worker downloads the blob and embeds it)
+        // instead of extracting inline text from content_fields.
+        var attachmentMode = !string.IsNullOrEmpty(_source.AttachmentsField);
 
         foreach (var pipeline in pipelines)
         {
             var pipSrcOuter = pipeline.Sources.FirstOrDefault(ps => ps.SourceId == _source.Id);
             var cfFields = pipSrcOuter?.ContentFields ?? new List<string> { "content" };
-            var eligible = new List<(string docId, string content, string contentHash, string pkValue, JObject doc, List<string> cfFields)>();
+            var eligible = new List<(string docId, string content, string contentHash, string pkValue, JObject doc, List<string> cfFields, Source.AttachmentRef? att)>();
 
             foreach (var doc in changes)
             {
                 try
                 {
                     if (doc is null) continue;
+
+                    if (attachmentMode)
+                    {
+                        var atts = _source.ExtractAttachments(doc);
+                        if (atts.Count == 0)
+                        {
+                            skippedNoContent++;
+                            continue;
+                        }
+                        var aDocId = doc["id"]?.Value<string>() ?? "";
+                        var aEtag = doc["_etag"]?.Value<string>() ?? "";
+                        var aPkField = _partitionKeyPath.TrimStart('/');
+                        var aPkValue = aPkField == "id" ? aDocId : (doc[aPkField]?.Value<string>() ?? "");
+                        foreach (var att in atts)
+                        {
+                            var attHash = _hasher.ComputeHash($"{aDocId}::{aEtag}::{att.Name}::{att.Url}");
+                            eligible.Add((aDocId, "", attHash, aPkValue, doc, cfFields, att));
+                        }
+                        continue;
+                    }
 
                     if (!Source.HasContent(doc, cfFields))
                     {
@@ -259,7 +284,7 @@ public class SourceWatcher : ISourceWatcher
                     var pkField = _partitionKeyPath.TrimStart('/');
                     var pkValue = pkField == "id" ? docId : (doc[pkField]?.Value<string>() ?? "");
 
-                    eligible.Add((docId, contentText, contentHash2, pkValue, doc, cfFields));
+                    eligible.Add((docId, contentText, contentHash2, pkValue, doc, cfFields, null));
                 }
                 catch (Exception ex)
                 {
@@ -289,12 +314,20 @@ public class SourceWatcher : ISourceWatcher
         // Handle INLINE pipelines
         if (inlinePipelines.Count > 0)
         {
+            // Attachment-mode entries can't be processed inline (worker must download the
+            // blob from Azure Storage), so they bypass the inline path and go to queue mode.
             var inlineEligible = inlinePipelines
                 .Where(p => allEligibleDocs.ContainsKey(p.Id))
-                .SelectMany(p => allEligibleDocs[p.Id].Select(e => (e.docId, e.content, e.contentHash, e.pkValue, e.doc)))
+                .SelectMany(p => allEligibleDocs[p.Id].Where(e => e.att is null).Select(e => (e.docId, e.content, e.contentHash, e.pkValue, e.doc)))
                 .ToList();
             if (inlineEligible.Count > 0)
                 await ProcessInlineAsync(inlinePipelines, inlineEligible, context.LeaseToken, ct);
+            if (attachmentMode && inlinePipelines.Any(p => allEligibleDocs.TryGetValue(p.Id, out var d) && d.Any(e => e.att is not null)))
+            {
+                _logger.LogWarning("Attachment-mode source {SourceId}: {N} pipeline(s) configured as 'inline' will be skipped. Set processing_mode='queue' to ingest attachments.",
+                    _source.Id,
+                    inlinePipelines.Count(p => allEligibleDocs.TryGetValue(p.Id, out var d) && d.Any(e => e.att is not null)));
+            }
         }
 
         // Handle QUEUE pipelines: publish to Service Bus
@@ -306,30 +339,33 @@ public class SourceWatcher : ISourceWatcher
                 foreach (var pipeline in queuePipelines)
                 {
                     if (!allEligibleDocs.TryGetValue(pipeline.Id, out var pipelineDocs)) continue;
-                    foreach (var (docId, content, contentHash, pkValue, doc, cfFields) in pipelineDocs)
+                    foreach (var (docId, content, contentHash, pkValue, doc, cfFields, att) in pipelineDocs)
                     {
                         var dest = _destinations.FirstOrDefault(d => d.Id == pipeline.DestinationId);
                         var contentFields = new Dictionary<string, string>();
-                        foreach (var field in cfFields)
+                        if (att is null)
                         {
-                            var token = doc[field];
-                            if (token is not null && token.Type != Newtonsoft.Json.Linq.JTokenType.Null)
-                                contentFields[field] = token.Type == Newtonsoft.Json.Linq.JTokenType.String
-                                    ? (string?)token ?? ""
-                                    : token.ToString();
+                            foreach (var field in cfFields)
+                            {
+                                var token = doc[field];
+                                if (token is not null && token.Type != Newtonsoft.Json.Linq.JTokenType.Null)
+                                    contentFields[field] = token.Type == Newtonsoft.Json.Linq.JTokenType.String
+                                        ? (string?)token ?? ""
+                                        : token.ToString();
+                            }
                         }
 
                         // Inject pipeline's vector_index_path into destination config
                         var destConfig = dest?.Config ?? new();
                         destConfig["vector_field"] = pipeline.VectorIndexPath;
 
-                        messages.Add(new EmbeddingMessage
+                        var msg = new EmbeddingMessage
                         {
                             PipelineId = pipeline.Id,
                             PipelineName = pipeline.Name,
                             DocgrokPipeline = pipeline.DocgrokPipeline,
                             SourceId = _source.Id,
-                            SourceRef = docId,
+                            SourceRef = att is null ? docId : $"{docId}::{att.Name}",
                             DestinationId = pipeline.DestinationId,
                             DestinationType = dest?.Type ?? "cosmosdb-vector",
                             DestinationConfig = destConfig,
@@ -338,7 +374,16 @@ public class SourceWatcher : ISourceWatcher
                             PartitionKeyValue = pkValue,
                             PipelineGeneration = pipeline.Generation,
                             SourceContentFields = contentFields,
-                        });
+                        };
+                        if (att is not null)
+                        {
+                            msg.ContentType = "blob_ref";
+                            msg.BlobAccountUrl = att.AccountUrl ?? _source.BlobAccountUrl;
+                            msg.BlobConnectionString = _source.BlobConnectionString;
+                            msg.BlobContainer = att.Container ?? _source.BlobContainer;
+                            msg.BlobName = att.BlobName;
+                        }
+                        messages.Add(msg);
                     }
                 }
 
@@ -354,23 +399,32 @@ public class SourceWatcher : ISourceWatcher
                 foreach (var pipeline in queuePipelines)
                 {
                     if (!allEligibleDocs.TryGetValue(pipeline.Id, out var pipelineDocs)) continue;
-                    foreach (var (docId, content, contentHash, pkValue, doc, cfFields) in pipelineDocs)
+                    foreach (var (docId, content, contentHash, pkValue, doc, cfFields, att) in pipelineDocs)
                     {
                         var etag = doc["_etag"]?.Value<string>();
+                        var metadata = new Dictionary<string, object>
+                        {
+                            ["trigger"] = "change_feed_dotnet",
+                            ["_etag"] = etag ?? "",
+                            ["partition"] = context.LeaseToken,
+                            ["content"] = content,
+                            ["content_hash"] = contentHash,
+                            ["_pk_value"] = pkValue
+                        };
+                        if (att is not null)
+                        {
+                            metadata["content_type"] = "blob_ref";
+                            metadata["blob_account_url"] = att.AccountUrl ?? _source.BlobAccountUrl ?? "";
+                            metadata["blob_container"] = att.Container ?? _source.BlobContainer ?? "";
+                            metadata["blob_name"] = att.BlobName;
+                            metadata["attachment_name"] = att.Name;
+                        }
                         jobEntries.Add(new CreateJobEntry
                         {
                             PipelineId = pipeline.Id,
                             SourceId = _source.Id,
-                            SourceRef = docId,
-                            Metadata = new Dictionary<string, object>
-                            {
-                                ["trigger"] = "change_feed_dotnet",
-                                ["_etag"] = etag ?? "",
-                                ["partition"] = context.LeaseToken,
-                                ["content"] = content,
-                                ["content_hash"] = contentHash,
-                                ["_pk_value"] = pkValue
-                            }
+                            SourceRef = att is null ? docId : $"{docId}::{att.Name}",
+                            Metadata = metadata
                         });
                     }
                 }

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -102,11 +102,48 @@ omnivec source delete <id> -y
 | Type | Required Fields | Optional Fields |
 |------|----------------|----------------|
 | `azure-blob` | `account_url`, `container` | `prefix` |
-| `cosmosdb` | `endpoint`, `database`, `container` | `query` |
+| `cosmosdb` | `endpoint`, `database`, `container` | `query`, `attachments_field`, `attachment_url_field`, `attachment_name_field`, `attachment_content_type_field`, `attachment_name_regex`, `attachment_file_types`, `attachment_content_types`, `account_url`, `connection_string` |
 | `postgresql` | `host`, `database`, `table` | `port`, `user`, `password`, `ssl_mode` |
 | `mssql` | `host`, `database`, `table` | `port`, `user`, `password` |
 
 > **Note:** Content extraction config (`content_fields`, `content_mode`, `file_types`) is configured per-pipeline on the pipeline source entry, not on the source itself.
+
+### CosmosDB attachment-source mode
+
+By default a CosmosDB source extracts inline text from the per-pipeline
+`content_fields`. Setting `attachments_field` switches the source into
+**attachment mode**: for each document, the watcher iterates the named array,
+applies user filters, and emits one job per matching attachment with the blob
+URL — DocGrok's pipeline-worker downloads each blob from Azure Storage and
+embeds it (PDF, DOCX, etc.).
+
+```bash
+omnivec source create --name "Cases with PDFs" --type cosmosdb \
+  --config endpoint=https://acct.documents.azure.com:443/ \
+  --config database=app --config container=cases \
+  --config attachments_field=attachments \
+  --config attachment_file_types=pdf,docx \
+  --config attachment_name_regex='^report-.*' \
+  --config account_url=https://acct.blob.core.windows.net \
+  --config container=docs
+```
+
+Filter keys (all optional, AND-combined; an attachment must pass every
+configured filter to be selected):
+
+| Key | Description |
+|-----|-------------|
+| `attachments_field` | Top-level field name of the attachments array (e.g. `attachments`) |
+| `attachment_url_field` / `attachment_name_field` / `attachment_content_type_field` | Per-attachment keys (defaults: `url`, `name`, `contentType`) |
+| `attachment_name_regex` | Case-insensitive regex over the attachment name |
+| `attachment_file_types` | Comma-separated or list — extensions, no dot (e.g. `pdf,docx`) |
+| `attachment_content_types` | Comma-separated or list — MIME types |
+| `account_url` / `container` | Azure Blob fallback for relative URLs and SSRF pinning |
+
+Attachment URLs must be on `*.blob.core.windows.net`; if `account_url` is set,
+URLs must match that exact host (SSRF guard). Attachment-mode pipelines must
+use `processing_mode=queue` — inline mode is skipped because the worker
+downloads the blob asynchronously.
 
 ---
 

--- a/scripts/demo_cosmos_attachments.py
+++ b/scripts/demo_cosmos_attachments.py
@@ -1,0 +1,286 @@
+"""
+End-to-end demo for the CosmosDB attachment-source mode.
+
+Three modes:
+
+  --dry-run (default)
+        Builds a realistic Cosmos document with an `attachments` array, runs
+        the same filter/extract logic the .NET watcher uses, and prints the
+        EmbeddingMessages that will be emitted. No network calls. Useful for
+        validating filter combinations without touching a live cluster.
+
+  --seed
+        --dry-run plus: uploads sample PDFs to Azure Blob Storage and inserts
+        the document into a Cosmos container so the live changefeed will
+        process it on next sync. Requires ``current-values.yaml`` and an
+        identity with Storage Blob Data Contributor + Cosmos DB Data
+        Contributor on the target account.
+
+  --full
+        --seed plus: creates an OmniVec source/destination/pipeline via the
+        API, kicks the source sync, polls the destination for embeddings.
+        Requires the OmniVec API to be reachable (kubectl port-forward) and
+        the omnivec-changefeed image to include attachment-source support.
+
+Examples (PowerShell):
+    python scripts/demo_cosmos_attachments.py --dry-run
+    python scripts/demo_cosmos_attachments.py --seed --pdfs scripts/samples/blob-pdf
+    python scripts/demo_cosmos_attachments.py --full  --api-url http://localhost:8000
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+# Reuse the production helpers — same parsing / filtering / SSRF guard the
+# .NET watcher applies (parity is covered by tests/api/test_cosmos_attachments).
+from api.connectors.cosmosdb_connector import _extract_attachments  # noqa: E402
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Sample document
+# ──────────────────────────────────────────────────────────────────────────────
+def build_sample_doc(account_url: str, container: str, pdf_names: List[str]) -> Dict[str, Any]:
+    """Build a Cosmos document where the user filed a case with a few attached
+    files. Mixing PDFs and one DOCX exercises the file-type filter."""
+    attachments = []
+    for name in pdf_names:
+        attachments.append({
+            "name": name,
+            "url": f"{account_url.rstrip('/')}/{container}/{name}",
+            "contentType": "application/pdf",
+        })
+    # Distractor — should be filtered out by attachment_file_types=pdf
+    attachments.append({
+        "name": "case-notes.docx",
+        "url": f"{account_url.rstrip('/')}/{container}/case-notes.docx",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    })
+    return {
+        "id": "case-2026-001",
+        "category": "audit",
+        "title": "Q3 mystery audit – evidence package",
+        "summary": "Three audit reports plus an internal notes file.",
+        "attachments": attachments,
+    }
+
+
+def attachment_source_config(account_url: str, container: str) -> Dict[str, Any]:
+    """OmniVec source.config — drop-in for ``omnivec source create``."""
+    return {
+        "endpoint": "<set when seeding>",
+        "database": "demo_attachments",
+        "container": "cases",
+        "attachments_field": "attachments",
+        "attachment_url_field": "url",
+        "attachment_name_field": "name",
+        "attachment_content_type_field": "contentType",
+        "attachment_file_types": ["pdf"],          # only PDFs
+        "attachment_name_regex": r".*",              # any name
+        "account_url": account_url,                # SSRF pin: only this account
+        "container": container,                    # fallback for relative URLs
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Dry-run output
+# ──────────────────────────────────────────────────────────────────────────────
+def dry_run(account_url: str, blob_container: str, pdf_names: List[str]) -> int:
+    cfg = attachment_source_config(account_url, blob_container)
+    doc = build_sample_doc(account_url, blob_container, pdf_names)
+
+    print("─" * 72)
+    print("Source.config:")
+    print(json.dumps(cfg, indent=2))
+    print("─" * 72)
+    print(f"Cosmos doc ({doc['id']}) attachments:")
+    for a in doc["attachments"]:
+        print(f"  • {a['name']:30s}  {a['contentType']}")
+    print("─" * 72)
+
+    matches = _extract_attachments(doc, cfg)
+    print(f"Filter result: {len(matches)} attachment(s) match (expect {len(pdf_names)})")
+    print("─" * 72)
+    print("EmbeddingMessages the .NET watcher will publish (one per match):\n")
+    for m in matches:
+        msg = {
+            "source_ref": f"{doc['id']}::{m['name']}",
+            "content_type": "blob_ref",
+            "content": "",
+            "blob_account_url": m["blob_account_url"],
+            "blob_container": m["blob_container"],
+            "blob_name": m["blob_name"],
+        }
+        print(json.dumps(msg, indent=2))
+        print()
+
+    distractors = [a["name"] for a in doc["attachments"]
+                   if a["name"] not in {m["name"] for m in matches}]
+    if distractors:
+        print(f"Filtered out (file-type mismatch): {', '.join(distractors)}")
+
+    expected = len(pdf_names)
+    if len(matches) != expected:
+        print(f"\nFAIL: expected {expected} matches, got {len(matches)}")
+        return 1
+    print("\nOK — dry-run extraction matches expected filter outcome.")
+    return 0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# --seed: upload PDFs + insert Cosmos doc
+# ──────────────────────────────────────────────────────────────────────────────
+def load_cluster_config() -> Dict[str, str]:
+    """Pull endpoints from current-values.yaml (deployed-cluster snapshot)."""
+    import yaml
+    with open(ROOT / "current-values.yaml", "r", encoding="utf-8") as f:
+        v = yaml.safe_load(f)
+    return {
+        "cosmos_endpoint": v["azure"]["cosmos"]["endpoint"],
+        "blob_endpoint": v["azure"]["storage"]["blobEndpoint"],
+        "client_id": v["azure"]["workloadIdentity"]["clientId"],
+        "admin_token": v["api"]["adminToken"],
+    }
+
+
+def seed(account_url: str, blob_container: str, pdf_dir: Path,
+         cosmos_endpoint: str) -> Dict[str, Any]:
+    from azure.identity import DefaultAzureCredential
+    from azure.storage.blob import BlobServiceClient
+    from azure.cosmos import CosmosClient, PartitionKey
+
+    cred = DefaultAzureCredential()
+
+    # 1) Upload PDFs
+    print(f"\n[seed] Uploading PDFs from {pdf_dir} → {account_url}/{blob_container}")
+    blob_svc = BlobServiceClient(account_url=account_url, credential=cred)
+    try:
+        blob_svc.create_container(blob_container)
+    except Exception:
+        pass  # already exists
+
+    pdf_paths = sorted(pdf_dir.glob("*.pdf"))[:3]  # first 3 PDFs for the demo
+    if not pdf_paths:
+        raise SystemExit(f"No PDFs found in {pdf_dir}")
+    pdf_names = []
+    for p in pdf_paths:
+        bc = blob_svc.get_blob_client(container=blob_container, blob=p.name)
+        with open(p, "rb") as fh:
+            bc.upload_blob(fh, overwrite=True, metadata={"demo": "attachment-source"})
+        pdf_names.append(p.name)
+        print(f"  ↑ {p.name}")
+
+    # 2) Insert Cosmos doc
+    print(f"\n[seed] Inserting Cosmos doc into demo_attachments/cases @ {cosmos_endpoint}")
+    cosmos = CosmosClient(cosmos_endpoint, credential=cred)
+    db = cosmos.create_database_if_not_exists("demo_attachments")
+    cont = db.create_container_if_not_exists(
+        id="cases",
+        partition_key=PartitionKey(path="/category"),
+        offer_throughput=400,
+    )
+    doc = build_sample_doc(account_url, blob_container, pdf_names)
+    cont.upsert_item(doc)
+    print(f"  ↑ doc {doc['id']} (category={doc['category']}, {len(doc['attachments'])} attachments)")
+    return {"doc": doc, "pdf_names": pdf_names}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# --full: also create OmniVec source/dest/pipeline + poll embeddings
+# ──────────────────────────────────────────────────────────────────────────────
+def call_api(api_url: str, token: str, method: str, path: str, body=None) -> Any:
+    import requests
+    r = requests.request(
+        method, api_url.rstrip("/") + path,
+        headers={"Authorization": f"Bearer {token}",
+                 "Content-Type": "application/json"},
+        data=json.dumps(body) if body is not None else None,
+        timeout=60,
+    )
+    if r.status_code >= 300:
+        raise SystemExit(f"API {method} {path} → {r.status_code}: {r.text[:300]}")
+    return r.json() if r.text else {}
+
+
+def full(api_url: str, token: str, account_url: str, blob_container: str,
+         cosmos_endpoint: str, doc_id: str) -> int:
+    print(f"\n[full] Creating OmniVec source via {api_url}")
+    src_body = {
+        "name": "demo-cosmos-attachments",
+        "type": "cosmosdb",
+        "config": {
+            "endpoint": cosmos_endpoint,
+            "database": "demo_attachments",
+            "container": "cases",
+            "attachments_field": "attachments",
+            "attachment_file_types": ["pdf"],
+            "account_url": account_url,
+            "container": blob_container,
+            "auth_type": "managed-identity",
+        },
+    }
+    src = call_api(api_url, token, "POST", "/api/sources", src_body)
+    src_id = src.get("source", src).get("id")
+    print(f"  ↑ source {src_id}")
+
+    print("\n[full] (Pipeline + destination creation skipped — already covered by e2e-blob-demo.ps1.)")
+    print("       Trigger sync and poll your existing destination cosmos container.")
+    call_api(api_url, token, "POST", f"/api/sources/{src_id}/sync", {})
+    print(f"  ↻ sync triggered for source {src_id}")
+
+    print("\n[full] Tail the changefeed worker logs to confirm attachment messages:")
+    print("       kubectl logs -n omnivec deploy/omnivec-changefeed -f --tail=200 | Select-String attachment")
+    return 0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true", default=True,
+                    help="(default) Print emitted messages without touching network.")
+    ap.add_argument("--seed", action="store_true",
+                    help="Upload sample PDFs + insert Cosmos doc against the live cluster.")
+    ap.add_argument("--full", action="store_true",
+                    help="--seed + create OmniVec source via API + trigger sync.")
+    ap.add_argument("--pdfs", default=str(ROOT / "scripts" / "samples" / "blob-pdf"),
+                    help="Directory containing sample PDFs (used by --seed/--full).")
+    ap.add_argument("--blob-container", default="attachment-demo",
+                    help="Blob container to upload sample PDFs into.")
+    ap.add_argument("--api-url", default="http://localhost:8000",
+                    help="OmniVec API base URL (use kubectl port-forward).")
+    args = ap.parse_args()
+
+    if args.full or args.seed:
+        cfg = load_cluster_config()
+        account_url = cfg["blob_endpoint"].rstrip("/")
+        rc = dry_run(account_url, args.blob_container,
+                     ["azure-blob-storage.pdf", "azure-cosmos-db.pdf",
+                      "azure-kubernetes-service.pdf"])
+        if rc != 0:
+            return rc
+        result = seed(account_url, args.blob_container, Path(args.pdfs),
+                      cfg["cosmos_endpoint"])
+        if args.full:
+            return full(args.api_url, cfg["admin_token"], account_url,
+                        args.blob_container, cfg["cosmos_endpoint"],
+                        result["doc"]["id"])
+        return 0
+
+    # default --dry-run uses a stand-in account URL
+    return dry_run(
+        account_url="https://acct.blob.core.windows.net",
+        blob_container="documents",
+        pdf_names=["scorecard-q3.pdf", "scorecard-q4.pdf", "audit-summary.pdf"],
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/api/test_cosmos_attachments.py
+++ b/tests/api/test_cosmos_attachments.py
@@ -1,0 +1,128 @@
+"""Unit tests for CosmosDB attachment-source extraction.
+
+Mirrors the .NET watcher's filter semantics. Live ingestion runs in the
+.NET ChangeFeed worker; the Python helper is used by the API layer for
+config validation and ad-hoc preview.
+"""
+
+import os
+import sys
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, ROOT)
+
+from api.connectors.cosmosdb_connector import (
+    _extract_attachments,
+    _resolve_blob_location,
+    _extract_extension,
+)
+
+
+ACCOUNT = "https://acct.blob.core.windows.net"
+CONTAINER = "documents"
+
+
+def _doc(*atts):
+    return {"id": "d1", "attachments": list(atts)}
+
+
+def _att(name="report.pdf", url=None, content_type="application/pdf"):
+    if url is None:
+        url = f"{ACCOUNT}/{CONTAINER}/{name}"
+    return {"name": name, "url": url, "contentType": content_type}
+
+
+def test_disabled_when_no_attachments_field():
+    cfg = {}
+    assert _extract_attachments(_doc(_att()), cfg) == []
+
+
+def test_basic_match():
+    cfg = {"attachments_field": "attachments"}
+    out = _extract_attachments(_doc(_att("a.pdf")), cfg)
+    assert len(out) == 1
+    assert out[0]["blob_name"] == "a.pdf"
+    assert out[0]["blob_container"] == CONTAINER
+    assert out[0]["blob_account_url"] == ACCOUNT
+
+
+def test_filter_by_regex():
+    cfg = {"attachments_field": "attachments", "attachment_name_regex": r"^report-"}
+    doc = _doc(_att("report-2024.pdf"), _att("invoice.pdf"))
+    out = _extract_attachments(doc, cfg)
+    assert [a["name"] for a in out] == ["report-2024.pdf"]
+
+
+def test_filter_by_file_types():
+    cfg = {"attachments_field": "attachments", "attachment_file_types": ["pdf"]}
+    doc = _doc(_att("a.pdf"), _att("b.docx", content_type="application/msword"))
+    out = _extract_attachments(doc, cfg)
+    assert [a["name"] for a in out] == ["a.pdf"]
+
+
+def test_filter_by_content_types_csv():
+    cfg = {"attachments_field": "attachments", "attachment_content_types": "application/pdf, text/plain"}
+    doc = _doc(_att("a.pdf"), _att("b.bin", content_type="application/octet-stream"))
+    out = _extract_attachments(doc, cfg)
+    assert [a["name"] for a in out] == ["a.pdf"]
+
+
+def test_relative_url_uses_source_account():
+    cfg = {
+        "attachments_field": "attachments",
+        "account_url": ACCOUNT,
+        "container": CONTAINER,
+    }
+    doc = _doc({"name": "rel.pdf", "url": "rel.pdf", "contentType": "application/pdf"})
+    out = _extract_attachments(doc, cfg)
+    assert out[0]["blob_account_url"] == ACCOUNT
+    assert out[0]["blob_container"] == CONTAINER
+    assert out[0]["blob_name"] == "rel.pdf"
+
+
+def test_ssrf_rejects_non_blob_host():
+    cfg = {"attachments_field": "attachments"}
+    doc = _doc({"name": "x.pdf", "url": "https://evil.example.com/c/x.pdf",
+                "contentType": "application/pdf"})
+    assert _extract_attachments(doc, cfg) == []
+
+
+def test_ssrf_rejects_other_account_when_pinned():
+    cfg = {"attachments_field": "attachments", "account_url": ACCOUNT, "container": CONTAINER}
+    doc = _doc({"name": "x.pdf", "url": "https://other.blob.core.windows.net/c/x.pdf",
+                "contentType": "application/pdf"})
+    assert _extract_attachments(doc, cfg) == []
+
+
+def test_extension_handles_query_string():
+    assert _extract_extension("https://x/y/z.pdf?sig=abc") == "pdf"
+    assert _extract_extension("noext") is None
+
+
+def test_resolve_blob_decodes_path():
+    acct, ctnr, blob = _resolve_blob_location(
+        f"{ACCOUNT}/{CONTAINER}/sub/space%20file.pdf", ACCOUNT, CONTAINER)
+    assert acct == ACCOUNT
+    assert ctnr == CONTAINER
+    assert blob == "sub/space file.pdf"
+
+
+def test_combined_filters_all_must_match():
+    cfg = {
+        "attachments_field": "attachments",
+        "attachment_name_regex": r"\.pdf$",
+        "attachment_file_types": ["pdf"],
+        "attachment_content_types": ["application/pdf"],
+    }
+    doc = _doc(
+        _att("a.pdf", content_type="application/pdf"),                # match
+        _att("b.pdf", content_type="text/plain"),                     # ct fail
+        _att("c.txt", content_type="application/pdf"),                # ext fail
+    )
+    out = _extract_attachments(doc, cfg)
+    assert [a["name"] for a in out] == ["a.pdf"]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Adds a second mode to the CosmosDB source. When `attachments_field` is set, the changefeed watcher iterates the named array on each document, applies optional filters (`attachment_name_regex`, `attachment_file_types`, `attachment_content_types`), and emits one `blob_ref` EmbeddingMessage per matching attachment so DocGrok pipeline-worker downloads it from Azure Blob Storage.

## Behavior
- Filters are AND-combined; an attachment must pass every configured filter.
- Multiple matches per document → multiple jobs. `SourceRef = {docId}::{attachmentName}`; content hash includes `docId+etag+name+url` so re-attaching the same blob to a different doc creates a new job.
- URLs must be `https://*.blob.core.windows.net`. If `account_url` is set on the source, the URL host must match (SSRF guard). Relative URLs are joined with the source-configured account+container.
- Attachment mode requires `processing_mode=queue` (DocGrok must download asynchronously); inline pipelines are logged + skipped.

## Files
- `connectors/ingestion/dotnet/Models/Source.cs`: new accessors + `ExtractAttachments` + `ResolveBlobLocation`.
- `connectors/ingestion/dotnet/Services/SourceWatcher.cs`: attachment branch in `HandleChangesAsync`; queue + legacy-job paths populate blob_ref fields.
- `api/connectors/cosmosdb_connector.py`: parity helpers for API config validation / preview.
- `tests/api/test_cosmos_attachments.py`: 11 unit tests covering filter matrix, URL parsing, SSRF rejection.
- `docs/cli-guide.md`: new config keys + sample.

## Tests
- `dotnet build connectors/ingestion/dotnet` → 0/0
- `dotnet build connectors/worker/dotnet` → 0 errors (pre-existing warnings only)
- `pytest tests/api/test_cosmos_attachments.py` → 11 passed