### PR TITLE
security: threat-model batch 1 — SSRF allowlist, blob-id sanitization, embed rate-limit, api_key migration

### DIFF
--- a/api/connectors/cosmosdb_connector.py
+++ b/api/connectors/cosmosdb_connector.py
@@ -2,7 +2,7 @@
 
 import os
 import hashlib
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from azure.cosmos import CosmosClient
 from azure.identity import ManagedIdentityCredential, DefaultAzureCredential
 
@@ -140,12 +140,68 @@ def _extract_extension(s: str):
     return ext or None
 
 
-def _resolve_blob_location(url: str, source_account_url: str = "", source_container: str = ""):
+_MAX_BLOB_NAME_LEN = 1024
+
+
+def _safe_blob_name(name: str) -> bool:
+    """Validate a (URL-decoded) blob key. Rejects traversal segments, control
+    chars, leading/trailing whitespace per segment, empty segments, and
+    absolute-path forms — defense-in-depth against an attacker-crafted
+    attachment ID smuggling itself into a different container/key (T-BLB-1)."""
+    if not name or not name.strip():
+        return False
+    if len(name) > _MAX_BLOB_NAME_LEN:
+        return False
+    if name.startswith(("/", "\\")):
+        return False
+    for ch in name:
+        if ch == "\0" or (ord(ch) < 0x20 and ch != "\t"):
+            return False
+    for seg in name.replace("\\", "/").split("/"):
+        if seg == "" or seg in (".", ".."):
+            return False
+        if seg.strip() != seg:
+            return False
+    return True
+
+
+def _safe_container_name(ctnr: str) -> bool:
+    if not ctnr or not ctnr.strip():
+        return False
+    if len(ctnr) > 63:
+        return False
+    for ch in ctnr:
+        if ch in ("/", "\\", ".") or ord(ch) < 0x20:
+            return False
+    return True
+
+
+def _extract_host(url_or_host: str) -> str:
+    if not url_or_host:
+        return ""
+    s = url_or_host.strip()
+    if "://" in s:
+        return urlparse(s).netloc.lower()
+    return s.rstrip("/").lower()
+
+
+def _resolve_blob_location(
+    url: str,
+    source_account_url: str = "",
+    source_container: str = "",
+    allowlist: Optional[List[str]] = None,
+):
     """Resolve an attachment URL to (account_url, container, blob_name).
 
-    Returns (None, None, "") for invalid / disallowed (non-Azure-Blob) URLs.
-    SSRF guard: when ``source_account_url`` is set, only URLs whose host matches
-    that account are accepted.
+    Returns (None, None, "") for invalid / disallowed URLs.
+
+    SSRF guard (T-CON-2): for absolute URLs, ``source_account_url`` OR
+    ``allowlist`` must be configured; the URL's host must match one of them.
+    Without either, any ``*.blob.core.windows.net`` host would be reachable
+    from the worker's network identity.
+
+    Path-traversal guard (T-BLB-1): the resolved blob key is validated via
+    :func:`_safe_blob_name` after URL-decoding.
     """
     if not url:
         return None, None, ""
@@ -155,22 +211,33 @@ def _resolve_blob_location(url: str, source_account_url: str = "", source_contai
             return None, None, ""
         if not parsed.netloc.lower().endswith(".blob.core.windows.net"):
             return None, None, ""
-        if source_account_url:
-            pinned = urlparse(source_account_url)
-            if pinned.netloc.lower() != parsed.netloc.lower():
-                return None, None, ""
+        pinned_host = _extract_host(source_account_url)
+        allowed_hosts = {_extract_host(h) for h in (allowlist or []) if h}
+        if not pinned_host and not allowed_hosts:
+            return None, None, ""
+        host = parsed.netloc.lower()
+        if host != pinned_host and host not in allowed_hosts:
+            return None, None, ""
         path = parsed.path.lstrip("/")
         if "/" not in path:
             return None, None, ""
-        ctnr, blob = path.split("/", 1)
-        if not blob:
+        ctnr, raw_blob = path.split("/", 1)
+        if not raw_blob:
             return None, None, ""
-        return f"https://{parsed.netloc}", ctnr, unquote(blob)
+        decoded = unquote(raw_blob)
+        if not _safe_blob_name(decoded) or not _safe_container_name(ctnr):
+            return None, None, ""
+        return f"https://{parsed.netloc}", ctnr, decoded
 
-    # Relative path
+    # Relative path — also sanitize before trusting it as a blob key.
+    # Defense-in-depth: do NOT auto-strip a leading slash; treat absolute-style
+    # relative URLs as invalid so attackers can't smuggle a different key shape.
     if not source_account_url or not source_container:
         return None, None, ""
-    return source_account_url, source_container, url.lstrip("/")
+    rel = unquote(url)
+    if not _safe_blob_name(rel):
+        return None, None, ""
+    return source_account_url, source_container, rel
 
 
 def _extract_attachments(doc: dict, config: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -210,6 +277,9 @@ def _extract_attachments(doc: dict, config: Dict[str, Any]) -> List[Dict[str, An
     # container; honor "attachment_blob_container" as the dedicated key for
     # the default blob container used to resolve relative attachment URLs.
     src_container = config.get("attachment_blob_container") or config.get("container", "")
+    allowlist = config.get("attachment_blob_account_allowlist") or []
+    if isinstance(allowlist, str):
+        allowlist = [a.strip() for a in allowlist.split(",") if a.strip()]
 
     matches: List[Dict[str, Any]] = []
     for item in arr:
@@ -229,7 +299,7 @@ def _extract_attachments(doc: dict, config: Dict[str, Any]) -> List[Dict[str, An
         if content_types:
             if not ctype or str(ctype).lower() not in content_types:
                 continue
-        acct, ctnr, blob = _resolve_blob_location(url, src_account, src_container)
+        acct, ctnr, blob = _resolve_blob_location(url, src_account, src_container, allowlist)
         if not blob:
             continue
         matches.append({

--- a/connectors/ingestion/dotnet/Models/Source.cs
+++ b/connectors/ingestion/dotnet/Models/Source.cs
@@ -53,6 +53,12 @@ public class Source
     public string? AttachmentNameRegex => TryGetString("attachment_name_regex");
     public List<string> AttachmentFileTypes => TryGetStringList("attachment_file_types");
     public List<string> AttachmentContentTypes => TryGetStringList("attachment_content_types");
+    // Optional explicit allowlist of blob storage account hosts permitted as
+    // attachment sources. Used as a tighter SSRF guard than BlobAccountUrl
+    // when a source legitimately spans multiple storage accounts. Each entry
+    // may be a full URL ("https://acct.blob.core.windows.net") or just a
+    // hostname ("acct.blob.core.windows.net").
+    public List<string> AttachmentBlobAccountAllowlist => TryGetStringList("attachment_blob_account_allowlist");
 
     /// <summary>
     /// Build connection string from config. Supports both explicit connection_string
@@ -288,9 +294,18 @@ public class Source
     /// Resolve an attachment URL to an (accountUrl, container, blobName) triple.
     /// Accepts either a full https URL on a *.blob.core.windows.net host
     /// (validated against the source's configured <see cref="BlobAccountUrl"/>
-    /// when set, as an SSRF guard), or a relative blob name that is joined
-    /// with the source's configured account_url + container.
-    /// Returns (null,null,"") for invalid / disallowed URLs.
+    /// or <see cref="AttachmentBlobAccountAllowlist"/> as an SSRF guard), or
+    /// a relative blob name that is joined with the source's configured
+    /// account_url + container. Returns (null,null,"") for invalid /
+    /// disallowed URLs.
+    ///
+    /// Hardening (T-CON-2 / T-BLB-1):
+    ///   * Absolute URLs require either BlobAccountUrl or
+    ///     AttachmentBlobAccountAllowlist to be set; otherwise any
+    ///     *.blob.core.windows.net host could be reached.
+    ///   * Blob name segments are validated to reject '..' traversal,
+    ///     leading/trailing whitespace, control characters, and empty
+    ///     segments after URL-decoding.
     /// </summary>
     public (string? AccountUrl, string? Container, string BlobName) ResolveBlobLocation(string url)
     {
@@ -302,27 +317,91 @@ public class Source
             if (!uri.Host.EndsWith(".blob.core.windows.net", StringComparison.OrdinalIgnoreCase))
                 return (null, null, "");
 
-            // SSRF guard: if source pins an account_url, the URL host must match.
-            if (!string.IsNullOrEmpty(BlobAccountUrl)
-                && Uri.TryCreate(BlobAccountUrl, UriKind.Absolute, out var pinned))
-            {
-                if (!string.Equals(pinned.Host, uri.Host, StringComparison.OrdinalIgnoreCase))
-                    return (null, null, "");
-            }
+            // SSRF guard: source MUST pin either account_url or an allowlist.
+            // Without one, any *.blob.core.windows.net host (incl. attacker-
+            // controlled accounts in the same tenant) would be reachable.
+            var pinnedHost = ExtractHost(BlobAccountUrl);
+            var allowedHosts = AttachmentBlobAccountAllowlist
+                .Select(ExtractHost)
+                .Where(h => !string.IsNullOrEmpty(h))
+                .Select(h => h!)
+                .ToList();
+            if (string.IsNullOrEmpty(pinnedHost) && allowedHosts.Count == 0)
+                return (null, null, "");
+
+            var hostMatches = false;
+            if (!string.IsNullOrEmpty(pinnedHost)
+                && string.Equals(pinnedHost, uri.Host, StringComparison.OrdinalIgnoreCase))
+                hostMatches = true;
+            if (!hostMatches && allowedHosts.Any(h =>
+                    string.Equals(h, uri.Host, StringComparison.OrdinalIgnoreCase)))
+                hostMatches = true;
+            if (!hostMatches) return (null, null, "");
 
             var path = uri.AbsolutePath.TrimStart('/');
             var slashIdx = path.IndexOf('/');
             if (slashIdx < 0) return (null, null, "");
             var ctnr = path.Substring(0, slashIdx);
-            var blob = path.Substring(slashIdx + 1);
-            if (string.IsNullOrEmpty(blob)) return (null, null, "");
-            return ($"https://{uri.Host}", ctnr, Uri.UnescapeDataString(blob));
+            var rawBlob = path.Substring(slashIdx + 1);
+            if (string.IsNullOrEmpty(rawBlob)) return (null, null, "");
+            var decoded = Uri.UnescapeDataString(rawBlob);
+            if (!IsSafeBlobName(decoded) || !IsSafeContainerName(ctnr))
+                return (null, null, "");
+            return ($"https://{uri.Host}", ctnr, decoded);
         }
 
         // Relative — fall back to source-configured account/container.
+        // Defense-in-depth: do NOT strip a leading slash. Reject absolute-style
+        // relative URLs so attackers can't smuggle a different key shape.
         if (string.IsNullOrEmpty(BlobAccountUrl) || string.IsNullOrEmpty(BlobContainer))
             return (null, null, "");
-        return (BlobAccountUrl, BlobContainer, url.TrimStart('/'));
+        var relDecoded = Uri.UnescapeDataString(url);
+        if (!IsSafeBlobName(relDecoded)) return (null, null, "");
+        return (BlobAccountUrl, BlobContainer, relDecoded);
+    }
+
+    private static string? ExtractHost(string? urlOrHost)
+    {
+        if (string.IsNullOrWhiteSpace(urlOrHost)) return null;
+        if (Uri.TryCreate(urlOrHost, UriKind.Absolute, out var u)) return u.Host;
+        return urlOrHost.Trim().TrimEnd('/');
+    }
+
+    /// <summary>
+    /// Validate a (URL-decoded) blob name. Rejects path traversal, control
+    /// characters, leading slashes, and absolute paths — anything that could
+    /// let an attacker pivot away from the configured container or smuggle a
+    /// crafted key into downstream storage operations.
+    /// </summary>
+    internal static bool IsSafeBlobName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return false;
+        if (name.Length > 1024) return false; // Azure Blob max key length
+        if (name.StartsWith('/') || name.StartsWith('\\')) return false;
+        foreach (var ch in name)
+        {
+            if (ch == '\0' || (ch < 0x20 && ch != '\t')) return false;
+        }
+        foreach (var seg in name.Split(new[] { '/', '\\' }, StringSplitOptions.None))
+        {
+            if (seg.Length == 0) return false; // empty segment ("//" or trailing "/")
+            if (seg == "." || seg == "..") return false;
+            if (seg.Trim() != seg) return false; // leading/trailing whitespace per segment
+        }
+        return true;
+    }
+
+    internal static bool IsSafeContainerName(string ctnr)
+    {
+        if (string.IsNullOrWhiteSpace(ctnr)) return false;
+        // Azure container names: 3-63 chars, lowercase letters, digits, hyphens.
+        // We only need a permissive sanity check — the storage SDK will do strict
+        // validation. The point here is to refuse traversal-style values.
+        foreach (var ch in ctnr)
+        {
+            if (ch == '/' || ch == '\\' || ch == '.' || ch < 0x20) return false;
+        }
+        return ctnr.Length is >= 1 and <= 63;
     }
 }
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,195 @@
+# OmniVec Threat Model
+
+| Field | Value |
+|---|---|
+| Owner | OmniVec Team |
+| Methodology | STRIDE per element + per trust-boundary crossing |
+| Last reviewed | 2026-05-05 |
+| Scope | Full system — ingestion → embedding → vector store → search → web UI |
+
+> If you prefer the Microsoft Threat Modeling Tool (TMT) format, paste the
+> **Mermaid DFD** below into TMT manually — auto-generating a valid `.tm7`
+> from scratch is brittle, and the markdown form below is the source of
+> truth that gets diff-reviewed in PRs.
+
+---
+
+## 1. Architecture & data flow (DFD)
+
+```mermaid
+flowchart LR
+  subgraph "INTERNET / AAD trust boundary"
+    user["End-user browser"]
+  end
+
+  subgraph "AKS cluster (omnivec namespace)"
+    web["omnivec-web<br/>(Next.js)"]
+    api["omnivec-api<br/>(FastAPI)"]
+    search["omnivec-search<br/>(Go)"]
+    router["docgrok-router<br/>(Rust)"]
+    pworker["docgrok-pipeline-worker"]
+    connector["connector .NET worker<br/>(change-feed watcher)"]
+    incluster["in-cluster embedders<br/>CLIP / BGE / DSE-Qwen2"]
+  end
+
+  subgraph "Azure managed services"
+    aoai["Azure OpenAI"]
+    cmeta["CosmosDB<br/>omnivec.metadata"]
+    cvec["CosmosDB<br/>e2eblob.vectors"]
+    blob["Azure Blob<br/>(attachment store)"]
+    kv["Azure Key Vault"]
+    sb["Azure Service Bus"]
+  end
+
+  subgraph "Customer-owned (external trust)"
+    csrc["Customer CosmosDB<br/>(source w/ attachments)"]
+    bsrc["Customer Blob source"]
+  end
+
+  user -->|HTTPS + AAD SSO| web
+  user -->|HTTPS + admin token| api
+  web --> api
+  web --> search
+  api --> cmeta
+  api --> kv
+  api --> sb
+  api --> router
+  search --> cvec
+  router -->|API key OR AAD| aoai
+  router --> incluster
+  router --> cmeta
+  router --> pworker
+  pworker --> sb
+  pworker --> bsrc
+  pworker --> blob
+  pworker --> router
+  pworker --> cvec
+  connector -->|change-feed read| csrc
+  connector -->|stage attachments| blob
+  connector -->|enqueue work| sb
+```
+
+## 2. Trust boundaries
+
+| Id | Boundary | Notes |
+|---|---|---|
+| TB-1 | Internet / AAD | Browser-side input, AAD SSO. |
+| TB-2 | AKS cluster | All cluster pods share NetworkPolicy default-deny + workload-identity SA bindings. |
+| TB-3 | Azure managed services | RBAC data-plane on each resource. Public-network-access enabled on AOAI / Blob / Cosmos today (no private endpoints). |
+| TB-4 | Customer-owned | We trust nothing about customer Cosmos / Blob: data, schemas, attachment names, MIME types, content. |
+
+## 3. Assets
+
+| Asset | Sensitivity | Where it lives |
+|---|---|---|
+| Customer document content (PDFs, Office, images) | High (may be PII) | Customer Blob → AKS (transient) → never persisted raw |
+| Vector embeddings of customer content | High (PII-derived) | `e2eblob.vectors` |
+| Source-of-truth pipeline / model definitions | Medium | `omnivec.metadata` |
+| **AOAI API keys** | High | `omnivec.metadata` model records (`api_key` field) ⚠️ |
+| Admin bearer token (`OMNIVEC_ADMIN_TOKEN`) | High | Pod env var; long-lived, no rotation ⚠️ |
+| Workload-identity federated credentials | High | AAD; rotated by AKS |
+| Service Bus messages | Medium (contain blob URLs + source IDs) | Service Bus queue |
+
+## 4. STRIDE — auto-generated risks (one row per applicable element)
+
+Legend: ✅ has mitigation in code · ⚠️ partial · ❌ open · — N/A
+
+### Processes
+
+| Element | S | T | R | I | D | E | Mitigations / Notes |
+|---|---|---|---|---|---|---|---|
+| omnivec-web | ⚠️ | ✅ | ✅ | ✅ | ⚠️ | ✅ | AAD SSO; CSP and output-encoding; **rate-limit at ingress is needed** |
+| omnivec-api | ⚠️ | ✅ | ✅ | ✅ | ⚠️ | ✅ | Pydantic schemas; admin token static (T-API-1) |
+| omnivec-search | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | Read-only RBAC on vectors; query length cap |
+| docgrok-router | ⚠️ | ✅ | ⚠️ | ❌ | ⚠️ | ✅ | Loads AOAI keys from Cosmos in-the-clear (T-RTR-1) |
+| pipeline-worker | ✅ | ✅ | ⚠️ | ✅ | ❌ | ⚠️ | Untrusted input parser; **needs sandboxing** (T-PWK-1) |
+| connector .NET | ✅ | ⚠️ | ❌ | ✅ | ⚠️ | ✅ | Lease container shared (T-CON-1); SSRF surface (T-CON-2) |
+
+### Data stores
+
+| Element | S | T | R | I | D | E | Mitigations |
+|---|---|---|---|---|---|---|---|
+| `omnivec.metadata` | — | ✅ | ✅ | ⚠️ | ✅ | ✅ | RBAC; **api_key field stored in cleartext** (T-MET-1) |
+| `e2eblob.vectors` | — | ✅ | ✅ | ⚠️ | ✅ | ✅ | RBAC; vectors are PII-derived → residency rules apply |
+| Blob (attachment store) | — | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | RBAC; SAS short-lived; **no path-traversal allowlist** (T-BLB-1) |
+| Service Bus | — | ✅ | ✅ | ✅ | ✅ | ✅ | RBAC; dead-letter on poison messages |
+| Key Vault | — | ✅ | ✅ | ✅ | ✅ | ✅ | RBAC + soft-delete + purge protection |
+
+### External interactors / cross-trust flows
+
+| Crossing | Risk |
+|---|---|
+| Browser → omnivec-api | Static admin-token replay (T-API-1) |
+| omnivec-api → AOAI | Key-in-cleartext exfiltration if metadata DB breached (T-RTR-1, T-MET-1) |
+| pipeline-worker → customer Blob | Oversized / malformed-doc DoS, parser RCE (T-PWK-1) |
+| connector → customer Cosmos | Cross-tenant ingress, change-feed lease takeover (T-CON-1) |
+| connector attachment-resolver → arbitrary blob URL | SSRF if URL not allowlisted (T-CON-2) — partially mitigated by PR #128 |
+
+## 5. Top open risks (project-specific)
+
+> These are the ones a generic STRIDE template will **not** surface — they
+> require knowledge of this codebase. Prioritize these.
+
+### T-API-1 — Static admin bearer token
+- **Where:** `OMNIVEC_ADMIN_TOKEN` env var on `omnivec-api`. Single secret, no rotation, no per-call audit, used by web and CLI.
+- **Risk:** S/E/R — anyone with the token has full admin. No revocation mid-life.
+- **Mitigation:** migrate to AAD bearer (already done for cluster→Azure); add RBAC roles inside the API; rotate the token as a breakglass-only path.
+
+### T-RTR-1 / T-MET-1 — AOAI API keys live in CosmosDB metadata
+- **Where:** `omnivec.metadata.docgrok_model.api_key` is a **plaintext string** on the doc (we hit this today — that's why `mdl-ext-475483bb` was 401: empty `api_key`).
+- **Risk:** I/T — Cosmos breach or misissued read role exfiltrates keys. Also — **rotation requires a Cosmos `replace_item`**, no automation.
+- **Mitigation:** (a) drop key auth entirely now that AAD RBAC is granted (we did this 2026-05-05); (b) if keys must remain, store a Key Vault reference (`kv://…`) and have the router resolve it at request time.
+
+### T-PWK-1 — Pipeline-worker parses untrusted documents in-process
+- **Where:** `docgrok-pipeline-worker` ingests customer PDFs / Office / images via Python parsers (PyMuPDF, python-docx, Pillow). Same memory space as the embedding HTTP client.
+- **Risk:** D/E — a single malicious doc can OOM the pod or escape the parser (CVEs in Pillow/PyMuPDF appear yearly).
+- **Mitigation:** run parsing in a one-shot subprocess with `RLIMIT_AS` and a `seccomp` profile; impose hard page count + bytes cap before embed.
+
+### T-CON-1 — Change-feed lease container shared with metadata
+- **Where:** `connector .NET worker` uses Cosmos change-feed; if the lease container is in the same DB and writable by the same SA, an attacker who lands a write can DoS or replay ingestion.
+- **Mitigation:** isolate lease container to its own DB / RBAC scope; minimum required permissions only.
+
+### T-CON-2 — Attachment-source SSRF surface
+- **Where:** `Source.cs` resolves relative attachment URLs against an account derived from source config. PR #128 split `attachment_blob_container` from `container` to fix one confusion class.
+- **Residual risk:** the resolved blob URL is **not allowlisted by account name** — a malicious `_attachment.media` value could point at an attacker-controlled storage account that we then download from.
+- **Mitigation:** require `attachment_blob_account` config and reject URLs whose host doesn't match; OR pin to private endpoint only.
+
+### T-BLB-1 — No attachment-name validation
+- **Where:** Blob keys are built from `{docId}/{attachmentId}` taken from customer Cosmos. No normalization.
+- **Risk:** path-traversal-style `id="../foo"` could collide with system blobs, or create blobs we don't expect.
+- **Mitigation:** sanitize/encode attachment IDs (e.g., percent-encode), reject `/` and `..`.
+
+### T-VEC-1 — Vector PII residency
+- **Where:** `e2eblob.vectors` rows hold 1536-dim embeddings derived from customer content. Embeddings are reversible enough to leak content under inversion attacks.
+- **Mitigation:** treat as PII for residency, retention, and right-to-erasure. Add a `purge by source_ref` admin endpoint and document the data classification.
+
+### T-RL-1 — AOAI tier rate-limit DoS amplification
+- **Where:** S0 tier 429s today on a single 25-page attachment (we observed this). Concurrent pipelines × pages × retries can starve other pipelines.
+- **Mitigation:** per-pipeline embed concurrency cap (e.g., 4); exponential backoff with jitter; circuit-breaker per AOAI deployment.
+
+## 6. Mitigations checklist (what to do next)
+
+- [x] **High** Migration script `scripts/scrub_model_api_keys.py` clears legacy `api_key` from `docgrok_model` records (push to Key Vault first, fall back to `--force-clear` once AAD verified). *(T-MET-1, batch 1.)*
+- [ ] **High** Replace `OMNIVEC_ADMIN_TOKEN` with AAD bearer + role gating. Add `audit_log` table for admin operations.
+- [x] **High** `attachment_blob_account_allowlist` config + mandatory pin: absolute attachment URLs are rejected unless host matches `account_url` or the allowlist. *(T-CON-2, batch 1.)*
+- [ ] **Medium** Sandbox `pipeline-worker` parser in a subprocess with `RLIMIT_AS=1GB` and seccomp; cap pages-per-attachment to 200.
+- [ ] **Medium** Isolate change-feed lease container into its own Cosmos DB with a separate SA.
+- [x] **Medium** Per-AOAI-deployment embed semaphore + jittered exponential backoff in pipeline-worker (`OMNIVEC_EMBED_CONCURRENCY`, default 4). *(T-RL-1, batch 1.)*
+- [x] **Low** Attachment IDs / blob keys validated: traversal segments (`..`, `.`), control chars, leading slashes, and empty segments are rejected; absolute-URL paths are sanitized after URL-decoding. *(T-BLB-1, batch 1.)*
+- [ ] **Low** Document data classification of `e2eblob.vectors` as PII; add purge-by-source endpoint.
+- [ ] **Low** Add CSP + rate-limit at omnivec-web ingress.
+
+## 7. How to update this model
+
+1. Edit this file. Diff is the source of truth.
+2. Update the Mermaid DFD if the architecture changes.
+3. Re-run STRIDE table when adding a process / data store / external interactor.
+4. Add new project-specific risks under section 5 with a `T-XXX-N` id.
+5. Mark items in section 6 done as PRs land.
+
+## 8. Out-of-scope for this iteration
+
+- Threat model of CI/CD pipeline (GitHub Actions → ACR push). Tracked separately.
+- Threat model of Helm chart / Terraform infra. Tracked under `infra/`.
+- Customer-side hardening of source CosmosDB / Blob. We document the
+  contract; customers are responsible for their own perimeter.

--- a/scripts/scrub_model_api_keys.py
+++ b/scripts/scrub_model_api_keys.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Scrub legacy ``api_key`` fields from ``docgrok_model`` records in the
+OmniVec metadata Cosmos container (T-MET-1).
+
+Background
+----------
+Earlier OmniVec releases stored AOAI ``api_key`` values directly inside the
+``docgrok_model`` document in Cosmos when no Azure Key Vault was configured.
+The current API now prefers Key Vault and only falls back to Cosmos. Existing
+records may still carry the secret.
+
+This script walks every ``docgrok_model`` record. For each record that has
+both ``api_key`` populated AND ``api_key_source != "keyvault"``, it:
+
+  1. (default) Pushes the secret to Key Vault via
+     :func:`api.keyvault_client.set_model_api_key`.
+  2. Replaces the document with ``api_key`` removed and
+     ``api_key_source = "keyvault"``.
+
+If Key Vault is not configured, the script refuses to scrub by default (so
+you don't lose the only copy of the credential). Pass ``--force-clear`` to
+clear the field anyway when you've already validated AAD / workload-identity
+auth works for every model and the keys are no longer needed.
+
+Usage::
+
+    # Dry run — list affected docs, no writes.
+    python scripts/scrub_model_api_keys.py --dry-run
+
+    # Migrate to Key Vault (default).
+    python scripts/scrub_model_api_keys.py
+
+    # Hard-clear (only after AAD auth confirmed for every model).
+    python scripts/scrub_model_api_keys.py --force-clear
+
+Required env vars (same as the API): ``COSMOS_ENDPOINT``, ``COSMOS_KEY`` or
+managed identity, ``COSMOS_DATABASE`` (default ``omnivec``),
+``COSMOS_METADATA_CONTAINER`` (default ``metadata``), and for Key Vault path
+``KEYVAULT_NAME`` or ``KEYVAULT_URI``.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from typing import List, Tuple
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+logger = logging.getLogger("scrub_model_api_keys")
+
+
+def _build_cosmos_client():
+    """Build a Cosmos container client using the same env vars as the API."""
+    from azure.cosmos import CosmosClient  # type: ignore
+    from azure.identity import DefaultAzureCredential  # type: ignore
+
+    endpoint = os.environ.get("COSMOS_ENDPOINT") or os.environ.get("COSMOS_URI")
+    if not endpoint:
+        raise SystemExit("COSMOS_ENDPOINT (or COSMOS_URI) must be set")
+    key = os.environ.get("COSMOS_KEY")
+    if key:
+        client = CosmosClient(endpoint, credential=key)
+    else:
+        client = CosmosClient(endpoint, credential=DefaultAzureCredential())
+    db_name = os.environ.get("COSMOS_DATABASE", "omnivec")
+    ctr_name = os.environ.get("COSMOS_METADATA_CONTAINER", "metadata")
+    return client.get_database_client(db_name).get_container_client(ctr_name)
+
+
+def _scan(container) -> List[dict]:
+    """Return every docgrok_model document. Partition key is ``/doc_type``."""
+    query = "SELECT * FROM c WHERE c.doc_type = 'docgrok_model'"
+    return list(container.query_items(query=query, partition_key="docgrok_model"))
+
+
+def _classify(doc: dict) -> str:
+    if not doc.get("api_key"):
+        return "clean"
+    if doc.get("api_key_source") == "keyvault":
+        # api_key shouldn't coexist with KV source, but if it does treat as
+        # legacy and clean up.
+        return "redundant"
+    return "legacy"
+
+
+def main(argv: List[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--dry-run", action="store_true", help="Don't write — just list affected docs.")
+    p.add_argument(
+        "--force-clear",
+        action="store_true",
+        help="Clear api_key without copying to Key Vault. Use only when AAD auth is confirmed.",
+    )
+    args = p.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    container = _build_cosmos_client()
+    docs = _scan(container)
+    logger.info("scanned %d docgrok_model records", len(docs))
+
+    legacy: List[Tuple[dict, str]] = []
+    for d in docs:
+        kind = _classify(d)
+        if kind != "clean":
+            legacy.append((d, kind))
+
+    if not legacy:
+        logger.info("no legacy api_key fields found — nothing to do")
+        return 0
+
+    logger.info("found %d records with api_key populated:", len(legacy))
+    for d, kind in legacy:
+        logger.info("  - id=%s name=%s kind=%s",
+                    d.get("id"), d.get("name", ""), kind)
+
+    if args.dry_run:
+        return 0
+
+    set_kv = None
+    if not args.force_clear:
+        try:
+            from api.keyvault_client import set_model_api_key as set_kv  # type: ignore
+        except Exception as e:
+            logger.error("Key Vault client unavailable (%s). Re-run with --force-clear "
+                         "if you've already migrated auth to AAD.", e)
+            return 2
+
+    migrated, cleared, failed = 0, 0, 0
+    for d, _kind in legacy:
+        model_id = d["id"]
+        api_key_value = d.get("api_key", "")
+        try:
+            if set_kv is not None and api_key_value:
+                if not set_kv(model_id, api_key_value):
+                    logger.error("Key Vault write failed for %s — leaving doc untouched", model_id)
+                    failed += 1
+                    continue
+                d["api_key_source"] = "keyvault"
+                migrated += 1
+            else:
+                d.pop("api_key_source", None)
+                cleared += 1
+            d.pop("api_key", None)
+            container.replace_item(item=model_id, body=d)
+        except Exception as e:
+            logger.exception("failed to update %s: %s", model_id, e)
+            failed += 1
+
+    logger.info("done: migrated=%d cleared=%d failed=%d", migrated, cleared, failed)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/api/test_cosmos_attachments.py
+++ b/tests/api/test_cosmos_attachments.py
@@ -39,7 +39,7 @@ def test_disabled_when_no_attachments_field():
 
 
 def test_basic_match():
-    cfg = {"attachments_field": "attachments"}
+    cfg = {"attachments_field": "attachments", "account_url": ACCOUNT}
     out = _extract_attachments(_doc(_att("a.pdf")), cfg)
     assert len(out) == 1
     assert out[0]["blob_name"] == "a.pdf"
@@ -48,21 +48,24 @@ def test_basic_match():
 
 
 def test_filter_by_regex():
-    cfg = {"attachments_field": "attachments", "attachment_name_regex": r"^report-"}
+    cfg = {"attachments_field": "attachments", "account_url": ACCOUNT,
+           "attachment_name_regex": r"^report-"}
     doc = _doc(_att("report-2024.pdf"), _att("invoice.pdf"))
     out = _extract_attachments(doc, cfg)
     assert [a["name"] for a in out] == ["report-2024.pdf"]
 
 
 def test_filter_by_file_types():
-    cfg = {"attachments_field": "attachments", "attachment_file_types": ["pdf"]}
+    cfg = {"attachments_field": "attachments", "account_url": ACCOUNT,
+           "attachment_file_types": ["pdf"]}
     doc = _doc(_att("a.pdf"), _att("b.docx", content_type="application/msword"))
     out = _extract_attachments(doc, cfg)
     assert [a["name"] for a in out] == ["a.pdf"]
 
 
 def test_filter_by_content_types_csv():
-    cfg = {"attachments_field": "attachments", "attachment_content_types": "application/pdf, text/plain"}
+    cfg = {"attachments_field": "attachments", "account_url": ACCOUNT,
+           "attachment_content_types": "application/pdf, text/plain"}
     doc = _doc(_att("a.pdf"), _att("b.bin", content_type="application/octet-stream"))
     out = _extract_attachments(doc, cfg)
     assert [a["name"] for a in out] == ["a.pdf"]
@@ -99,7 +102,7 @@ def test_relative_url_prefers_attachment_blob_container():
 
 
 def test_ssrf_rejects_non_blob_host():
-    cfg = {"attachments_field": "attachments"}
+    cfg = {"attachments_field": "attachments", "account_url": ACCOUNT}
     doc = _doc({"name": "x.pdf", "url": "https://evil.example.com/c/x.pdf",
                 "contentType": "application/pdf"})
     assert _extract_attachments(doc, cfg) == []
@@ -128,6 +131,7 @@ def test_resolve_blob_decodes_path():
 def test_combined_filters_all_must_match():
     cfg = {
         "attachments_field": "attachments",
+        "account_url": ACCOUNT,
         "attachment_name_regex": r"\.pdf$",
         "attachment_file_types": ["pdf"],
         "attachment_content_types": ["application/pdf"],
@@ -139,6 +143,104 @@ def test_combined_filters_all_must_match():
     )
     out = _extract_attachments(doc, cfg)
     assert [a["name"] for a in out] == ["a.pdf"]
+
+
+# ── T-CON-2: SSRF allowlist hardening ─────────────────────────────────
+
+def test_absolute_url_rejected_when_no_account_pin_or_allowlist():
+    # Without source_account_url or allowlist, an absolute *.blob.core.windows.net
+    # URL must NOT be accepted — defense against SSRF via attacker-crafted
+    # attachments pointing at any same-tenant storage account.
+    acct, ctnr, blob = _resolve_blob_location(
+        f"{ACCOUNT}/{CONTAINER}/x.pdf", source_account_url="", source_container="")
+    assert (acct, ctnr, blob) == (None, None, "")
+
+
+def test_absolute_url_accepted_when_in_allowlist_only():
+    # source_account_url is unset but the host appears in the allowlist —
+    # accepted because the operator explicitly declared it OK.
+    acct, ctnr, blob = _resolve_blob_location(
+        f"{ACCOUNT}/{CONTAINER}/x.pdf",
+        source_account_url="",
+        source_container="",
+        allowlist=["acct.blob.core.windows.net"])
+    assert acct == ACCOUNT and ctnr == CONTAINER and blob == "x.pdf"
+
+
+def test_allowlist_rejects_non_listed_host():
+    acct, ctnr, blob = _resolve_blob_location(
+        "https://other.blob.core.windows.net/c/x.pdf",
+        source_account_url="",
+        source_container="",
+        allowlist=["acct.blob.core.windows.net"])
+    assert (acct, ctnr, blob) == (None, None, "")
+
+
+def test_extract_attachments_honors_allowlist_config():
+    cfg = {
+        "attachments_field": "attachments",
+        "attachment_blob_account_allowlist": [
+            "acct.blob.core.windows.net",
+            "second.blob.core.windows.net",
+        ],
+    }
+    doc = _doc(
+        {"name": "a.pdf", "url": f"{ACCOUNT}/{CONTAINER}/a.pdf", "contentType": "application/pdf"},
+        {"name": "b.pdf", "url": "https://second.blob.core.windows.net/c/b.pdf", "contentType": "application/pdf"},
+        {"name": "c.pdf", "url": "https://nope.blob.core.windows.net/c/c.pdf", "contentType": "application/pdf"},
+    )
+    out = _extract_attachments(doc, cfg)
+    assert sorted(a["name"] for a in out) == ["a.pdf", "b.pdf"]
+
+
+# ── T-BLB-1: Blob name sanitization ────────────────────────────────────
+
+@pytest.mark.parametrize("evil_name", [
+    "../../etc/passwd",
+    "..\\..\\system32\\sam",
+    "/abs/path",
+    "good/../bad",
+    "a//b",                       # empty middle segment
+    " leading-space",
+    "trailing-space ",
+    "ctrl\x01char",
+    "",
+    "   ",
+])
+def test_relative_url_rejects_unsafe_blob_names(evil_name):
+    acct, ctnr, blob = _resolve_blob_location(
+        evil_name, source_account_url=ACCOUNT, source_container=CONTAINER)
+    assert (acct, ctnr, blob) == (None, None, ""), f"unexpectedly accepted: {evil_name!r}"
+
+
+def test_relative_url_accepts_normal_nested_path():
+    acct, ctnr, blob = _resolve_blob_location(
+        "case-2026-001/exhibit-A.pdf",
+        source_account_url=ACCOUNT, source_container=CONTAINER)
+    assert acct == ACCOUNT and ctnr == CONTAINER and blob == "case-2026-001/exhibit-A.pdf"
+
+
+def test_absolute_url_rejects_traversal_in_decoded_path():
+    # Percent-encoded "../" survived the prior implementation because
+    # unquote() ran *after* the host check; now blocked by _safe_blob_name.
+    acct, ctnr, blob = _resolve_blob_location(
+        f"{ACCOUNT}/{CONTAINER}/a/..%2F..%2Fsecret.pdf",
+        source_account_url=ACCOUNT, source_container=CONTAINER)
+    assert (acct, ctnr, blob) == (None, None, "")
+
+
+def test_extract_attachments_drops_unsafe_relative_url():
+    cfg = {
+        "attachments_field": "attachments",
+        "account_url": ACCOUNT,
+        "attachment_blob_container": CONTAINER,
+    }
+    doc = _doc(
+        {"name": "good", "url": "case-1/a.pdf", "contentType": "application/pdf"},
+        {"name": "bad",  "url": "../escape.pdf", "contentType": "application/pdf"},
+    )
+    out = _extract_attachments(doc, cfg)
+    assert [a["name"] for a in out] == ["good"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements four mitigations from docs/security/threat-model.md in one PR.

## Fixes

| ID | Severity | What changed |
|----|----------|--------------|
| **T-CON-2** | High | Absolute attachment URLs are rejected unless host matches ccount_url or new ttachment_blob_account_allowlist config. Previously *any* *.blob.core.windows.net host was reachable when ccount_url was unset. |
| **T-BLB-1** | Low | Blob keys validated after URL-decoding: .. / . segments, control chars, leading slashes, empty segments rejected. Closes percent-encoded traversal smuggling. |
| **T-RL-1** | Medium | mbed_via_router in docgrok/pipeline-worker now uses a process-wide `asyncio.Semaphore` (default 4, env `OMNIVEC_EMBED_CONCURRENCY`) plus exp-backoff retry with jitter on 429/5xx. |
| **T-MET-1** | High | New `scripts/scrub_model_api_keys.py` migrates any legacy `api_key` on `docgrok_model` records to Key Vault (or `--force-clear` once AAD verified). |

## Validation

- `pytest tests/api/test_cosmos_attachments.py` — **29/29 pass** (13 new cases for SSRF + sanitization).
- `dotnet build -c Release` for `connectors/ingestion/dotnet` and `connectors/worker/dotnet` — both green.
- Submodule bump: `docgrok` → branch `security/threat-model-fixes-batch1` (1 commit, 70+/14- in `worker.py`).

## Notes for reviewers

- Existing tests using absolute attachment URLs without an `account_url` pin now require it (realistic config). Updated in this PR.
- `attachment_blob_account_allowlist` is the new escape hatch for sources whose attachments span multiple storage accounts — entries can be either full URLs or bare hostnames.
- `OMNIVEC_EMBED_CONCURRENCY=4` is conservative for AOAI S0 deployments. Bump for higher tiers.
- Mitigation checklist in `docs/security/threat-model.md` updated; remaining open items listed there.