### PR TITLE
security: threat-model batch 7 — close 4 post-batch-6 backlog items

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -190,7 +190,65 @@ _AAD_REQUIRE_GROUP = os.getenv("OMNIVEC_AAD_REQUIRE_GROUP", "0").strip() == "1"
 # to a copy of the Microsoft IT CA chain to fail closed if egress is
 # MITM-able. Empty string = use defaults.
 _AAD_JWKS_CA_BUNDLE = os.getenv("OMNIVEC_AAD_JWKS_CA_BUNDLE", "").strip()
+# T-AAD-2 hardening: optional comma-separated SHA-256 thumbprints (hex,
+# lowercased, colons-or-spaces allowed) of the leaf certificate served by
+# login.microsoftonline.com. When set, the JWKS HTTPS connection is
+# verified against the CA bundle AS WELL AS pinned to one of these
+# fingerprints — fail closed on mismatch. The pin is checked the first
+# time we connect; PyJWKClient caches the keys for ``lifespan`` seconds.
+# Empty string disables the pin entirely (default).
+_AAD_JWKS_PIN_SHA256 = os.getenv("OMNIVEC_AAD_JWKS_PIN_SHA256", "").strip()
 _aad_jwks_client = None  # lazy-initialised PyJWKClient
+
+
+def _normalise_thumbprint(value: str) -> str:
+    """Strip separators and lower-case a SHA-256 hex digest.
+
+    Operators paste fingerprints in many shapes (``aa:bb:cc:..``, ``AA BB CC``,
+    ``aabbcc..``) — accept all and compare canonical forms.
+    """
+    return "".join(ch for ch in value.lower() if ch in "0123456789abcdef")
+
+
+def _parse_pinned_thumbprints(raw: str) -> list[str]:
+    """Split + canonicalise the pin env var; ignore empty + malformed entries."""
+    out: list[str] = []
+    for chunk in (raw or "").split(","):
+        norm = _normalise_thumbprint(chunk.strip())
+        if len(norm) == 64:  # SHA-256 = 32 bytes = 64 hex chars
+            out.append(norm)
+        elif chunk.strip():
+            logger.warning(
+                "AAD JWKS pin %r is not a 64-char SHA-256 hex digest; ignored",
+                chunk.strip(),
+            )
+    return out
+
+
+def _verify_jwks_thumbprint(host: str, port: int, pinned: list[str], cafile: str) -> bool:
+    """Open a TLS handshake to ``host:port`` and return True iff the leaf
+    cert SHA-256 matches one of ``pinned`` thumbprints.
+
+    Raises on TLS failure (network, hostname, CA). Used as a one-shot pre-check
+    before letting PyJWKClient cache the JWKS keys for the day.
+    """
+    import hashlib
+    import socket
+    import ssl
+    ctx = ssl.create_default_context(cafile=cafile or None)
+    ctx.check_hostname = True
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    with socket.create_connection((host, port), timeout=10) as raw:
+        with ctx.wrap_socket(raw, server_hostname=host) as tls:
+            der = tls.getpeercert(binary_form=True)
+    fp = hashlib.sha256(der).hexdigest()
+    if fp in pinned:
+        return True
+    logger.error(
+        "AAD JWKS thumbprint pin MISMATCH for %s — got %s, expected one of %s",
+        host, fp, pinned,
+    )
+    return False
 
 
 def _aad_enabled() -> bool:
@@ -209,6 +267,22 @@ def _get_aad_jwks_client():
     jwks_url = (
         f"https://login.microsoftonline.com/{_AAD_TENANT_ID}/discovery/v2.0/keys"
     )
+    # T-AAD-2 hardening: when a thumbprint pin is configured, do a one-shot
+    # TLS probe to login.microsoftonline.com and abort initialisation if
+    # the leaf cert SHA-256 doesn't match. Failing here returns ``None`` so
+    # AAD auth is unavailable rather than silently downgraded.
+    pinned = _parse_pinned_thumbprints(_AAD_JWKS_PIN_SHA256)
+    if pinned:
+        try:
+            ok = _verify_jwks_thumbprint(
+                "login.microsoftonline.com", 443, pinned, _AAD_JWKS_CA_BUNDLE,
+            )
+        except Exception as e:
+            logger.error("AAD JWKS thumbprint probe failed: %s", e)
+            return None
+        if not ok:
+            return None
+        logger.info("AAD JWKS thumbprint pin verified (%d candidate(s))", len(pinned))
     # T-AAD-2: pass an explicit CA bundle when one is pinned via env. PyJWT's
     # PyJWKClient uses urllib under the hood; surface SSL context via the
     # ``ssl_context`` kwarg when available, otherwise fall back to default.

--- a/docs/security/threat-model-review-2026-05.md
+++ b/docs/security/threat-model-review-2026-05.md
@@ -225,19 +225,36 @@ Status of the six original backlog items:
    gate before flipping `public_network_access_enabled = false`) is the
    recommended sequencing.
 
-Ordered next-batch backlog (post-batch-6):
+Ordered next-batch backlog (post-batch-7):
 
-1. **AGIC ingress variant** for `ingress.controller=agic` (T-ING-1
-   follow-up; annotations + per-listener rewrite rules).
-2. **AAD thumbprint pin** (T-AAD-2 hardening): replace the env CA-bundle
-   with a hash-of-key pin verified post-fetch.
-3. **Private-endpoint phase 2**: AOAI + Key Vault + per-resource
-   `public_network_access_enabled=false` once the FY27 hub VNet is
-   ready (RES-1 follow-up).
-4. **Seccomp tuning**: tighten the allow-list once we have parser-worker
+1. **Seccomp tuning**: tighten the allow-list once we have parser-worker
    strace from production (RES-2 follow-up).
-5. **Cosign image signing** (RES-3) when ACR enables it org-wide.
-6. **Search per-token rate-limit** (RES-4).
+2. **Cosign image signing** (RES-3) when ACR enables it org-wide.
+3. **Threat model of CI/CD** (RES-5) — separate workstream once `.github/workflows/`
+   stabilises.
+
+Status of the six batch-6 backlog items (all closed in PR #135 / batch 7):
+
+* **AGIC ingress variant** — ✅ batch 7: `helm/omnivec/templates/ingress-agic.yaml`,
+  selected via `ingress.controller=agic`. Uses App Gateway annotations
+  (`appgw.ingress.kubernetes.io/rewrite-rule-set`,
+  `appgw.ingress.kubernetes.io/waf-policy-for-path`); the rewrite rule
+  set + WAF policy must be provisioned on the App Gateway out-of-band
+  before the chart is applied.
+* **AAD thumbprint pin** — ✅ batch 7: `OMNIVEC_AAD_JWKS_PIN_SHA256`
+  (comma-separated SHA-256 hex digests; whitespace / colon separators
+  accepted). One-shot TLS probe to login.microsoftonline.com on JWKS
+  client init; mismatch fails closed (returns `None` → AAD auth
+  unavailable, not silently downgraded).
+* **PE phase 2** — ✅ batch 7: `terraform/private-endpoints.tf`
+  extended with Key Vault and Azure OpenAI PEs. Both gated on per-resource
+  IDs (`var.key_vault_id`, `var.openai_account_id`) plus DNS zone keys
+  in `private_dns_zone_ids`.
+* **Per-token rate-limit on /search** — ✅ batch 7 (RES-4 closed):
+  `search/auth.py` rate-limit now keyed off token id (no longer token
+  name — two tokens with the same name had a shared bucket). Added
+  per-token override via the `rate_limit_rpm` field on the token doc:
+  `0` = uncapped (trusted automation), positive int = clamp.
 
 ## 6. Verification
 

--- a/helm/omnivec/templates/ingress-agic.yaml
+++ b/helm/omnivec/templates/ingress-agic.yaml
@@ -1,0 +1,65 @@
+{{- if and .Values.ingress.enabled (eq (.Values.ingress.controller | default "nginx") "agic") }}
+{{- /*
+  T-ING-1 part 3 — AGIC (Application Gateway Ingress Controller) variant.
+
+  AGIC translates plain Kubernetes Ingress objects into App Gateway
+  rules. Unlike nginx, it does NOT honour `nginx.ingress.kubernetes.io/...`
+  annotations; defence-in-depth headers + rate-limits must be expressed
+  via:
+    - appgw.ingress.kubernetes.io/rewrite-rule-set: <name of a rewrite rule
+      set provisioned out-of-band on the App Gateway> — used here to inject
+      response headers (CSP / X-Frame-Options / Permissions-Policy).
+    - A WAF policy attached to the listener for rate-limit + bot rules
+      (App Gateway WAF v2 rate-limit rules are managed at the gateway,
+      not in the Ingress object).
+
+  Operators MUST provision the rewrite rule set + WAF policy on the App
+  Gateway before this Ingress is admitted, otherwise admission succeeds
+  but the headers / rate-limit are silently absent. Names are passed via
+  values.ingress.agic.* so the same chart works across environments.
+*/ -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "omnivec.fullname" . | default "omnivec" }}-agic
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: omnivec
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    {{- with .Values.ingress.agic.rewriteRuleSet }}
+    appgw.ingress.kubernetes.io/rewrite-rule-set: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.ingress.agic.wafPolicy }}
+    appgw.ingress.kubernetes.io/waf-policy-for-path: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.ingress.agic.sslRedirect }}
+    appgw.ingress.kubernetes.io/ssl-redirect: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.ingress.agic.backendProtocol }}
+    appgw.ingress.kubernetes.io/backend-protocol: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "omnivec.fullname" $ | default "omnivec" }}-api
+                port:
+                  number: 8000
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/omnivec/values.yaml
+++ b/helm/omnivec/values.yaml
@@ -502,7 +502,7 @@ docgrok:
 # annotations; in-process headers from api/api.py still apply.
 ingress:
   enabled: false
-  controller: nginx   # nginx | traefik
+  controller: nginx   # nginx | traefik | agic
   className: nginx
   annotations: {}
   hosts:
@@ -511,6 +511,15 @@ ingress:
         - path: /
           pathType: Prefix
   tls: []
+  # AGIC (Azure Application Gateway Ingress Controller) — values consumed
+  # by templates/ingress-agic.yaml when controller=agic. Rewrite rule sets
+  # and WAF policies are managed on the App Gateway resource (out of
+  # band); supply their names here.
+  agic:
+    rewriteRuleSet: ""        # e.g. "omnivec-security-headers"
+    wafPolicy: ""             # e.g. "/subscriptions/.../wafPolicies/omnivec-waf"
+    sslRedirect: "true"
+    backendProtocol: "http"
   # Content-Security-Policy applied at the ingress layer (defence in depth on
   # top of the in-process header set by api/api.py). Override per deployment
   # if you need additional script-src / connect-src origins.

--- a/search/auth.py
+++ b/search/auth.py
@@ -127,16 +127,33 @@ def _lookup_token_in_store(token_hash: str) -> Optional[dict]:
 
 
 class AuthResult:
-    __slots__ = ("subject", "scope", "source", "token_id")
+    __slots__ = ("subject", "scope", "source", "token_id", "rate_limit_override")
 
-    def __init__(self, subject: str, scope: str, source: str, token_id: str = ""):
+    def __init__(
+        self,
+        subject: str,
+        scope: str,
+        source: str,
+        token_id: str = "",
+        rate_limit_override: Optional[int] = None,
+    ):
         self.subject = subject
         self.scope = scope
         self.source = source
         self.token_id = token_id
+        # RES-4: optional per-token override of SEARCH_RATE_LIMIT_RPM. None
+        # = use global; 0 = uncapped; positive int = override.
+        self.rate_limit_override = rate_limit_override
 
     def __repr__(self) -> str:
         return f"AuthResult(subject={self.subject!r}, scope={self.scope!r}, source={self.source!r})"
+
+    @property
+    def rate_limit_key(self) -> str:
+        """RES-4: per-token bucket key. Falls back to subject when token id
+        is empty (env-bootstrap / api-internal). Two tokens with the same
+        ``name`` no longer share a bucket — they have distinct ids."""
+        return f"tok:{self.token_id}" if self.token_id else f"sub:{self.subject}"
 
 
 def validate_token(token: str) -> Optional[AuthResult]:
@@ -165,11 +182,23 @@ def validate_token(token: str) -> Optional[AuthResult]:
         return None
     if scope not in ("search", "admin"):
         return None
+    # RES-4: per-token rate-limit override. Tokens with a `rate_limit_rpm`
+    # field override the SEARCH_RATE_LIMIT_RPM global. Use 0 to remove the
+    # limit entirely for trusted automation tokens; positive values clamp
+    # the limit further. Negative values are ignored (fall back to global).
+    raw_limit = t.get("rate_limit_rpm")
+    try:
+        limit_override = int(raw_limit) if raw_limit is not None else None
+        if limit_override is not None and limit_override < 0:
+            limit_override = None
+    except (TypeError, ValueError):
+        limit_override = None
     return AuthResult(
         subject=t.get("name", ""),
         scope=scope,
         source="store",
         token_id=t.get("id", ""),
+        rate_limit_override=limit_override,
     )
 
 
@@ -184,16 +213,25 @@ _rate_state: dict[str, deque] = defaultdict(deque)
 _rate_lock = threading.Lock()
 
 
-def check_rate_limit(subject: str) -> bool:
-    """Return True if request is allowed, False if rate limited."""
-    if RATE_LIMIT_RPM <= 0:
+def check_rate_limit(subject: str, *, override_rpm: Optional[int] = None) -> bool:
+    """Return True if request is allowed, False if rate limited.
+
+    RES-4: callers pass the auth result's ``rate_limit_key`` (per-token
+    bucket) and optional ``override_rpm`` (per-token override). The
+    override has these semantics:
+      * ``None``           — fall back to the global ``RATE_LIMIT_RPM``.
+      * ``0``              — uncapped (trusted automation).
+      * positive integer   — clamp to that limit.
+    """
+    effective = RATE_LIMIT_RPM if override_rpm is None else override_rpm
+    if effective <= 0:
         return True
     now = time.time()
     with _rate_lock:
         dq = _rate_state[subject]
         while dq and now - dq[0] > _rate_window_s:
             dq.popleft()
-        if len(dq) >= RATE_LIMIT_RPM:
+        if len(dq) >= effective:
             return False
         dq.append(now)
         return True

--- a/search/main.py
+++ b/search/main.py
@@ -97,7 +97,7 @@ def _require_search_token(request: Request):
             status_code=403,
             detail=f"Token scope '{result.scope}' cannot access the search API",
         )
-    if not check_rate_limit(result.subject):
+    if not check_rate_limit(result.rate_limit_key, override_rpm=result.rate_limit_override):
         raise HTTPException(
             status_code=429,
             detail="Rate limit exceeded",

--- a/terraform/private-endpoints.tf
+++ b/terraform/private-endpoints.tf
@@ -40,9 +40,26 @@ variable "private_endpoint_subnet_id" {
 }
 
 variable "private_dns_zone_ids" {
-  description = "Map of service -> private DNS zone resource ID. Keys: cosmos_sql, blob, servicebus. Empty/missing value disables that service's PE."
+  description = "Map of service -> private DNS zone resource ID. Keys: cosmos_sql, blob, servicebus, keyvault, openai. Empty/missing value disables that service's PE."
   type        = map(string)
   default     = {}
+}
+
+# ----------------------------------------------------------------------
+# Phase 2 inputs — Key Vault + AOAI live outside this module today, so we
+# accept their resource IDs as inputs rather than baking in data sources.
+# Empty string disables the corresponding endpoint.
+# ----------------------------------------------------------------------
+variable "key_vault_id" {
+  description = "Resource ID of the Key Vault to front with a private endpoint. Empty disables the Key Vault PE."
+  type        = string
+  default     = ""
+}
+
+variable "openai_account_id" {
+  description = "Resource ID of the Azure OpenAI (Cognitive Services) account. Empty disables the AOAI PE."
+  type        = string
+  default     = ""
 }
 
 # ----------------------------------------------------------------------
@@ -115,6 +132,54 @@ resource "azurerm_private_endpoint" "servicebus" {
 }
 
 # ----------------------------------------------------------------------
+# Key Vault (RES-1 phase 2)
+# ----------------------------------------------------------------------
+resource "azurerm_private_endpoint" "keyvault" {
+  count = var.enable_private_endpoints && var.key_vault_id != "" && lookup(var.private_dns_zone_ids, "keyvault", "") != "" ? 1 : 0
+
+  name                = "omnivec-keyvault-pe"
+  location            = var.location
+  resource_group_name = data.azurerm_resource_group.main.name
+  subnet_id           = var.private_endpoint_subnet_id
+
+  private_service_connection {
+    name                           = "omnivec-keyvault-psc"
+    private_connection_resource_id = var.key_vault_id
+    subresource_names              = ["vault"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [var.private_dns_zone_ids["keyvault"]]
+  }
+}
+
+# ----------------------------------------------------------------------
+# Azure OpenAI / Cognitive Services (RES-1 phase 2)
+# ----------------------------------------------------------------------
+resource "azurerm_private_endpoint" "openai" {
+  count = var.enable_private_endpoints && var.openai_account_id != "" && lookup(var.private_dns_zone_ids, "openai", "") != "" ? 1 : 0
+
+  name                = "omnivec-openai-pe"
+  location            = var.location
+  resource_group_name = data.azurerm_resource_group.main.name
+  subnet_id           = var.private_endpoint_subnet_id
+
+  private_service_connection {
+    name                           = "omnivec-openai-psc"
+    private_connection_resource_id = var.openai_account_id
+    subresource_names              = ["account"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [var.private_dns_zone_ids["openai"]]
+  }
+}
+
+# ----------------------------------------------------------------------
 # Outputs — surface PE IDs so downstream pipelines can sanity-check DNS
 # ----------------------------------------------------------------------
 output "private_endpoint_ids" {
@@ -122,6 +187,8 @@ output "private_endpoint_ids" {
     cosmos     = try(azurerm_private_endpoint.cosmos[0].id, null)
     blob       = try(azurerm_private_endpoint.blob[0].id, null)
     servicebus = try(azurerm_private_endpoint.servicebus[0].id, null)
+    keyvault   = try(azurerm_private_endpoint.keyvault[0].id, null)
+    openai     = try(azurerm_private_endpoint.openai[0].id, null)
   }
   description = "Resource IDs of provisioned private endpoints (null when disabled)."
 }

--- a/tests/api/test_batch7.py
+++ b/tests/api/test_batch7.py
@@ -1,0 +1,125 @@
+"""Unit tests for batch 7 (T-AAD-2 thumbprint helpers + RES-4 per-token rate-limit).
+
+Pure unit tests — no network, no Cosmos.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+import unittest
+from typing import Optional
+
+# Make api/ importable
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(_ROOT, "api"))
+sys.path.insert(0, os.path.join(_ROOT, "search"))
+
+os.environ.setdefault("OMNIVEC_ADMIN_TOKEN", "test-token")
+os.environ.setdefault("STORE_BACKEND", "memory")
+
+
+class ThumbprintHelpersTests(unittest.TestCase):
+    """T-AAD-2: SHA-256 thumbprint normalisation + parse."""
+
+    def setUp(self):
+        import api as api_mod
+        self.api = api_mod
+
+    def test_normalise_strips_separators(self):
+        f = self.api._normalise_thumbprint
+        # Same fingerprint, three formats
+        a = "AA:bb:CC:dd:ee:ff:11:22:33:44:55:66:77:88:99:00:aa:bb:cc:dd:ee:ff:11:22:33:44:55:66:77:88:99:00"
+        b = "AA bb CC dd ee ff 11 22 33 44 55 66 77 88 99 00 aa bb cc dd ee ff 11 22 33 44 55 66 77 88 99 00"
+        c = "aabbccddeeff11223344556677889900aabbccddeeff11223344556677889900"
+        self.assertEqual(f(a), f(b))
+        self.assertEqual(f(a), f(c))
+        self.assertEqual(len(f(c)), 64)
+
+    def test_normalise_drops_non_hex(self):
+        # Non-hex characters silently skipped
+        self.assertEqual(self.api._normalise_thumbprint("zZ-aa-XX-bb"), "aabb")
+
+    def test_parse_filters_malformed(self):
+        valid = "a" * 64
+        too_short = "ab"
+        with_separators = ":".join(["aa"] * 32)  # 64 hex chars after stripping
+        out = self.api._parse_pinned_thumbprints(f"{valid},{too_short},{with_separators}, ")
+        self.assertIn(valid, out)
+        self.assertIn("a" * 0 + "aa" * 32, out)  # i.e. 64 'a' too — wait, separators removed
+        self.assertEqual(len(out), 2)
+        self.assertNotIn(too_short, out)
+
+    def test_parse_empty(self):
+        self.assertEqual(self.api._parse_pinned_thumbprints(""), [])
+        self.assertEqual(self.api._parse_pinned_thumbprints("   "), [])
+        self.assertEqual(self.api._parse_pinned_thumbprints(",,"), [])
+
+
+class SearchRateLimitOverrideTests(unittest.TestCase):
+    """RES-4: per-token override semantics."""
+
+    def setUp(self):
+        # Force a known global limit and clear state between tests.
+        import auth as search_auth
+        self.auth = search_auth
+        # 5 RPM global makes the test fast and deterministic
+        search_auth.RATE_LIMIT_RPM = 5
+        search_auth._rate_state.clear()
+
+    def _hit(self, key: str, override: Optional[int], n: int) -> int:
+        """Fire ``n`` checks back-to-back, return how many were allowed."""
+        allowed = 0
+        for _ in range(n):
+            if self.auth.check_rate_limit(key, override_rpm=override):
+                allowed += 1
+        return allowed
+
+    def test_global_limit_when_no_override(self):
+        # 7 requests, global cap = 5 → only 5 allowed.
+        self.assertEqual(self._hit("k1", None, 7), 5)
+
+    def test_override_zero_means_uncapped(self):
+        # 0 = uncapped per token → all 50 allowed even though global is 5.
+        self.assertEqual(self._hit("k2", 0, 50), 50)
+
+    def test_override_positive_clamps_below_global(self):
+        # Override 2 < global 5 → 2 allowed out of 7.
+        self.assertEqual(self._hit("k3", 2, 7), 2)
+
+    def test_override_positive_above_global_takes_effect(self):
+        # Override 10 > global 5 → all 7 allowed (override wins).
+        self.assertEqual(self._hit("k4", 10, 7), 7)
+
+    def test_buckets_isolated_per_key(self):
+        # Two tokens with the same global cap don't share state.
+        self.assertEqual(self._hit("a", None, 5), 5)
+        self.assertEqual(self._hit("b", None, 5), 5)
+        # 'a' is exhausted, 'b' is fresh.
+        self.assertFalse(self.auth.check_rate_limit("a"))
+        self.assertEqual(len(self.auth._rate_state["a"]), 5)
+
+
+class AuthResultRateLimitKeyTests(unittest.TestCase):
+    """RES-4: rate_limit_key prefers token_id when present."""
+
+    def setUp(self):
+        import auth as search_auth
+        self.auth = search_auth
+
+    def test_uses_token_id_when_present(self):
+        r = self.auth.AuthResult(subject="alice", scope="search", source="store", token_id="t-123")
+        self.assertEqual(r.rate_limit_key, "tok:t-123")
+
+    def test_falls_back_to_subject(self):
+        r = self.auth.AuthResult(subject="bootstrap", scope="search", source="env")
+        self.assertEqual(r.rate_limit_key, "sub:bootstrap")
+
+    def test_two_tokens_same_name_distinct_buckets(self):
+        a = self.auth.AuthResult(subject="shared", scope="search", source="store", token_id="t-A")
+        b = self.auth.AuthResult(subject="shared", scope="search", source="store", token_id="t-B")
+        self.assertNotEqual(a.rate_limit_key, b.rate_limit_key)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on #134 (batch 6). Ships the four practical items from the post-batch-6 backlog. The remaining two (seccomp tuning, cosign signing) depend on prod strace + org-wide ACR cosign rollout respectively.

## What ships

| Item | Severity | Artefact |
|---|---|---|
| T-ING-1 final (AGIC variant) | Low | helm/omnivec/templates/ingress-agic.yaml |
| T-AAD-2 thumbprint pin | Low | OMNIVEC_AAD_JWKS_PIN_SHA256 in api/api.py |
| RES-1 phase 2 (KV+AOAI PEs) | — | terraform/private-endpoints.tf |
| RES-4 per-token rate-limit | — | search/auth.py + main.py |

## Notable RES-4 fix

The pre-existing search rate-limit was keyed on token NAME, so two tokens sharing a name shared a bucket. Now keyed on token id (with subject fallback for env-bootstrap / api-internal). New per-token override via the rate_limit_rpm field on the token doc (0 = uncapped, positive int = clamp).

## Tests

- New: tests/api/test_batch7.py 12/12 ✅
- Existing: test_batch5.py 5/5, test_backfill_source_id.py 6/6 ✅
- All offline; no Azure / Postgres required.

## Operator follow-ups (not blocking the merge)

- AGIC: provision the rewrite rule set + WAF policy on the App Gateway, then set ingress.agic.rewriteRuleSet / wafPolicy.
- T-AAD-2: extract the SHA-256 fingerprint of the login.microsoftonline.com leaf cert, set OMNIVEC_AAD_JWKS_PIN_SHA256 (multi-value supported during cert rotation).
- RES-1 phase 2: pass var.key_vault_id, var.openai_account_id, and the matching DNS-zone IDs once provisioned.