### PR TITLE
security(api): audit log + per-token last-used (T-API-1, batch 2)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -130,7 +130,14 @@ def _validate_token(token: str) -> Optional[dict]:
             tok_scope = (t.get("scope") or "").lower()
             if tok_scope == "search":
                 return None
-            return {"name": t.get("name", ""), "role": t.get("role", "user"), "id": t.get("id", "")}
+            return {
+                "name": t.get("name", ""),
+                "role": t.get("role", "user"),
+                "id": t.get("id", ""),
+                # Marker so the middleware knows this is a stored Cosmos token
+                # eligible for last_used tracking (vs the env-bootstrap admin).
+                "_persisted": True,
+            }
     except Exception as e:
         logger.warning("Token validation error: %s", e)
     return None
@@ -191,6 +198,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
             # Attach token metadata to request state
             request.state.auth = token_meta
+            # Best-effort last-used touch for persisted Cosmos tokens (T-API-1).
+            if token_meta.get("_persisted") and token_meta.get("id"):
+                asyncio.create_task(_touch_token_last_used(token_meta["id"]))
 
         return await call_next(request)
 
@@ -254,6 +264,167 @@ async def metrics_middleware(request: Request, call_next):
         if response.status_code >= 400:
             record_error(status_code=response.status_code, path=path)
     return response
+
+
+# =============================================================================
+# AUDIT LOG (T-API-1)
+# =============================================================================
+# Records every state-changing /api/* request into a Cosmos `audit_log`
+# doc-type so admin operations leave a forensic trail. Reads (GET) are
+# excluded — they're typically high-volume probe traffic and the latency
+# middleware already records them. Internal pod-to-pod calls (skipped via
+# AUTH_SKIP_* / _INTERNAL_HOSTS in AuthMiddleware) carry no auth context
+# and are intentionally NOT audited.
+#
+# The write is fire-and-forget on a background task so the response is not
+# blocked by Cosmos latency. If the audit container is unavailable we log
+# and drop — auditing must never break the request path.
+
+_AUDIT_METHODS = {"POST", "PUT", "DELETE", "PATCH"}
+# Don't audit auth-token list/login churn; they're already covered by
+# /api/auth/login rate-limiting and aren't state changes when GET-only.
+_AUDIT_SKIP_PREFIXES = ("/api/health", "/api/metrics", "/api/auth/login")
+
+
+def _redact_path(path: str) -> str:
+    """Strip query string. Path itself is the resource identifier; bodies are
+    NOT logged (could contain secrets / PII)."""
+    return path.split("?", 1)[0]
+
+
+async def _write_audit_record(
+    actor_name: str,
+    actor_role: str,
+    actor_id: str,
+    method: str,
+    path: str,
+    status: int,
+    ip: str,
+) -> None:
+    try:
+        store = get_store()
+        doc = {
+            "id": f"aud-{uuid.uuid4().hex[:12]}",
+            "doc_type": "audit_log",
+            "ts": datetime.utcnow().isoformat(),
+            "actor_name": actor_name,
+            "actor_role": actor_role,
+            "actor_id": actor_id,
+            "method": method,
+            "path": path,
+            "status": status,
+            "ip": ip,
+        }
+        await asyncio.to_thread(store.upsert, doc)
+    except Exception as e:  # lgtm[py/catch-base-exception]
+        # Never let audit-log failure break the request flow.
+        logger.warning("audit_log write failed: %s", e)
+
+
+@app.middleware("http")
+async def audit_middleware(request: Request, call_next):
+    response = await call_next(request)
+    try:
+        path = request.url.path
+        if (request.method in _AUDIT_METHODS
+                and path.startswith("/api/")
+                and not any(path.startswith(p) for p in _AUDIT_SKIP_PREFIXES)
+                and not getattr(request.state, "internal", False)):
+            auth = getattr(request.state, "auth", None) or {}
+            ip = request.client.host if request.client else "unknown"
+            asyncio.create_task(_write_audit_record(
+                actor_name=auth.get("name", "anonymous"),
+                actor_role=auth.get("role", "none"),
+                actor_id=auth.get("id", ""),
+                method=request.method,
+                path=_redact_path(path),
+                status=response.status_code,
+                ip=ip,
+            ))
+    except Exception as e:  # lgtm[py/catch-base-exception]
+        logger.warning("audit_middleware error: %s", e)
+    return response
+
+
+@app.get("/api/audit-log")
+async def list_audit_log(
+    request: Request,
+    actor: Optional[str] = None,
+    path_prefix: Optional[str] = None,
+    method: Optional[str] = None,
+    since: Optional[str] = None,
+    limit: int = 100,
+):
+    """Return recent audit-log entries. Admin role required.
+
+    Filters (all optional, all ANDed):
+      * ``actor`` — actor_name or actor_id substring match
+      * ``path_prefix`` — startswith match on the resource path
+      * ``method`` — exact match (POST/PUT/DELETE/PATCH)
+      * ``since`` — ISO-8601 timestamp; entries with ``ts >= since`` only
+      * ``limit`` — max records (default 100, capped at 1000)
+    """
+    auth = getattr(request.state, "auth", None)
+    if not auth or auth.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin role required")
+
+    limit = max(1, min(int(limit or 100), 1000))
+    where = ["c.doc_type = 'audit_log'"]
+    params: List[Dict[str, Any]] = []
+    if since:
+        where.append("c.ts >= @since")
+        params.append({"name": "@since", "value": since})
+    if method:
+        where.append("UPPER(c.method) = @method")
+        params.append({"name": "@method", "value": method.upper()})
+    sql = (
+        "SELECT TOP @limit c.id, c.ts, c.actor_name, c.actor_role, c.actor_id, "
+        "c.method, c.path, c.status, c.ip FROM c WHERE "
+        + " AND ".join(where)
+        + " ORDER BY c.ts DESC"
+    )
+    params.append({"name": "@limit", "value": limit})
+
+    store = get_store()
+    rows = list(store.query(sql, parameters=params, partition_key="audit_log"))
+
+    # Substring/prefix filters applied client-side (cheap; result set is small).
+    if actor:
+        a = actor.lower()
+        rows = [r for r in rows if a in (r.get("actor_name", "") or "").lower()
+                or a in (r.get("actor_id", "") or "").lower()]
+    if path_prefix:
+        rows = [r for r in rows if (r.get("path", "") or "").startswith(path_prefix)]
+
+    return {"entries": rows, "count": len(rows)}
+
+
+# Per-token last-used tracking. Updates are debounced to one write per token
+# per ``_LAST_USED_DEBOUNCE_S`` to keep Cosmos writes off the hot path.
+_LAST_USED_DEBOUNCE_S = 60.0
+_last_used_seen: Dict[str, float] = {}
+
+
+async def _touch_token_last_used(token_id: str) -> None:
+    try:
+        now_mono = time.monotonic()
+        last = _last_used_seen.get(token_id, 0.0)
+        if now_mono - last < _LAST_USED_DEBOUNCE_S:
+            return
+        _last_used_seen[token_id] = now_mono
+        store = get_store()
+
+        def _update():
+            doc = store.get(token_id, "auth_token")
+            if not doc:
+                return
+            doc["last_used_at"] = datetime.utcnow().isoformat()
+            doc["use_count"] = int(doc.get("use_count", 0)) + 1
+            store.upsert(doc)
+        await asyncio.to_thread(_update)
+    except Exception as e:  # lgtm[py/catch-base-exception]
+        logger.debug("last_used update failed for %s: %s", token_id, e)
+
 
 # â”€â”€ test-connection timeout / retry config â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 TEST_CONN_TIMEOUT = 10   # seconds
@@ -643,6 +814,8 @@ async def list_tokens(request: Request, scope: Optional[str] = None):
             "created_by": t.get("created_by"),
             "expires_at": t.get("expires_at"),
             "revoked": t.get("revoked", False),
+            "last_used_at": t.get("last_used_at"),
+            "use_count": t.get("use_count", 0),
         }
         for t in tokens
     ]}

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -170,7 +170,7 @@ Legend: ✅ has mitigation in code · ⚠️ partial · ❌ open · — N/A
 ## 6. Mitigations checklist (what to do next)
 
 - [x] **High** Migration script `scripts/scrub_model_api_keys.py` clears legacy `api_key` from `docgrok_model` records (push to Key Vault first, fall back to `--force-clear` once AAD verified). *(T-MET-1, batch 1.)*
-- [ ] **High** Replace `OMNIVEC_ADMIN_TOKEN` with AAD bearer + role gating. Add `audit_log` table for admin operations.
+- [~] **High** `OMNIVEC_ADMIN_TOKEN` → AAD bearer + role gating: **batch 2 ships audit-log + per-token last-used**; AAD-bearer migration still pending. *(T-API-1.)*
 - [x] **High** `attachment_blob_account_allowlist` config + mandatory pin: absolute attachment URLs are rejected unless host matches `account_url` or the allowlist. *(T-CON-2, batch 1.)*
 - [ ] **Medium** Sandbox `pipeline-worker` parser in a subprocess with `RLIMIT_AS=1GB` and seccomp; cap pages-per-attachment to 200.
 - [ ] **Medium** Isolate change-feed lease container into its own Cosmos DB with a separate SA.

--- a/tests/api/test_audit_log.py
+++ b/tests/api/test_audit_log.py
@@ -1,0 +1,261 @@
+"""Offline tests for audit-log middleware + per-token last-used tracking
+(threat-model item T-API-1).
+
+Validates:
+  * Mutating /api/* requests produce one audit_log Cosmos doc with the
+    expected actor/method/path/status fields.
+  * GET requests are NOT audited.
+  * Internal cluster traffic (request.state.internal=True) is NOT audited.
+  * Auth-skip prefixes (/api/health, /api/metrics, /api/auth/login) are
+    NOT audited even on POST.
+  * Persisted Cosmos tokens get last_used_at touched (debounced).
+  * /api/audit-log endpoint applies actor / path_prefix / method / since
+    filters and gates on admin role.
+
+No pytest required (mirrors test_admin_endpoints.py style). Run via:
+    python tests/api/test_audit_log.py
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+import unittest
+from typing import Any, Dict, List
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(_ROOT, "api"))
+os.environ.setdefault("OMNIVEC_ADMIN_TOKEN", "test-token")
+
+import api  # noqa: E402
+
+
+class FakeStore:
+    """Minimal in-memory stand-in for the Cosmos store wrapper."""
+
+    def __init__(self):
+        self.docs: Dict[tuple, Dict[str, Any]] = {}
+
+    def upsert(self, doc):
+        self.docs[(doc["id"], doc.get("doc_type", ""))] = dict(doc)
+
+    def get(self, doc_id, doc_type):
+        return self.docs.get((doc_id, doc_type))
+
+    def query(self, sql, parameters=None, partition_key=None):
+        # Tests only use it for audit_log listing — return all matching docs.
+        params = {p["name"]: p["value"] for p in (parameters or [])}
+        out: List[Dict[str, Any]] = []
+        for (_id, dt), doc in self.docs.items():
+            if partition_key and dt != partition_key:
+                continue
+            if "audit_log" in sql and dt != "audit_log":
+                continue
+            if "@since" in sql and doc.get("ts", "") < params.get("@since", ""):
+                continue
+            if "@method" in sql and doc.get("method", "").upper() != params["@method"]:
+                continue
+            out.append(doc)
+        out.sort(key=lambda d: d.get("ts", ""), reverse=True)
+        if "@limit" in params:
+            out = out[: int(params["@limit"])]
+        return out
+
+
+class FakeRequest:
+    def __init__(self, method="POST", path="/api/sources", auth=None, internal=False, host_ip="1.2.3.4"):
+        self.method = method
+        self.url = type("U", (), {"path": path})()
+        self.client = type("C", (), {"host": host_ip})()
+        self.headers: Dict[str, str] = {}
+        self.state = type("S", (), {})()
+        if auth is not None:
+            self.state.auth = auth
+        self.state.internal = internal
+
+
+class FakeResponse:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class AuditMiddlewareTests(unittest.TestCase):
+    def setUp(self):
+        self.store = FakeStore()
+        api.get_store = lambda: self.store
+        # Reset debounce cache so tests don't bleed into each other.
+        api._last_used_seen.clear()
+
+    async def _exercise(self, request, response_status=200):
+        async def _next(_req):
+            return FakeResponse(response_status)
+        await api.audit_middleware(request, _next)
+        # Drain any background tasks the middleware scheduled.
+        pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    def _audit_docs(self):
+        return [d for (_id, dt), d in self.store.docs.items() if dt == "audit_log"]
+
+    def test_post_creates_audit_record(self):
+        req = FakeRequest("POST", "/api/sources",
+                          auth={"name": "alice", "role": "admin", "id": "tok-1"})
+        _run(self._exercise(req, 201))
+        docs = self._audit_docs()
+        self.assertEqual(len(docs), 1)
+        d = docs[0]
+        self.assertEqual(d["actor_name"], "alice")
+        self.assertEqual(d["actor_role"], "admin")
+        self.assertEqual(d["actor_id"], "tok-1")
+        self.assertEqual(d["method"], "POST")
+        self.assertEqual(d["path"], "/api/sources")
+        self.assertEqual(d["status"], 201)
+        self.assertEqual(d["ip"], "1.2.3.4")
+        self.assertTrue(d["id"].startswith("aud-"))
+        self.assertIn("ts", d)
+
+    def test_get_is_not_audited(self):
+        req = FakeRequest("GET", "/api/sources",
+                          auth={"name": "alice", "role": "admin"})
+        _run(self._exercise(req))
+        self.assertEqual(self._audit_docs(), [])
+
+    def test_internal_traffic_is_not_audited(self):
+        req = FakeRequest("POST", "/api/sources", internal=True)
+        _run(self._exercise(req))
+        self.assertEqual(self._audit_docs(), [])
+
+    def test_skip_prefixes_not_audited(self):
+        for path in ("/api/health/check", "/api/metrics/foo", "/api/auth/login"):
+            with self.subTest(path=path):
+                self.store.docs.clear()
+                req = FakeRequest("POST", path,
+                                  auth={"name": "alice", "role": "admin"})
+                _run(self._exercise(req))
+                self.assertEqual(self._audit_docs(), [])
+
+    def test_anonymous_actor_when_no_auth(self):
+        # Edge case — auth middleware would normally 401 first, but if a
+        # handler short-circuits we still want a record with anonymous actor.
+        req = FakeRequest("DELETE", "/api/sources/abc")
+        _run(self._exercise(req, 401))
+        docs = self._audit_docs()
+        self.assertEqual(len(docs), 1)
+        self.assertEqual(docs[0]["actor_name"], "anonymous")
+        self.assertEqual(docs[0]["actor_role"], "none")
+        self.assertEqual(docs[0]["status"], 401)
+
+    def test_query_string_stripped_from_path(self):
+        req = FakeRequest("PUT", "/api/sources/s1?force=true",
+                          auth={"name": "alice", "role": "admin"})
+        _run(self._exercise(req))
+        docs = self._audit_docs()
+        self.assertEqual(docs[0]["path"], "/api/sources/s1")
+
+    def test_audit_write_failure_does_not_break_request(self):
+        # Simulate Cosmos outage. The middleware must still return cleanly.
+        def _boom(_doc):
+            raise RuntimeError("cosmos down")
+        self.store.upsert = _boom
+        req = FakeRequest("POST", "/api/sources",
+                          auth={"name": "alice", "role": "admin"})
+        _run(self._exercise(req, 200))  # no exception escapes
+
+
+class TokenLastUsedTests(unittest.TestCase):
+    def setUp(self):
+        self.store = FakeStore()
+        api.get_store = lambda: self.store
+        api._last_used_seen.clear()
+        self.store.upsert({
+            "id": "tok-1", "doc_type": "auth_token",
+            "name": "alice", "role": "admin", "scope": "admin",
+            "token_hash": "x",
+        })
+
+    def test_first_call_writes_last_used(self):
+        _run(api._touch_token_last_used("tok-1"))
+        doc = self.store.get("tok-1", "auth_token")
+        self.assertIn("last_used_at", doc)
+        self.assertEqual(doc.get("use_count"), 1)
+
+    def test_debounce_suppresses_immediate_second_write(self):
+        _run(api._touch_token_last_used("tok-1"))
+        first_ts = self.store.get("tok-1", "auth_token")["last_used_at"]
+        time.sleep(0.01)
+        _run(api._touch_token_last_used("tok-1"))
+        # Same record — second call should have been suppressed by debounce.
+        doc = self.store.get("tok-1", "auth_token")
+        self.assertEqual(doc["last_used_at"], first_ts)
+        self.assertEqual(doc["use_count"], 1)
+
+    def test_missing_token_doc_is_silently_ignored(self):
+        # No write should happen, no exception should bubble up.
+        _run(api._touch_token_last_used("does-not-exist"))
+
+
+class AuditLogEndpointTests(unittest.TestCase):
+    def setUp(self):
+        self.store = FakeStore()
+        api.get_store = lambda: self.store
+        # Seed several entries.
+        for i, (actor, role, method, path, ts) in enumerate([
+            ("alice", "admin", "POST", "/api/sources",   "2026-05-01T10:00:00"),
+            ("bob",   "user",  "PUT",  "/api/pipelines/p1", "2026-05-01T11:00:00"),
+            ("alice", "admin", "DELETE", "/api/sources/s1", "2026-05-02T09:00:00"),
+        ]):
+            self.store.upsert({
+                "id": f"aud-{i}", "doc_type": "audit_log",
+                "ts": ts, "actor_name": actor, "actor_role": role,
+                "actor_id": f"tok-{actor}", "method": method, "path": path,
+                "status": 200, "ip": "1.2.3.4",
+            })
+
+    def _request(self, role="admin"):
+        req = FakeRequest()
+        req.state.auth = {"name": "tester", "role": role}
+        return req
+
+    def test_admin_required(self):
+        req = self._request(role="user")
+        with self.assertRaises(api.HTTPException) as ctx:
+            _run(api.list_audit_log(req))
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_default_returns_all_newest_first(self):
+        out = _run(api.list_audit_log(self._request()))
+        self.assertEqual(out["count"], 3)
+        # Newest first
+        self.assertEqual(out["entries"][0]["ts"], "2026-05-02T09:00:00")
+
+    def test_actor_filter(self):
+        out = _run(api.list_audit_log(self._request(), actor="alice"))
+        actors = {e["actor_name"] for e in out["entries"]}
+        self.assertEqual(actors, {"alice"})
+
+    def test_path_prefix_filter(self):
+        out = _run(api.list_audit_log(self._request(), path_prefix="/api/pipelines"))
+        self.assertEqual([e["path"] for e in out["entries"]], ["/api/pipelines/p1"])
+
+    def test_method_filter(self):
+        out = _run(api.list_audit_log(self._request(), method="delete"))
+        methods = {e["method"] for e in out["entries"]}
+        self.assertEqual(methods, {"DELETE"})
+
+    def test_since_filter(self):
+        out = _run(api.list_audit_log(self._request(), since="2026-05-02T00:00:00"))
+        self.assertEqual(out["count"], 1)
+
+    def test_limit_capped(self):
+        out = _run(api.list_audit_log(self._request(), limit=2))
+        self.assertEqual(len(out["entries"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on **#129**. Re-target to `dev` once #129 merges.

Implements the *minimal* slice of threat-model item **T-API-1** chosen this round — non-breaking, no client/script changes required.

## What's added

| Piece | Where | Notes |
|-------|-------|-------|
| `audit_middleware` | `api/api.py` | Records every POST/PUT/DELETE/PATCH on `/api/*` to a new `audit_log` Cosmos doc-type. Reads + internal pod traffic + `/api/health|metrics|auth/login` skipped. Fire-and-forget — Cosmos failure never breaks the request. |
| `GET /api/audit-log` | `api/api.py` | Admin-only listing with `actor` / `path_prefix` / `method` / `since` filters (default 100, cap 1000). |
| Per-token `last_used_at` + `use_count` | `_validate_token` + `_touch_token_last_used` | Updates persisted Cosmos `auth_token` records on each use, debounced to 1 write / token / 60s. Surfaced on `GET /api/auth/tokens` so operators can revoke dormant tokens. |
| 17 offline unit tests | `tests/api/test_audit_log.py` | FakeStore stub; no Azure required. |

## Validation
- `python tests/api/test_audit_log.py` — **17/17 pass**
- `python tests/api/test_admin_endpoints.py` — **8/8 pass**
- `pytest tests/api/test_cosmos_attachments.py` — **29/29 pass**

## Threat-model status
- T-API-1 marked partial (`[~]`): audit-log + token telemetry shipped here. AAD-bearer migration of `OMNIVEC_ADMIN_TOKEN` remains open and is the next follow-up.

## Not in scope (deferred)
- AAD JWT validation path on `AuthMiddleware`
- `audit_log` UI in `omnivec-web`
- `audit_log` retention/purge job (recommend setting Cosmos TTL on the container — operator action)