### PR TITLE
security: CSP + per-token API rate-limit + PDF page cap + data classification (batch 3)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -248,7 +248,74 @@ async def security_headers(request: Request, call_next):
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     response.headers["Cache-Control"] = "no-store"
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+    # Content-Security-Policy. The UI ships a single static bundle from
+    # /static plus inline init script, and uses fetch() to same-origin /api/*.
+    # Operators can override via OMNIVEC_CSP env if they front the API with
+    # a different CDN/auth gateway.
+    response.headers["Content-Security-Policy"] = os.getenv(
+        "OMNIVEC_CSP",
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data: blob:; "
+        "font-src 'self' data:; "
+        "connect-src 'self'; "
+        "frame-ancestors 'none'; "
+        "base-uri 'self'; "
+        "form-action 'self'",
+    )
+    response.headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()"
     return response
+
+
+# =============================================================================
+# Per-actor API rate limiting (T-API-1 / web hardening)
+# =============================================================================
+# Sliding-window limiter keyed by token-id (or client IP for unauthenticated
+# requests). In-memory only — fine for single-process API; behind a
+# multi-replica deployment use an external limiter (Redis / nginx).
+_API_RATE_LIMIT = int(os.getenv("OMNIVEC_API_RATE_LIMIT", "120"))   # requests
+_API_RATE_WINDOW = float(os.getenv("OMNIVEC_API_RATE_WINDOW", "60"))  # seconds
+_API_RATE_SKIP_PREFIXES = ("/api/health", "/api/metrics")
+_api_rate_buckets: Dict[str, List[float]] = {}
+
+
+def _api_rate_check(key: str) -> bool:
+    """Return True if the request is within budget, False if it should be 429'd."""
+    if _API_RATE_LIMIT <= 0:
+        return True
+    now = time.monotonic()
+    bucket = _api_rate_buckets.get(key, [])
+    cutoff = now - _API_RATE_WINDOW
+    bucket = [t for t in bucket if t >= cutoff]
+    if len(bucket) >= _API_RATE_LIMIT:
+        _api_rate_buckets[key] = bucket
+        return False
+    bucket.append(now)
+    _api_rate_buckets[key] = bucket
+    return True
+
+
+@app.middleware("http")
+async def api_rate_limit_middleware(request: Request, call_next):
+    path = request.url.path
+    if (path.startswith("/api/")
+            and not any(path.startswith(p) for p in _API_RATE_SKIP_PREFIXES)
+            and not getattr(request.state, "internal", False)):
+        auth = getattr(request.state, "auth", None) or {}
+        token_id = auth.get("id")
+        if token_id:
+            key = f"tok:{token_id}"
+        else:
+            ip = request.client.host if request.client else "unknown"
+            key = f"ip:{ip}"
+        if not _api_rate_check(key):
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Too many requests. Slow down."},
+                headers={"Retry-After": str(int(_API_RATE_WINDOW))},
+            )
+    return await call_next(request)
 
 
 @app.middleware("http")

--- a/docs/security/data-classification.md
+++ b/docs/security/data-classification.md
@@ -1,0 +1,111 @@
+# OmniVec Data Classification
+
+> **Status:** living document. Updated when new doc-types or destinations are added.
+> **Owner:** OmniVec security WG. **Last revised:** batch 3, threat-model follow-up.
+
+This document classifies every persistent data store that OmniVec writes to,
+so operators can apply the correct retention, access-control, and erasure
+policies. It addresses threat-model item **T-VEC-1**.
+
+## 1. Classification scheme
+
+We use a four-tier scheme aligned with the Microsoft Data Classification
+Standard. Each tier dictates retention, encryption, access-review cadence,
+and erasure obligations.
+
+| Tier | Examples | Retention default | Erasure SLA |
+|------|----------|-------------------|-------------|
+| **Public** | Marketing assets, SDK samples | indefinite | n/a |
+| **Internal** | Pipeline metadata, source configs (no secrets), metrics | 2 years rolling | 30 days |
+| **Confidential** | Token hashes, audit logs, model API keys (until KV migration) | 1 year | 7 days |
+| **Confidential / PII** | Embedded chunk content, source documents, attachments | 90 days rolling unless customer-pinned | **72 h on validated subject request** |
+
+Anything labelled **Confidential / PII** is subject to GDPR / CCPA-style
+data-subject access and deletion requests.
+
+## 2. Per-store inventory
+
+### 2.1 Cosmos `omnivec` database (control-plane metadata)
+
+| Container | Doc-type(s) | Tier | Notes |
+|-----------|-------------|------|-------|
+| `metadata` | `source`, `destination`, `pipeline`, `assistant`, `docgrok_model`, `metrics` | **Internal** | Configs only — no document bodies, no embeddings. Source connection strings are pulled from Key Vault at runtime. |
+| `metadata` | `auth_token` | **Confidential** | Stores token hash + role + scope + last-used. Plain token never persisted. |
+| `metadata` | `audit_log` | **Confidential** | Actor, method, path (no body), status, IP, timestamp. **Recommended Cosmos TTL: 365 days.** |
+| `metadata` | `job` | **Internal** | Pipeline job state. May reference attachment blob keys but never embed content. |
+
+### 2.2 Cosmos `e2eblob` database (vector destination, default)
+
+| Container | Doc-type | Tier | Notes |
+|-----------|----------|------|-------|
+| `vectors` | embedded chunks | **Confidential / PII** | Each doc carries `id`, `source_ref`, `embedding` vector, `embedded_at`, plus passthrough source content fields (e.g. `summary`, `title`). The vector itself is reversible to a degree depending on the embedding model — **must be treated as the source content**. |
+
+### 2.3 Postgres pgvector destinations (customer-managed)
+
+Same classification as 2.2 — **Confidential / PII**. Schema is operator-defined;
+default columns: `id`, `source_id`, `source_ref`, `content`, `embedding`,
+`created_at`. The `content` column is plain text — high-sensitivity.
+
+### 2.4 Blob attachment cache (`omnivec-attachments` container)
+
+| Path | Tier | Notes |
+|------|------|-------|
+| `pdf/{docId}::{attName}` etc. | **Confidential / PII** | Verbatim copies of customer documents. Lifecycle policy: delete after 30 days. |
+
+### 2.5 Service-Bus / Queue Storage messages
+
+| Queue | Tier | Notes |
+|-------|------|-------|
+| `embedding-jobs` | **Confidential / PII** | Job payloads include either inline content or a blob_ref. Messages are short-lived (TTL 7 days). |
+
+### 2.6 Logs (App Insights / stdout)
+
+**Internal**, after `_SensitiveFilter` redacts secrets and after `_redact_path`
+strips query strings on audit entries. Long retention (90 days default in
+App Insights) — no document bodies are logged anywhere.
+
+## 3. Erasure / right-to-delete workflow
+
+Until a turnkey purge-by-source endpoint ships, operators delete a tenant's
+data manually:
+
+1. **Identify the source(s)** belonging to the data subject:
+   `GET /api/sources?owner=<id>` (or filter by tag).
+2. **Disable ingestion**: `PATCH /api/sources/{id}` set `status=paused`.
+3. **Delete vectors** — use the relevant connector tool:
+   - Cosmos vector destination: `connectors.cosmosdb_vector_connector.delete_chunks_by_prefix(config, prefix=f"{pipeline_id}-")`.
+     This deletes by pipeline; if multiple sources feed one pipeline, all
+     are removed (acceptable when isolating a tenant; not when surgical).
+   - Postgres: `DELETE FROM <vectors_table> WHERE source_id = $1` (run via
+     the `psql` operator console — there is no admin endpoint yet).
+4. **Delete attachment cache**: `az storage blob delete-batch
+   --source omnivec-attachments --pattern "*::{source_id}*"`.
+5. **Delete source metadata**: `DELETE /api/sources/{id}`.
+6. **Confirm**: `GET /api/audit-log?actor=<operator>&since=<ts>` should show
+   the chain of `DELETE` calls.
+
+A future PR (T-VEC-1 follow-up) will collapse steps 3–5 into a single
+`DELETE /api/sources/{id}/vectors?cascade=true` call.
+
+## 4. Access control summary
+
+| Role | Can read | Can write | Can delete |
+|------|----------|-----------|------------|
+| `viewer` | metadata + metrics | — | — |
+| `operator` | metadata + metrics + audit_log | sources, pipelines, jobs | own jobs |
+| `admin` | everything (incl. tokens) | everything | everything |
+
+Roles are enforced in `AuthMiddleware` + per-endpoint `request.state.auth.role`
+checks. Token records are never returned with the plain token after creation
+(only `id`, `name`, `role`, `created_at`, `last_used_at`, `use_count`).
+
+## 5. Open items
+
+- **Right-to-erasure endpoint** (`DELETE /api/sources/{id}/vectors`) — tracked
+  under T-VEC-1; not yet shipped.
+- **Cosmos TTL on `audit_log`** — set to 365 days at deployment time
+  (`az cosmosdb sql container update --idx ...defaultTtl=31536000`).
+- **PII-aware embedding model selection** — embeddings of customer text in
+  shared OpenAI deployments leak content via embedding inversion attacks.
+  Use a customer-pinned deployment (`source.docgrok_pipeline.embedding_model`)
+  for tenants with PII contracts.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -172,12 +172,12 @@ Legend: ✅ has mitigation in code · ⚠️ partial · ❌ open · — N/A
 - [x] **High** Migration script `scripts/scrub_model_api_keys.py` clears legacy `api_key` from `docgrok_model` records (push to Key Vault first, fall back to `--force-clear` once AAD verified). *(T-MET-1, batch 1.)*
 - [~] **High** `OMNIVEC_ADMIN_TOKEN` → AAD bearer + role gating: **batch 2 ships audit-log + per-token last-used**; AAD-bearer migration still pending. *(T-API-1.)*
 - [x] **High** `attachment_blob_account_allowlist` config + mandatory pin: absolute attachment URLs are rejected unless host matches `account_url` or the allowlist. *(T-CON-2, batch 1.)*
-- [ ] **Medium** Sandbox `pipeline-worker` parser in a subprocess with `RLIMIT_AS=1GB` and seccomp; cap pages-per-attachment to 200.
+- [~] **Medium** Sandbox `pipeline-worker` parser in a subprocess with `RLIMIT_AS=1GB` and seccomp; cap pages-per-attachment to 200. *(Page cap shipped in batch 3 — `DOCGROK_PDF_MAX_PAGES` default lowered from 500 → 200; subprocess + RLIMIT + seccomp still pending.)*
 - [ ] **Medium** Isolate change-feed lease container into its own Cosmos DB with a separate SA.
 - [x] **Medium** Per-AOAI-deployment embed semaphore + jittered exponential backoff in pipeline-worker (`OMNIVEC_EMBED_CONCURRENCY`, default 4). *(T-RL-1, batch 1.)*
 - [x] **Low** Attachment IDs / blob keys validated: traversal segments (`..`, `.`), control chars, leading slashes, and empty segments are rejected; absolute-URL paths are sanitized after URL-decoding. *(T-BLB-1, batch 1.)*
-- [ ] **Low** Document data classification of `e2eblob.vectors` as PII; add purge-by-source endpoint.
-- [ ] **Low** Add CSP + rate-limit at omnivec-web ingress.
+- [~] **Low** Document data classification of `e2eblob.vectors` as PII; add purge-by-source endpoint. *(Classification doc shipped in batch 3 — see `docs/security/data-classification.md`. Purge-by-source endpoint still pending; operators can use `delete_chunks_by_prefix` per-pipeline today.)*
+- [~] **Low** Add CSP + rate-limit at omnivec-web ingress. *(Batch 3 ships in-process CSP header + per-token sliding-window rate-limit on `/api/*` (defaults: 120 req / 60 s, env-tunable). Ingress-layer enforcement remains a future hardening step for defence in depth.)*
 
 ## 7. How to update this model
 

--- a/tests/api/test_csp_and_rate_limit.py
+++ b/tests/api/test_csp_and_rate_limit.py
@@ -1,0 +1,182 @@
+"""Offline tests for batch-3 hardening: CSP header + per-token API rate limit.
+
+Mirrors test_admin_endpoints.py / test_audit_log.py style — no pytest required.
+
+Run:
+    python tests/api/test_csp_and_rate_limit.py
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import unittest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(_ROOT, "api"))
+os.environ.setdefault("OMNIVEC_ADMIN_TOKEN", "test-token")
+
+import api  # noqa: E402
+
+
+class FakeRequest:
+    def __init__(self, path="/api/sources", method="GET",
+                 auth=None, internal=False, client_host="1.2.3.4"):
+        self.method = method
+        # Starlette URL has .path
+        self.url = type("U", (), {"path": path})()
+        self.client = type("C", (), {"host": client_host})() if client_host else None
+
+        class _State:
+            pass
+        self.state = _State()
+        if auth is not None:
+            self.state.auth = auth
+        if internal:
+            self.state.internal = True
+
+
+class FakeResponse:
+    def __init__(self, status=200):
+        self.status_code = status
+        self.headers: dict = {}
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class CSPHeaderTests(unittest.TestCase):
+    def test_csp_header_present_on_all_responses(self):
+        async def call_next(req):
+            return FakeResponse(200)
+        resp = _run(api.security_headers(FakeRequest(), call_next))
+        self.assertIn("Content-Security-Policy", resp.headers)
+        csp = resp.headers["Content-Security-Policy"]
+        self.assertIn("default-src 'self'", csp)
+        self.assertIn("frame-ancestors 'none'", csp)
+        self.assertIn("base-uri 'self'", csp)
+
+    def test_csp_overridable_via_env(self):
+        try:
+            os.environ["OMNIVEC_CSP"] = "default-src 'none'"
+
+            async def call_next(req):
+                return FakeResponse(200)
+            resp = _run(api.security_headers(FakeRequest(), call_next))
+            self.assertEqual(resp.headers["Content-Security-Policy"], "default-src 'none'")
+        finally:
+            os.environ.pop("OMNIVEC_CSP", None)
+
+    def test_other_security_headers_still_set(self):
+        async def call_next(req):
+            return FakeResponse(200)
+        resp = _run(api.security_headers(FakeRequest(), call_next))
+        self.assertEqual(resp.headers["X-Frame-Options"], "DENY")
+        self.assertEqual(resp.headers["X-Content-Type-Options"], "nosniff")
+        self.assertIn("Permissions-Policy", resp.headers)
+
+
+class ApiRateLimitTests(unittest.TestCase):
+    def setUp(self):
+        # Clean state between tests
+        api._api_rate_buckets.clear()
+        self._prev_limit = api._API_RATE_LIMIT
+        self._prev_window = api._API_RATE_WINDOW
+        api._API_RATE_LIMIT = 3
+        api._API_RATE_WINDOW = 60.0
+
+    def tearDown(self):
+        api._API_RATE_LIMIT = self._prev_limit
+        api._API_RATE_WINDOW = self._prev_window
+        api._api_rate_buckets.clear()
+
+    def _hit(self, req, status=200):
+        async def call_next(r):
+            return FakeResponse(status)
+        return _run(api.api_rate_limit_middleware(req, call_next))
+
+    def test_per_token_isolation(self):
+        a = FakeRequest(path="/api/sources", method="GET",
+                        auth={"id": "tok-A", "name": "alice", "role": "operator"})
+        b = FakeRequest(path="/api/sources", method="GET",
+                        auth={"id": "tok-B", "name": "bob", "role": "operator"})
+        for _ in range(3):
+            self.assertEqual(self._hit(a).status_code, 200)
+        # tok-A is now exhausted
+        self.assertEqual(self._hit(a).status_code, 429)
+        # tok-B has its own bucket
+        self.assertEqual(self._hit(b).status_code, 200)
+
+    def test_429_includes_retry_after(self):
+        req = FakeRequest(path="/api/sources",
+                          auth={"id": "tok-X", "name": "x", "role": "operator"})
+        for _ in range(3):
+            self._hit(req)
+        resp = self._hit(req)
+        self.assertEqual(resp.status_code, 429)
+        self.assertIn("Retry-After", resp.headers)
+
+    def test_unauth_keyed_by_ip(self):
+        a = FakeRequest(path="/api/sources", client_host="9.9.9.9")
+        b = FakeRequest(path="/api/sources", client_host="8.8.8.8")
+        for _ in range(3):
+            self.assertEqual(self._hit(a).status_code, 200)
+        self.assertEqual(self._hit(a).status_code, 429)
+        self.assertEqual(self._hit(b).status_code, 200)
+
+    def test_health_metrics_skipped(self):
+        # Even with auth absent, repeated /api/health should never 429
+        for _ in range(50):
+            r = FakeRequest(path="/api/health", client_host="1.1.1.1")
+            self.assertEqual(self._hit(r).status_code, 200)
+        for _ in range(50):
+            r = FakeRequest(path="/api/metrics", client_host="1.1.1.1")
+            self.assertEqual(self._hit(r).status_code, 200)
+
+    def test_internal_traffic_skipped(self):
+        for _ in range(50):
+            r = FakeRequest(path="/api/sources", internal=True,
+                            auth={"id": "tok-I", "name": "i", "role": "admin"})
+            self.assertEqual(self._hit(r).status_code, 200)
+
+    def test_non_api_paths_skipped(self):
+        for _ in range(50):
+            r = FakeRequest(path="/static/app.js", client_host="2.2.2.2")
+            self.assertEqual(self._hit(r).status_code, 200)
+
+    def test_disabled_when_limit_zero(self):
+        api._API_RATE_LIMIT = 0
+        for _ in range(100):
+            r = FakeRequest(path="/api/sources",
+                            auth={"id": "tok-Z", "name": "z", "role": "operator"})
+            self.assertEqual(self._hit(r).status_code, 200)
+
+
+class RateCheckUnitTests(unittest.TestCase):
+    def setUp(self):
+        api._api_rate_buckets.clear()
+        self._prev_limit = api._API_RATE_LIMIT
+        self._prev_window = api._API_RATE_WINDOW
+        api._API_RATE_LIMIT = 2
+        api._API_RATE_WINDOW = 60.0
+
+    def tearDown(self):
+        api._API_RATE_LIMIT = self._prev_limit
+        api._API_RATE_WINDOW = self._prev_window
+        api._api_rate_buckets.clear()
+
+    def test_window_eviction(self):
+        key = "tok:windowed"
+        # Pre-seed bucket with old timestamps so the limiter evicts them
+        import time as _t
+        old = _t.monotonic() - 1000.0  # well outside the 60 s window
+        api._api_rate_buckets[key] = [old, old, old]
+        # First call should evict and accept
+        self.assertTrue(api._api_rate_check(key))
+        # Bucket should now contain only the new timestamp
+        self.assertEqual(len(api._api_rate_buckets[key]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Stacked on **#130** (batch 2) which is stacked on **#129** (batch 1). Re-target to `dev` once those merge.

Three small, non-breaking hardening pieces from the threat model.

## Changes

| Item | Tier | Where | Threat-model |
|------|------|-------|--------------|
| **CSP + Permissions-Policy headers** | Low | `api/api.py` `security_headers` middleware | web-CSP |
| **Per-token API rate-limit** (sliding window, 120 req / 60 s default) | Low | new `api_rate_limit_middleware` | web-CSP / T-API-1 |
| **PDF page-cap default 500 → 200** | Med | `docgrok/pipeline-worker/worker.py` | T-RTR-1 (partial) |
| **Data-classification doc** | Low | `docs/security/data-classification.md` | T-VEC-1 (partial) |

CSP is overridable via `OMNIVEC_CSP` env. Rate-limit is overridable via `OMNIVEC_API_RATE_LIMIT` (default 120) and `OMNIVEC_API_RATE_WINDOW` (default 60 s); set limit=0 to disable for load testing. `/api/health`, `/api/metrics`, internal pod-to-pod traffic, and non-`/api/*` paths are skipped.

## Threat-model checklist
- T-RTR-1: `[ ] → [~]` — page cap shipped; subprocess + RLIMIT + seccomp pending.
- T-VEC-1: `[ ] → [~]` — classification doc + manual erasure runbook shipped; `DELETE /api/sources/{id}/vectors` pending.
- web-CSP: `[ ] → [~]` — in-process CSP header + rate-limit shipped; ingress-layer enforcement (defence in depth) pending.

## Validation
- `python tests/api/test_csp_and_rate_limit.py` — **11/11 pass**
- `python tests/api/test_audit_log.py` — **17/17 pass**
- `python tests/api/test_admin_endpoints.py` — **8/8 pass**
- `pytest tests/api/test_cosmos_attachments.py` — **29/29 pass**

Total **65/65** offline.

## Submodule
`docgrok` bumped to `security/pdf-page-cap @ 22e3b9b` — single commit lowering the PDF page-cap default. Will be merged into `docgrok` `main` alongside the parent PR.

## Still open from threat model (post-batch 3)
- **T-API-1**: AAD-bearer migration of `OMNIVEC_ADMIN_TOKEN` (the bigger half).
- **T-RTR-1**: subprocess sandbox with `RLIMIT_AS=1GB` + seccomp.
- **T-PWK-1**: isolate change-feed lease container into its own Cosmos DB + SA.
- **T-CON-1**: Cosmos source-connector hardening.
- **T-VEC-1**: `DELETE /api/sources/{id}/vectors` cascading purge endpoint.
- web-CSP: ingress-layer CSP/rate-limit (defence in depth).