### PR TITLE
security: threat-model batch 5 — close batch-4 review residuals (T-AAD-1, T-CON-3, T-PWK-2, T-RTR-2, T-ING-1)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -179,6 +179,11 @@ _AAD_AUDIENCE = os.getenv("OMNIVEC_AAD_AUDIENCE", "").strip()
 _AAD_ADMIN_GROUP = os.getenv("OMNIVEC_AAD_ADMIN_GROUP_ID", "").strip()
 _AAD_OPERATOR_GROUP = os.getenv("OMNIVEC_AAD_OPERATOR_GROUP_ID", "").strip()
 _AAD_VIEWER_GROUP = os.getenv("OMNIVEC_AAD_VIEWER_GROUP_ID", "").strip()
+# T-AAD-1: when ``1``, AAD identities whose ``groups``/``roles`` claims do not
+# match any configured role group are *rejected* rather than defaulting to
+# viewer. Operators in tenants with guests / service identities should set
+# this. Default ``0`` preserves the original behaviour.
+_AAD_REQUIRE_GROUP = os.getenv("OMNIVEC_AAD_REQUIRE_GROUP", "0").strip() == "1"
 _aad_jwks_client = None  # lazy-initialised PyJWKClient
 
 
@@ -202,8 +207,13 @@ def _get_aad_jwks_client():
     return _aad_jwks_client
 
 
-def _aad_role_for_claims(claims: dict) -> str:
-    """Map AAD ``groups`` / ``roles`` claims to OmniVec role names."""
+def _aad_role_for_claims(claims: dict) -> Optional[str]:
+    """Map AAD ``groups`` / ``roles`` claims to OmniVec role names.
+
+    Returns ``None`` only when ``OMNIVEC_AAD_REQUIRE_GROUP=1`` is set and the
+    token has no matching role group — caller treats that as auth failure
+    (T-AAD-1). Otherwise unmapped tokens fall through to ``viewer``.
+    """
     groups = claims.get("groups") or []
     roles = claims.get("roles") or []
     if isinstance(groups, str):
@@ -217,9 +227,10 @@ def _aad_role_for_claims(claims: dict) -> str:
         return "operator"
     if _AAD_VIEWER_GROUP and _AAD_VIEWER_GROUP in membership:
         return "viewer"
-    # Operators who set neither admin nor operator group get the default
-    # least-privileged role; tighten by setting an explicit viewer group and
-    # rejecting unmapped tokens at the gateway.
+    if _AAD_REQUIRE_GROUP:
+        # Strict mode: refuse to grant any role to an unmapped principal.
+        return None
+    # Default: least-privileged viewer for unmapped principals.
     return "viewer"
 
 
@@ -273,6 +284,13 @@ def _validate_aad_token(token: str) -> Optional[dict]:
         return None
 
     role = _aad_role_for_claims(claims)
+    if role is None:
+        # T-AAD-1 strict mode: principal is authenticated but unmapped.
+        logger.info(
+            "AAD token rejected (no matching role group; OMNIVEC_AAD_REQUIRE_GROUP=1): oid=%s",
+            claims.get("oid", "")[:8],
+        )
+        return None
     return {
         "name": claims.get("preferred_username") or claims.get("upn") or claims.get("oid", ""),
         "role": role,

--- a/api/connectors/cosmosdb_connector.py
+++ b/api/connectors/cosmosdb_connector.py
@@ -2,9 +2,12 @@
 
 import os
 import hashlib
+import logging
 from typing import List, Dict, Any, Optional
 from azure.cosmos import CosmosClient
 from azure.identity import ManagedIdentityCredential, DefaultAzureCredential
+
+logger = logging.getLogger(__name__)
 
 
 class SkipDocument(Exception):
@@ -73,6 +76,7 @@ async def list_documents(config: Dict[str, Any], full_sync: bool = False) -> Lis
     cap = int(config.get("result_cap", 50_000))
 
     documents = []
+    truncated = False
     for item in container.query_items(query, enable_cross_partition_query=True):
         documents.append({
             "ref": item.get("id"),
@@ -83,7 +87,16 @@ async def list_documents(config: Dict[str, Any], full_sync: bool = False) -> Lis
             }
         })
         if len(documents) >= cap:
+            truncated = True
             break
+
+    if truncated:
+        logger.warning(
+            "cosmosdb list_documents truncated at result_cap=%d (container=%s); "
+            "raise OMNIVEC_COSMOS_RESULT_CAP or set 'result_cap' on the source config "
+            "if you need the full set (T-CON-3).",
+            cap, config.get("container", ""),
+        )
 
     return documents
 

--- a/connectors/ingestion/dotnet/Program.cs
+++ b/connectors/ingestion/dotnet/Program.cs
@@ -73,6 +73,8 @@ logger.LogInformation("  Cosmos: {Cosmos}", opts.OmniVecCosmosEndpoint);
 if (!string.IsNullOrWhiteSpace(opts.LeaseCosmosEndpoint))
     logger.LogInformation("  Lease Cosmos: {Lease}/{Db}", opts.LeaseCosmosEndpoint,
         string.IsNullOrWhiteSpace(opts.LeaseCosmosDatabase) ? opts.OmniVecDatabase : opts.LeaseCosmosDatabase);
+else
+    logger.LogWarning("  Lease Cosmos: SHARED with metadata account. Set ChangeFeed:LeaseCosmosEndpoint to isolate the change-feed lease container per the T-PWK-1 guidance.");
 logger.LogInformation("  Poll: {Poll}s, Feed: {Feed}s, Batch: {Batch}",
     opts.SourcePollIntervalSeconds, opts.FeedPollIntervalSeconds, opts.MaxItemsPerBatch);
 

--- a/docs/security/threat-model-review-2026-05.md
+++ b/docs/security/threat-model-review-2026-05.md
@@ -76,20 +76,18 @@ Legend: ✅ mitigated · ⚠️ partial / config-dependent · ❌ open
 These are residual or *new* attack surfaces created by the fixes themselves.
 Track them under fresh `T-…-N` ids so future PRs can close them.
 
-### T-AAD-1 (Med) — Default-viewer fall-through for unmapped AAD identities
+### T-AAD-1 (Med) — Default-viewer fall-through for unmapped AAD identities ✅ batch 5
 
-* **Where:** `api/api.py::_aad_role_for_claims` returns `"viewer"` when none of
-  the configured `OMNIVEC_AAD_*_GROUP_ID` env vars are set or the token's
-  `groups`/`roles` claims don't include them.
+* **Where:** `api/api.py::_aad_role_for_claims` returned `"viewer"` when none of
+  the configured `OMNIVEC_AAD_*_GROUP_ID` env vars matched the token's
+  `groups`/`roles` claims.
 * **Risk:** any AAD principal in the tenant — including service identities or
-  guests — successfully validates and gets read access to /api/sources,
+  guests — successfully validated and got read access to /api/sources,
   /api/pipelines, etc. as a viewer.
-* **Mitigation paths:**
-  - Set `OMNIVEC_AAD_VIEWER_GROUP_ID` so unmapped tokens reject (the code
-    will still default-viewer, but operators can wire a deny-list group).
-  - Add an `OMNIVEC_AAD_REQUIRE_GROUP=1` env to flip the default to "reject"
-    (future PR — small).
-  - Document this clearly in the auth runbook.
+* **Mitigation shipped:** `OMNIVEC_AAD_REQUIRE_GROUP=1` flips the default to
+  *reject* — `_aad_role_for_claims` returns `None` for unmapped principals
+  and `_validate_aad_token` treats that as auth failure (logged at INFO).
+  Default `0` preserves the original lax behaviour for backwards compat.
 
 ### T-AAD-2 (Low) — JWKS cache poisoning if MSFT endpoint is hijacked
 
@@ -105,17 +103,17 @@ Track them under fresh `T-…-N` ids so future PRs can close them.
   - Treat as accepted residual; egress to login.microsoftonline.com is
     industry-standard.
 
-### T-RTR-2 (Med) — Sandbox child returns full page list via `multiprocessing.Queue`
+### T-RTR-2 (Med) — Sandbox child returns full page list via `multiprocessing.Queue` ✅ batch 5
 
 * **Where:** `docgrok/pipeline-worker/worker.py::_pdf_subprocess_target`
-  pickles `pages` (list of strings) over a `mp.Queue` back to the parent.
-* **Risk:** a malicious PDF that legitimately produces lots of OCR text
-  (within `RLIMIT_AS`) can still hand back a multi-hundred-MB list to the
-  parent — the parent has no rlimit. Memory pressure on the worker pod.
-* **Mitigation paths:**
-  - Stream pages back via a chunked pipe instead of materialising a list.
-  - Cap the cumulative bytes returned (e.g., 64 MiB) and abort.
-  - For now: `DOCGROK_PDF_MAX_PAGES=200` is the de-facto bound.
+  pickled the full `pages` list back to the parent.
+* **Risk:** a malicious PDF that legitimately produced lots of OCR text
+  (within `RLIMIT_AS`) could still hand back a multi-hundred-MB list to
+  the parent — the parent had no rlimit. Memory pressure on the worker pod.
+* **Mitigation shipped:** child accumulates pages until
+  `DOCGROK_PARSER_SANDBOX_MAX_BYTES` (default 64 MiB) is reached, then
+  stops and signals truncation. Parent logs a WARNING. Total bytes shipped
+  back to the parent are now hard-bounded.
 
 ### T-RTR-3 (Low) — Sandbox is Linux-only
 
@@ -141,7 +139,7 @@ Track them under fresh `T-…-N` ids so future PRs can close them.
     with `source_id` are touched.
   - Long-term: backfill `source_id` for legacy docs via a one-shot job.
 
-### T-ING-1 (Low) — Default ingress template assumes nginx-ingress
+### T-ING-1 (Low) — Default ingress template assumes nginx-ingress ✅ batch 5 (documented)
 
 * **Where:** `helm/omnivec/templates/ingress.yaml` uses
   `nginx.ingress.kubernetes.io/...` annotations for CSP, X-Frame-Options,
@@ -149,31 +147,31 @@ Track them under fresh `T-…-N` ids so future PRs can close them.
 * **Risk:** operators who deploy on a non-nginx ingress class get **no**
   defence-in-depth from the template. The in-process header set in
   batch 3 still applies, so this is genuinely "low".
-* **Mitigation paths:**
-  - Documented in `values.yaml` comment.
-  - Future PR: add controller-detection or a Traefik middleware variant.
+* **Mitigation shipped:** explicit warning + remediation guidance at the top
+  of the `ingress:` block in `helm/omnivec/values.yaml`. Operator on a
+  non-nginx controller sees it the moment they enable ingress.
 
-### T-PWK-2 (Low) — Lease isolation is opt-in
+### T-PWK-2 (Low) — Lease isolation is opt-in ✅ batch 5 (warning)
 
 * **Where:** `LeaseCosmosEndpoint` / `LeaseCosmosDatabase` default empty;
   the keyed `"lease"` `CosmosClient` falls back to the main account.
 * **Risk:** operators who don't set the new env vars stay on the original
   shared-lease topology, i.e. **the same risk T-PWK-1 originally
   surfaced**.
-* **Mitigation paths:**
-  - Default-on is breaking; opt-in is the intentional trade-off.
-  - Document strongly in the deploy runbook + helm chart values.
-  - Future PR: emit a startup warning when shared.
+* **Mitigation shipped:** `Program.cs` now emits `LogWarning` at startup
+  when `LeaseCosmosEndpoint` is empty, telling the operator the lease
+  container is shared and pointing at the T-PWK-1 guidance. Default-on is
+  still breaking; this is the safest opt-in default.
 
-### T-CON-3 (Low) — `result_cap` silent truncation
+### T-CON-3 (Low) — `result_cap` silent truncation ✅ batch 5
 
 * **Where:** `cosmosdb_connector::list_documents` stops the iterator at
   `cap` rows.
-* **Risk:** operators expecting "all rows" silently get the first 50 000.
+* **Risk:** operators expecting "all rows" silently got the first 50 000.
   Could mask data-completeness bugs.
-* **Mitigation paths:**
-  - Log a WARNING at the truncation boundary (small follow-up PR).
-  - Surface a header / response field on the API.
+* **Mitigation shipped:** WARNING log emitted whenever truncation happens,
+  naming the container and pointing at the env var. Tests assert log
+  fires on overflow and is silent under cap.
 
 ## 4. Residual / deliberately accepted risks
 
@@ -188,19 +186,18 @@ remediation. Documented for transparency.
 | RES-4 | Search service rate-limit | Currently per-IP at ingress; per-token rate-limit on `/search` is on the search-team backlog. |
 | RES-5 | Threat model of CI/CD | Tracked separately under `infra/` and `.github/workflows/`. |
 
-## 5. Future hardening backlog (post-batch-4)
+## 5. Future hardening backlog (post-batch-5)
 
 Ordered by ROI. Each is a future PR-sized chunk, not a release blocker.
 
-1. **T-AAD-1**: `OMNIVEC_AAD_REQUIRE_GROUP` env → reject unmapped AAD tokens.
-2. **T-RTR-2**: stream sandbox parser output via chunked pipe + byte cap.
-3. **T-VEC-2 backfill**: one-shot job to add `source_id` to pre-batch-4
+1. **T-VEC-2 backfill**: one-shot job to add `source_id` to pre-batch-4
    vectors so cascade purge is no longer pipeline-wide.
-4. **T-ING-1**: controller-detection in helm chart (nginx vs. Traefik vs. AGIC).
-5. **T-CON-3**: surface `result_cap` truncation in API response + log.
-6. **RES-2**: ship a baseline seccomp profile for the parser worker.
-7. **RES-1**: private-endpoint migration scoped per-Azure-resource.
-8. **PWK-2 warning**: startup log when lease is shared.
+2. **RES-2**: ship a baseline seccomp profile for the parser worker.
+3. **T-AAD-2**: thumbprint-pinned JWKS adapter (accepted residual today).
+4. **T-RTR-3**: cross-platform sandbox shim for non-Linux dev/CI parity.
+5. **T-ING-1 part 2**: ship Traefik `Middleware` and AGIC variants of the
+   ingress template.
+6. **RES-1**: private-endpoint migration scoped per-Azure-resource.
 
 Each item should be filed as an issue with a `T-…` id and pulled into the
 next quarterly threat-model batch (batch 5) when it tops the queue.

--- a/helm/omnivec/values.yaml
+++ b/helm/omnivec/values.yaml
@@ -495,6 +495,13 @@ docgrok:
 # =============================================================================
 # INGRESS (Optional)
 # =============================================================================
+# T-ING-1: the bundled annotations target nginx-ingress
+# (`nginx.ingress.kubernetes.io/...`). On Traefik / AGIC / Istio they are
+# silently ignored — the in-process CSP header set by api/api.py still
+# applies, but the ingress-layer defence in depth does not. If you run a
+# non-nginx controller, replicate the equivalent CSP / X-Frame-Options /
+# rate-limit policy in your controller's native config (e.g. Traefik
+# `Middleware` CRD, AGIC custom rewrite rules).
 ingress:
   enabled: false
   className: nginx

--- a/tests/api/test_batch5.py
+++ b/tests/api/test_batch5.py
@@ -1,0 +1,125 @@
+"""Offline tests for batch 5 threat-model follow-ups.
+
+Covers:
+  - T-AAD-1: OMNIVEC_AAD_REQUIRE_GROUP=1 rejects unmapped tokens
+  - T-CON-3: list_documents logs WARNING on cap truncation
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(_ROOT, "api"))
+os.environ.setdefault("OMNIVEC_ADMIN_TOKEN", "test-token")
+
+import api  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+class AadRequireGroupTests(unittest.TestCase):
+    def setUp(self):
+        self._orig_admin = api._AAD_ADMIN_GROUP
+        self._orig_op = api._AAD_OPERATOR_GROUP
+        self._orig_view = api._AAD_VIEWER_GROUP
+        self._orig_strict = api._AAD_REQUIRE_GROUP
+        api._AAD_ADMIN_GROUP = "grp-admin"
+        api._AAD_OPERATOR_GROUP = "grp-operator"
+        api._AAD_VIEWER_GROUP = "grp-viewer"
+
+    def tearDown(self):
+        api._AAD_ADMIN_GROUP = self._orig_admin
+        api._AAD_OPERATOR_GROUP = self._orig_op
+        api._AAD_VIEWER_GROUP = self._orig_view
+        api._AAD_REQUIRE_GROUP = self._orig_strict
+
+    def test_strict_returns_none_for_unmapped(self):
+        api._AAD_REQUIRE_GROUP = True
+        self.assertIsNone(api._aad_role_for_claims({"groups": ["random-group"]}))
+
+    def test_strict_still_maps_admin(self):
+        api._AAD_REQUIRE_GROUP = True
+        self.assertEqual(api._aad_role_for_claims({"groups": ["grp-admin"]}), "admin")
+
+    def test_lax_default_falls_through_to_viewer(self):
+        api._AAD_REQUIRE_GROUP = False
+        self.assertEqual(api._aad_role_for_claims({"groups": ["random"]}), "viewer")
+
+
+class CosmosResultCapWarningTests(unittest.TestCase):
+    def test_warning_emitted_when_cap_hit(self):
+        from connectors import cosmosdb_connector as cdc
+
+        class FakeContainer:
+            def query_items(self, query=None, parameters=None, **kw):
+                return iter([{"id": f"d{i}"} for i in range(100)])
+
+        class FakeDB:
+            def get_container_client(self, *a, **kw):
+                return FakeContainer()
+
+        class FakeClient:
+            def get_database_client(self, *a, **kw):
+                return FakeDB()
+
+        cfg = {"database": "db", "container": "c", "result_cap": 5}
+
+        async def _fake(c):
+            return FakeClient()
+
+        with patch.object(cdc, "get_cosmos_client", _fake):
+            with self.assertLogs(cdc.logger, level="WARNING") as ctx:
+                docs = _run(cdc.list_documents(cfg))
+        self.assertEqual(len(docs), 5)
+        self.assertTrue(any("truncated" in m for m in ctx.output))
+
+    def test_no_warning_when_under_cap(self):
+        from connectors import cosmosdb_connector as cdc
+
+        class FakeContainer:
+            def query_items(self, query=None, parameters=None, **kw):
+                return iter([{"id": f"d{i}"} for i in range(3)])
+
+        class FakeDB:
+            def get_container_client(self, *a, **kw):
+                return FakeContainer()
+
+        class FakeClient:
+            def get_database_client(self, *a, **kw):
+                return FakeDB()
+
+        cfg = {"database": "db", "container": "c", "result_cap": 5}
+
+        async def _fake(c):
+            return FakeClient()
+
+        # Under cap should not warn — assertNoLogs is 3.10+; just check messages.
+        cdc.logger.setLevel(logging.WARNING)
+        captured: list[str] = []
+
+        class _Handler(logging.Handler):
+            def emit(self, record):
+                captured.append(record.getMessage())
+
+        h = _Handler()
+        cdc.logger.addHandler(h)
+        try:
+            with patch.object(cdc, "get_cosmos_client", _fake):
+                docs = _run(cdc.list_documents(cfg))
+        finally:
+            cdc.logger.removeHandler(h)
+        self.assertEqual(len(docs), 3)
+        self.assertFalse(any("truncated" in m for m in captured))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Stacked on #132. Closes the five actionable items surfaced in the batch-4 review (\`docs/security/threat-model-review-2026-05.md\`).

## What this ships

| Item | Sev | Change |
|---|---|---|
| **T-AAD-1** | Med | \`OMNIVEC_AAD_REQUIRE_GROUP=1\` flips unmapped-principal default from viewer→reject. Lax default preserved. |
| **T-RTR-2** | Med | Sandbox child caps bytes returned to parent at \`DOCGROK_PARSER_SANDBOX_MAX_BYTES\` (default 64 MiB). |
| **T-CON-3** | Low | \`list_documents\` logs WARNING when \`result_cap\` truncates. |
| **T-PWK-2** | Low | .NET ingestion worker logs WARNING at startup when lease Cosmos shared. |
| **T-ING-1** | Low | values.yaml ingress block carries explicit guidance for non-nginx controllers. |

## Tests

+5 in \`tests/api/test_batch5.py\`: AAD strict-mode (3 cases) + result_cap WARNING (positive + negative). Total 54/54 offline.

## Submodule bump

\\\docgrok @ security/parser-sandbox: 7d6d04e → 739d557 (T-RTR-2 byte cap)\\\`n
## Backlog after this

Residual items deliberately deferred to batch 6+: T-VEC-2 backfill, RES-2 seccomp, T-AAD-2 thumbprint pin, T-RTR-3 cross-platform, T-ING-1 part 2 (Traefik/AGIC variants), RES-1 private endpoints.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>