### PR TITLE
fix(cosmosdb): separate attachment_blob_container key to avoid clash with cosmos container

### DIFF
--- a/api/connectors/cosmosdb_connector.py
+++ b/api/connectors/cosmosdb_connector.py
@@ -206,7 +206,10 @@ def _extract_attachments(doc: dict, config: Dict[str, Any]) -> List[Dict[str, An
     content_types = {t.lower() for t in content_types}
 
     src_account = config.get("account_url", "")
-    src_container = config.get("container", "")
+    # For cosmosdb attachment-mode sources, "container" names the cosmos
+    # container; honor "attachment_blob_container" as the dedicated key for
+    # the default blob container used to resolve relative attachment URLs.
+    src_container = config.get("attachment_blob_container") or config.get("container", "")
 
     matches: List[Dict[str, Any]] = []
     for item in arr:

--- a/connectors/ingestion/dotnet/Models/Source.cs
+++ b/connectors/ingestion/dotnet/Models/Source.cs
@@ -33,7 +33,12 @@ public class Source
     // Blob source config accessors
     public string? BlobAccountUrl => TryGetString("account_url");
     public string? BlobConnectionString => TryGetString("connection_string");
-    public string? BlobContainer => TryGetString("container");
+    // For pure blob sources, "container" names the blob container.
+    // For cosmosdb attachment-mode sources, "container" names the *cosmos*
+    // container, so we honor "attachment_blob_container" first as a default
+    // for relative attachment URLs (and as the SSRF guard fallback container).
+    public string? BlobContainer =>
+        TryGetString("attachment_blob_container") ?? TryGetString("container");
     public string? BlobPrefix => TryGetString("prefix") ?? "";
     public string? BlobFileType => TryGetString("file_type") ?? "pdf";
 

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -102,7 +102,7 @@ omnivec source delete <id> -y
 | Type | Required Fields | Optional Fields |
 |------|----------------|----------------|
 | `azure-blob` | `account_url`, `container` | `prefix` |
-| `cosmosdb` | `endpoint`, `database`, `container` | `query`, `attachments_field`, `attachment_url_field`, `attachment_name_field`, `attachment_content_type_field`, `attachment_name_regex`, `attachment_file_types`, `attachment_content_types`, `account_url`, `connection_string` |
+| `cosmosdb` | `endpoint`, `database`, `container` | `query`, `attachments_field`, `attachment_url_field`, `attachment_name_field`, `attachment_content_type_field`, `attachment_name_regex`, `attachment_file_types`, `attachment_content_types`, `attachment_blob_container`, `account_url`, `connection_string` |
 | `postgresql` | `host`, `database`, `table` | `port`, `user`, `password`, `ssl_mode` |
 | `mssql` | `host`, `database`, `table` | `port`, `user`, `password` |
 
@@ -125,8 +125,15 @@ omnivec source create --name "Cases with PDFs" --type cosmosdb \
   --config attachment_file_types=pdf,docx \
   --config attachment_name_regex='^report-.*' \
   --config account_url=https://acct.blob.core.windows.net \
-  --config container=docs
+  --config attachment_blob_container=docs
 ```
+
+Note that `container` names the **cosmos** container (`cases` above). For
+attachments stored in Azure Blob Storage, use the dedicated
+`attachment_blob_container` key — it is honored ahead of `container` for
+relative-URL resolution and SSRF guard so the two values do not collide.
+Most deployments use absolute blob URLs in the document itself and can omit
+both `account_url` and `attachment_blob_container`.
 
 Filter keys (all optional, AND-combined; an attachment must pass every
 configured filter to be selected):
@@ -138,7 +145,8 @@ configured filter to be selected):
 | `attachment_name_regex` | Case-insensitive regex over the attachment name |
 | `attachment_file_types` | Comma-separated or list — extensions, no dot (e.g. `pdf,docx`) |
 | `attachment_content_types` | Comma-separated or list — MIME types |
-| `account_url` / `container` | Azure Blob fallback for relative URLs and SSRF pinning |
+| `account_url` | Azure Blob account URL — SSRF host pin (URLs must match) |
+| `attachment_blob_container` | Default blob container for relative URLs (preferred over `container`) |
 
 Attachment URLs must be on `*.blob.core.windows.net`; if `account_url` is set,
 URLs must match that exact host (SSRF guard). Attachment-mode pipelines must

--- a/tests/api/test_cosmos_attachments.py
+++ b/tests/api/test_cosmos_attachments.py
@@ -81,6 +81,23 @@ def test_relative_url_uses_source_account():
     assert out[0]["blob_name"] == "rel.pdf"
 
 
+def test_relative_url_prefers_attachment_blob_container():
+    # When both keys are present, attachment_blob_container wins so the
+    # cosmos container value (still in "container") is not used as the blob
+    # container. This is the documented escape hatch for sources that need
+    # to also pin a default blob container for relative URLs.
+    cfg = {
+        "attachments_field": "attachments",
+        "account_url": ACCOUNT,
+        "container": "cases",  # cosmos container — must NOT be used as blob container
+        "attachment_blob_container": CONTAINER,
+    }
+    doc = _doc({"name": "rel.pdf", "url": "rel.pdf", "contentType": "application/pdf"})
+    out = _extract_attachments(doc, cfg)
+    assert out[0]["blob_container"] == CONTAINER
+    assert out[0]["blob_container"] != "cases"
+
+
 def test_ssrf_rejects_non_blob_host():
     cfg = {"attachments_field": "attachments"}
     doc = _doc({"name": "x.pdf", "url": "https://evil.example.com/c/x.pdf",


### PR DESCRIPTION
## Problem

PR #127 introduced cosmosdb attachment-source mode where the `container` config key names the **cosmos** container. However, `Source.BlobContainer` (used as the default container for relative attachment URLs and for the SSRF-guard fallback) also reads `container` — so a source could not configure both at once: setting a default blob container would overwrite the cosmos container, which is exactly what bit us during the live E2E run.

## Fix

Honor a dedicated `attachment_blob_container` key first, falling back to `container` for backwards compatibility with non-attachment blob sources:

- `connectors/ingestion/dotnet/Models/Source.cs`: `BlobContainer` reads `attachment_blob_container` then `container`.
- `api/connectors/cosmosdb_connector.py`: parity in `_extract_attachments`.
- `docs/cli-guide.md`: document the new key and fix the example which previously had the bugged dual-`container` form.
- `tests/api/test_cosmos_attachments.py`: new test covering the precedence (12/12 pass).

## Validation

- `pytest tests/api/test_cosmos_attachments.py` — 12/12 ✅ (1 new test added)
- `dotnet build -c Release` — clean

The original PR #127 E2E demo ran successfully end-to-end after working around this by relying on absolute blob URLs in the document. With this fix, sources can also pin a default blob container without the cosmos/blob collision.