### PR TITLE
security(threat-model): refactor to DPSS / SQL Security Review Board structure

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -3,26 +3,140 @@
 | Field | Value |
 |---|---|
 | Owner | OmniVec Team |
-| Methodology | STRIDE per element + per trust-boundary crossing |
-| Last reviewed | 2026-05-06 |
-| Scope | Full system — ingestion → embedding → vector store → search → web UI |
-
-> A companion **`threat-model.tm7`** (Microsoft Threat Modeling Tool format)
-> sits next to this file. Regenerate via
-> `python scripts/gen_threat_model_tm7.py` (requires a known-good template
-> tm7 — set `OMNIVEC_TM7_TEMPLATE=/path/to/template.tm7` if not at the default
-> location). The script clones the template's `KnowledgeBase` (so generic
-> stencils render correctly) and surgically replaces the diagram. The
-> markdown form remains the source of truth; the `.tm7` is for STRIDE in the
-> desktop UI.
->
-> For the latest current-state assessment across the markdown model, the `.tm7`
-> artifact, and the CI/CD model, see
-> [`threat-model-review-2026-05.md`](./threat-model-review-2026-05.md).
+| Last reviewed | 2026-05-11 |
+| Methodology | STRIDE-at-boundaries, manually identified (per DPSS / SQL Security Review Board guidance) |
+| Companion artifact | [`threat-model.tm7`](./threat-model.tm7) — open in [Microsoft Threat Modeling Tool](https://aka.ms/threatmodelingtool); **TMT auto-threat-generation is intentionally disabled** (Settings → Disable Threat Generation) |
+| Companion (CI/CD) | [`cicd-threat-model.md`](./cicd-threat-model.md) |
+| Latest review notes | [`threat-model-review-2026-05.md`](./threat-model-review-2026-05.md) |
 
 ---
 
-## 1. Architecture & data flow (DFD)
+## 1. Scope
+
+OmniVec is a **single-tenant** retrieval-augmented vector platform. One customer = one
+AKS cluster + one set of Azure data-plane resources. The customer brings their own
+source data (CosmosDB or Blob) and their own destination vector store; OmniVec runs
+ingestion, embedding, and search inside the cluster.
+
+**In scope for this threat model:**
+- Cluster-internal services (web, api, search, ingestor, dotnet-worker, docgrok router/pipeline-worker, in-cluster embedders)
+- Trust boundaries crossed by user, customer data, and Azure managed services
+- Bootstrap/admin authentication and AAD integration
+- Inter-component data plane
+
+**Out of scope** (covered elsewhere or by other Microsoft policy):
+- CI/CD supply chain — see [`cicd-threat-model.md`](./cicd-threat-model.md)
+- Helm chart / Bicep infra threat model — tracked under `infra/`
+- Code-level vulnerabilities (SQLi, XSS, etc.) — addressed by CodeQL / SAST / SDL
+- Operational/SIEM ingestion design — handled by AppInsights consumer
+- Customer-side hardening of *their* CosmosDB / Blob — customer responsibility
+
+## 2. What we're working on (collapsed DFD)
+
+Six logical zones across four trust boundaries. **Detailed 19-element view in [Appendix A](#appendix-a-detailed-dfd-19-elements).**
+
+```mermaid
+flowchart LR
+  user["End user<br/>(browser)"]
+  aad["Azure AD"]
+
+  subgraph cluster["AKS cluster (single tenant)"]
+    direction TB
+    webtier["Web / API tier<br/>(omnivec-web, -api, -search)"]
+    docgrok["DocGrok tier<br/>(router + pipeline-worker + embedders)"]
+    ingest["Ingest tier<br/>(ingestor + dotnet-worker)"]
+  end
+
+  azure["Azure managed services<br/>(AOAI, CosmosDB metadata, Key Vault, Service Bus, App Insights)"]
+  customer["Customer data plane<br/>(source CosmosDB, source Blob, vectors CosmosDB, attachment Blob)"]
+
+  user -. TB-1 .-> webtier
+  user -. TB-1 .-> aad
+  webtier -. TB-2 .-> docgrok
+  webtier -. TB-2 .-> ingest
+  webtier -. TB-3 .-> azure
+  docgrok -. TB-3 .-> azure
+  ingest -. TB-3 .-> azure
+  ingest -. TB-4 .-> customer
+  docgrok -. TB-4 .-> customer
+  webtier -. TB-4 .-> customer
+```
+
+**Trust boundaries**
+
+| Id | Boundary | Threat-model relevance |
+|---|---|---|
+| TB-1 | Internet ↔ AKS | Public web/api/search endpoints; AAD as identity provider |
+| TB-2 | Inter-tier within cluster | Plain HTTP today, no NetworkPolicy; cross-tier compromise is the main lateral-movement path |
+| TB-3 | AKS ↔ Azure managed services | Workload Identity Federation (HTTPS + AAD); not key-based |
+| TB-4 | OmniVec ↔ customer data plane | Customer data is **untrusted**: schemas, attachment names, MIME types, blob URLs |
+
+## 3. Assets
+
+| Asset | Sensitivity | Where it lives |
+|---|---|---|
+| Customer document content | **High** (may be PII) | Customer Blob → AKS RAM (transient) |
+| Vector embeddings of customer content | **High** (PII-derived; partially invertible) | Customer destination (`e2eblob.vectors`) |
+| AOAI API keys (legacy) | **High** | `omnivec.metadata.docgrok_model.api_key` — being removed in favor of AAD |
+| `OMNIVEC_ADMIN_TOKEN` | **High** | Pod env var; long-lived; breakglass-only after AAD migration |
+| AAD JWT signing keys (JWKS) | High | Microsoft tenant — out of OmniVec control |
+| Workload-identity federated credential | High | UAMI; rotated by AKS |
+| Pipeline / model definitions | Medium | `omnivec.metadata` |
+| Service Bus messages (blob URLs + IDs) | Medium | Service Bus |
+
+## 4. What can go wrong (top 10 design threats)
+
+Selected manually at boundary crossings. Risk rating uses the SDL scale: **Critical / Important / Moderate / Low / DefenseInDepth**. *Status*: ✅ shipped · ⚠️ partial · ❌ open.
+
+| Id | Boundary | STRIDE | Threat | Risk | Status | Mitigation & residual |
+|---|---|---|---|---|---|---|
+| **T-API-1** | TB-1 → API | S/E/R | Static `OMNIVEC_ADMIN_TOKEN` replay grants full admin; no rotation, no per-call audit | **Important** | ✅ | AAD bearer + group→role mapping shipped (batch 2 + 4); admin token is now breakglass-only. Residual: token still exists; documented rotation runbook needed. |
+| **T-MET-1** | TB-2 (router → cmeta) | I/T | AOAI API keys stored cleartext in `docgrok_model.api_key`; Cosmos breach exfiltrates keys | **Important** | ✅ | AAD-only model records (no `api_key`); `scripts/scrub_model_api_keys.py` purges legacy values. Residual: legacy fallback path still readable if ever populated. |
+| **T-PWK-1** | TB-4 → pipeline-worker | D/E | Malicious customer document (PDF/Office/image) crashes parser or escapes via Pillow/PyMuPDF CVE; same address space as embedding HTTP client | **Important** | ⚠️ | Subprocess sandbox with `RLIMIT_AS`/`RLIMIT_CPU`/`RLIMIT_NOFILE` shipped behind `DOCGROK_PARSER_SANDBOX=1` (batch 4); page-cap 200. **Residual: full seccomp-bpf profile not yet enforced; flag default-off.** |
+| **T-CON-2** | TB-4 → ingestor (SSRF) | T/I | Customer Cosmos attachment value points at attacker-controlled storage account; ingestor downloads it | **Important** | ✅ | Mandatory `attachment_blob_account_allowlist`; absolute URLs whose host doesn't match are rejected (batch 1). Residual: relies on operator config; misconfig = open. |
+| **T-CON-1** | TB-2 (lease container) | T/D | Change-feed lease container shares Cosmos DB with metadata; cross-write can DoS or replay ingestion | **Moderate** | ✅ | Optional `LeaseCosmosEndpoint` / `LeaseCosmosDatabase` route lease to dedicated account (batch 4). Residual: not enabled by default. |
+| **T-VEC-1** | TB-4 (data at rest) | I | Vectors are PII-derived and partially invertible (embedding-inversion attacks); residency / right-to-erasure obligations apply | **Moderate** | ✅ | Documented PII classification; `DELETE /api/sources/{id}/vectors` cascade-purge endpoint (batch 4). Residual: classification doc must propagate to customer-facing data agreements. |
+| **T-RL-1** | TB-3 (router → AOAI) | D | One pipeline saturates AOAI tier RPM → 429 cascade starves other pipelines | **Moderate** | ✅ | Per-deployment embed semaphore (`OMNIVEC_EMBED_CONCURRENCY=4` default) + jittered exponential backoff (batch 1). Residual: no circuit-breaker yet. |
+| **T-SRCH-1** | TB-1 → search | I/T | `omnivec-search` Service is type `LoadBalancer` on plain HTTP — query embeddings (PII per T-VEC-1) and bearer tokens travel in cleartext over public internet | **Important** | ❌ | **Open.** Front search behind the omnivec ingress with TLS, OR put it behind App Gateway / Front Door, OR switch service to ClusterIP + dedicated TLS ingress. |
+| **T-NET-1** | TB-2 (in-cluster) | S/T/I | No `NetworkPolicy` in `helm/`; all in-cluster traffic plain HTTP on ClusterIP. A compromised pod can call any service unauth (no mTLS, no service mesh) | **Moderate** | ❌ | **Open.** Add default-deny `NetworkPolicy` per namespace + per-tier allow rules. mTLS/service-mesh is roadmap. |
+| **T-SUP-1** | Pre-cluster (image source) | T | Compromised registry or MITM swaps an OmniVec image; cluster pulls and runs malicious code | **Moderate** | ⚠️ | Cosign keyless signing on every push (RES-3, batch 4 build pipeline); Helm template `cosign-policy.yaml` exists. **Residual: cluster admission verification (Ratify/Kyverno) not enforced by default — signature is generated but not yet checked at deploy.** |
+
+> The CI/CD pipeline itself (the GitHub Actions runner that produces those signatures) has its own threat model in [`cicd-threat-model.md`](./cicd-threat-model.md).
+
+## 5. What we did about it (mitigation backlog)
+
+Open items only — closed items are the ✅ rows above.
+
+| Threat | Action | Owner | ETA |
+|---|---|---|---|
+| T-SRCH-1 | Front `omnivec-search` behind shared ingress + TLS, or add dedicated TLS ingress; remove public LoadBalancer in default values | OmniVec | next batch |
+| T-NET-1 | Author default-deny + per-tier `NetworkPolicy` for `omnivec` and `docgrok` namespaces | OmniVec | next batch |
+| T-PWK-1 | Switch `DOCGROK_PARSER_SANDBOX` default to `1`; ship seccomp-bpf profile and require it via PSA `restricted` | DocGrok / OmniVec | next batch |
+| T-SUP-1 | Add Ratify or Kyverno admission-controller chart that requires cosign signature on every OmniVec image | OmniVec | follow-up |
+| T-API-1 (residual) | Document admin-token rotation runbook + deletion-after-AAD-cutover policy | OmniVec | follow-up |
+
+## 6. Did we do enough? (review log)
+
+| Date | Reviewer | Outcome | Notes |
+|---|---|---|---|
+| 2026-05-06 | Internal | Initial STRIDE-per-element pass | See `threat-model.md.bak` (pre-DPSS-refactor structure) |
+| 2026-05-11 | Internal (DPSS-style refactor) | Trimmed to 10 boundary threats; collapsed DFD; surfaced T-SRCH-1, T-NET-1, T-SUP-1 from inter-component audit | Ready for SQL Security Review Board submission |
+
+**To request a Threat Model Review:** upload `threat-model.tm7` + this `.md` via the Threat Modeling Portal ([aka.ms/dpgtrack](https://aka.ms/dpgtrack)). Per DPSS guidance, the review meeting is a 2–3 hour call; this document is sized to fit.
+
+## 7. How to update this model
+
+1. Edit this file. Diff is the source of truth; `.tm7` is the visualization.
+2. If the architecture changes, update the collapsed DFD in §2 *and* the detailed DFD in [Appendix A](#appendix-a-detailed-dfd-19-elements).
+3. Regenerate `.tm7` with `python scripts/gen_threat_model_tm7.py`.
+4. Add new boundary threats to §4 with id `T-XXX-N` and a risk rating from the SDL scale.
+5. Update §6 review log on every formal review or material refactor.
+
+---
+
+## Appendix A — Detailed DFD (19 elements)
+
+The collapsed view in §2 hides per-pod detail. The full diagram below is the source for the `.tm7` artifact.
 
 ```mermaid
 flowchart LR
@@ -101,128 +215,15 @@ flowchart LR
   dotnetworker -->|telemetry| appinsights
 ```
 
-## 2. Trust boundaries
+## Appendix B — Prior STRIDE-per-element analysis (archive)
 
-| Id | Boundary | Notes |
-|---|---|---|
-| TB-1 | Internet / AAD | Browser-side input, AAD SSO. |
-| TB-2 | AKS cluster | All cluster pods share NetworkPolicy default-deny + workload-identity SA bindings. |
-| TB-3 | Azure managed services | RBAC data-plane on each resource. Public-network-access enabled on AOAI / Blob / Cosmos today (no private endpoints). |
-| TB-4 | Customer-owned | We trust nothing about customer Cosmos / Blob: data, schemas, attachment names, MIME types, content. |
+The previous version of this document (kept at `threat-model.md.bak` in the repo
+working tree, also visible in git history before commit replacing it) contained
+exhaustive STRIDE rows per process, per data store, and per external interactor.
+That format was flagged by reviewers as **too detailed and lacking clarity from
+a security-design standpoint** — most rows duplicated SDL/CodeQL coverage
+rather than calling out boundary risks specific to OmniVec.
 
-## 3. Assets
-
-| Asset | Sensitivity | Where it lives |
-|---|---|---|
-| Customer document content (PDFs, Office, images) | High (may be PII) | Customer Blob → AKS (transient) → never persisted raw |
-| Vector embeddings of customer content | High (PII-derived) | `e2eblob.vectors` |
-| Source-of-truth pipeline / model definitions | Medium | `omnivec.metadata` |
-| **AOAI API keys** | High | `omnivec.metadata` model records (`api_key` field) ⚠️ |
-| Admin bearer token (`OMNIVEC_ADMIN_TOKEN`) | High | Pod env var; long-lived, no rotation ⚠️ |
-| Workload-identity federated credentials | High | AAD; rotated by AKS |
-| Service Bus messages | Medium (contain blob URLs + source IDs) | Service Bus queue |
-
-## 4. STRIDE — auto-generated risks (one row per applicable element)
-
-Legend: ✅ has mitigation in code · ⚠️ partial · ❌ open · — N/A
-
-### Processes
-
-| Element | S | T | R | I | D | E | Mitigations / Notes |
-|---|---|---|---|---|---|---|---|
-| omnivec-web | ⚠️ | ✅ | ✅ | ✅ | ⚠️ | ✅ | AAD SSO; CSP and output-encoding; **rate-limit at ingress is needed** |
-| omnivec-api | ⚠️ | ✅ | ✅ | ✅ | ⚠️ | ✅ | Pydantic schemas; admin token static (T-API-1) |
-| omnivec-search | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | Read-only RBAC on vectors; query length cap |
-| docgrok-router | ⚠️ | ✅ | ⚠️ | ❌ | ⚠️ | ✅ | Loads AOAI keys from Cosmos in-the-clear (T-RTR-1) |
-| pipeline-worker | ✅ | ✅ | ⚠️ | ✅ | ❌ | ⚠️ | Untrusted input parser; **needs sandboxing** (T-PWK-1) |
-| connector .NET | ✅ | ⚠️ | ❌ | ✅ | ⚠️ | ✅ | Lease container shared (T-CON-1); SSRF surface (T-CON-2) |
-
-### Data stores
-
-| Element | S | T | R | I | D | E | Mitigations |
-|---|---|---|---|---|---|---|---|
-| `omnivec.metadata` | — | ✅ | ✅ | ⚠️ | ✅ | ✅ | RBAC; **api_key field stored in cleartext** (T-MET-1) |
-| `e2eblob.vectors` | — | ✅ | ✅ | ⚠️ | ✅ | ✅ | RBAC; vectors are PII-derived → residency rules apply |
-| Blob (attachment store) | — | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | RBAC; SAS short-lived; **no path-traversal allowlist** (T-BLB-1) |
-| Service Bus | — | ✅ | ✅ | ✅ | ✅ | ✅ | RBAC; dead-letter on poison messages |
-| Key Vault | — | ✅ | ✅ | ✅ | ✅ | ✅ | RBAC + soft-delete + purge protection |
-
-### External interactors / cross-trust flows
-
-| Crossing | Risk |
-|---|---|
-| Browser → omnivec-api | Static admin-token replay (T-API-1) |
-| omnivec-api → AOAI | Key-in-cleartext exfiltration if metadata DB breached (T-RTR-1, T-MET-1) |
-| pipeline-worker → customer Blob | Oversized / malformed-doc DoS, parser RCE (T-PWK-1) |
-| connector → customer Cosmos | Cross-tenant ingress, change-feed lease takeover (T-CON-1) |
-| connector attachment-resolver → arbitrary blob URL | SSRF if URL not allowlisted (T-CON-2) — partially mitigated by PR #128 |
-
-## 5. Top open risks (project-specific)
-
-> These are the ones a generic STRIDE template will **not** surface — they
-> require knowledge of this codebase. Prioritize these.
-
-### T-API-1 — Static admin bearer token
-- **Where:** `OMNIVEC_ADMIN_TOKEN` env var on `omnivec-api`. Single secret, no rotation, no per-call audit, used by web and CLI.
-- **Risk:** S/E/R — anyone with the token has full admin. No revocation mid-life.
-- **Mitigation:** migrate to AAD bearer (already done for cluster→Azure); add RBAC roles inside the API; rotate the token as a breakglass-only path.
-
-### T-RTR-1 / T-MET-1 — AOAI API keys live in CosmosDB metadata
-- **Where:** `omnivec.metadata.docgrok_model.api_key` is a **plaintext string** on the doc (we hit this today — that's why `mdl-ext-475483bb` was 401: empty `api_key`).
-- **Risk:** I/T — Cosmos breach or misissued read role exfiltrates keys. Also — **rotation requires a Cosmos `replace_item`**, no automation.
-- **Mitigation:** (a) drop key auth entirely now that AAD RBAC is granted (we did this 2026-05-05); (b) if keys must remain, store a Key Vault reference (`kv://…`) and have the router resolve it at request time.
-
-### T-PWK-1 — Pipeline-worker parses untrusted documents in-process
-- **Where:** `docgrok-pipeline-worker` ingests customer PDFs / Office / images via Python parsers (PyMuPDF, python-docx, Pillow). Same memory space as the embedding HTTP client.
-- **Risk:** D/E — a single malicious doc can OOM the pod or escape the parser (CVEs in Pillow/PyMuPDF appear yearly).
-- **Mitigation:** run parsing in a one-shot subprocess with `RLIMIT_AS` and a `seccomp` profile; impose hard page count + bytes cap before embed.
-
-### T-CON-1 — Change-feed lease container shared with metadata
-- **Where:** `connector .NET worker` uses Cosmos change-feed; if the lease container is in the same DB and writable by the same SA, an attacker who lands a write can DoS or replay ingestion.
-- **Mitigation:** isolate lease container to its own DB / RBAC scope; minimum required permissions only.
-
-### T-CON-2 — Attachment-source SSRF surface
-- **Where:** `Source.cs` resolves relative attachment URLs against an account derived from source config. PR #128 split `attachment_blob_container` from `container` to fix one confusion class.
-- **Residual risk:** the resolved blob URL is **not allowlisted by account name** — a malicious `_attachment.media` value could point at an attacker-controlled storage account that we then download from.
-- **Mitigation:** require `attachment_blob_account` config and reject URLs whose host doesn't match; OR pin to private endpoint only.
-
-### T-BLB-1 — No attachment-name validation
-- **Where:** Blob keys are built from `{docId}/{attachmentId}` taken from customer Cosmos. No normalization.
-- **Risk:** path-traversal-style `id="../foo"` could collide with system blobs, or create blobs we don't expect.
-- **Mitigation:** sanitize/encode attachment IDs (e.g., percent-encode), reject `/` and `..`.
-
-### T-VEC-1 — Vector PII residency
-- **Where:** `e2eblob.vectors` rows hold 1536-dim embeddings derived from customer content. Embeddings are reversible enough to leak content under inversion attacks.
-- **Mitigation:** treat as PII for residency, retention, and right-to-erasure. Add a `purge by source_ref` admin endpoint and document the data classification.
-
-### T-RL-1 — AOAI tier rate-limit DoS amplification
-- **Where:** S0 tier 429s today on a single 25-page attachment (we observed this). Concurrent pipelines × pages × retries can starve other pipelines.
-- **Mitigation:** per-pipeline embed concurrency cap (e.g., 4); exponential backoff with jitter; circuit-breaker per AOAI deployment.
-
-## 6. Mitigations checklist (what to do next)
-
-- [x] **High** Migration script `scripts/scrub_model_api_keys.py` clears legacy `api_key` from `docgrok_model` records (push to Key Vault first, fall back to `--force-clear` once AAD verified). *(T-MET-1, batch 1.)*
-- [x] **High** `OMNIVEC_ADMIN_TOKEN` → AAD bearer + role gating: audit-log + per-token last-used (batch 2) and dual-mode AAD JWT validation with group→role mapping (batch 4). *(T-API-1.)*
-- [x] **High** `attachment_blob_account_allowlist` config + mandatory pin: absolute attachment URLs are rejected unless host matches `account_url` or the allowlist. *(T-CON-2, batch 1.)*
-- [x] **Medium** Sandbox `pipeline-worker` parser in a subprocess with `RLIMIT_AS=1GB` and seccomp; cap pages-per-attachment to 200. *(Page cap shipped in batch 3; subprocess sandbox with `RLIMIT_AS` + `RLIMIT_CPU` + `RLIMIT_NOFILE` shipped in batch 4 behind `DOCGROK_PARSER_SANDBOX=1`. Full seccomp BPF profile remains a future hardening.)*
-- [x] **Medium** Isolate change-feed lease container into its own Cosmos DB with a separate SA. *(Batch 4: `LeaseCosmosEndpoint` / `LeaseCosmosDatabase` change-feed options route lease containers to a dedicated account when set; default behaviour unchanged for backwards compat.)*
-- [x] **Medium** Per-AOAI-deployment embed semaphore + jittered exponential backoff in pipeline-worker (`OMNIVEC_EMBED_CONCURRENCY`, default 4). *(T-RL-1, batch 1.)*
-- [x] **Medium** Cosmos source-connector hardening: parameterized `get_document` query (no f-string SQL) + `result_cap` on `list_documents`. *(T-CON-1, batch 4.)*
-- [x] **Low** Attachment IDs / blob keys validated: traversal segments (`..`, `.`), control chars, leading slashes, and empty segments are rejected; absolute-URL paths are sanitized after URL-decoding. *(T-BLB-1, batch 1.)*
-- [x] **Low** Document data classification of `e2eblob.vectors` as PII; add purge-by-source endpoint. *(Classification doc in batch 3; `DELETE /api/sources/{id}/vectors` admin-gated cascade-purge endpoint in batch 4 with `source_id` field persisted by both Cosmos and Postgres destination writers.)*
-- [x] **Low** Add CSP + rate-limit at omnivec-web ingress. *(Batch 3: in-process CSP + per-token sliding-window rate-limit. Batch 4: nginx-ingress `Ingress` template ships matching CSP/headers/rate-limit annotations as defence in depth.)*
-
-## 7. How to update this model
-
-1. Edit this file. Diff is the source of truth.
-2. Update the Mermaid DFD if the architecture changes.
-3. Re-run STRIDE table when adding a process / data store / external interactor.
-4. Add new project-specific risks under section 5 with a `T-XXX-N` id.
-5. Mark items in section 6 done as PRs land.
-
-## 8. Out-of-scope for this iteration
-
-- Threat model of CI/CD pipeline (GitHub Actions → ACR push). Tracked separately.
-- Threat model of Helm chart / Terraform infra. Tracked under `infra/`.
-- Customer-side hardening of source CosmosDB / Blob. We document the
-  contract; customers are responsible for their own perimeter.
+The 10 threats in §4 are the curated subset of those rows that represent
+*design risk that STRIDE-at-boundaries surfaces and SDL/CodeQL does not*. If you
+need the historical per-element matrix for context, see `threat-model.md.bak`.

--- a/docs/security/threat-model.md.bak
+++ b/docs/security/threat-model.md.bak
@@ -1,0 +1,228 @@
+# OmniVec Threat Model
+
+| Field | Value |
+|---|---|
+| Owner | OmniVec Team |
+| Methodology | STRIDE per element + per trust-boundary crossing |
+| Last reviewed | 2026-05-06 |
+| Scope | Full system — ingestion → embedding → vector store → search → web UI |
+
+> A companion **`threat-model.tm7`** (Microsoft Threat Modeling Tool format)
+> sits next to this file. Regenerate via
+> `python scripts/gen_threat_model_tm7.py` (requires a known-good template
+> tm7 — set `OMNIVEC_TM7_TEMPLATE=/path/to/template.tm7` if not at the default
+> location). The script clones the template's `KnowledgeBase` (so generic
+> stencils render correctly) and surgically replaces the diagram. The
+> markdown form remains the source of truth; the `.tm7` is for STRIDE in the
+> desktop UI.
+>
+> For the latest current-state assessment across the markdown model, the `.tm7`
+> artifact, and the CI/CD model, see
+> [`threat-model-review-2026-05.md`](./threat-model-review-2026-05.md).
+
+---
+
+## 1. Architecture & data flow (DFD)
+
+```mermaid
+flowchart LR
+  subgraph "INTERNET / AAD trust boundary"
+    user["End-user browser"]
+    aad["Azure AD<br/>(login.microsoftonline.com)"]
+  end
+
+  subgraph "AKS cluster (omnivec namespace)"
+    subgraph "Web / API tier"
+      web["omnivec-web<br/>(Next.js)"]
+      api["omnivec-api<br/>(FastAPI)"]
+      search["omnivec-search<br/>(Go)"]
+    end
+    subgraph "DocGrok tier"
+      router["docgrok-router<br/>(Rust)"]
+      pworker["docgrok-pipeline-worker"]
+      incluster["in-cluster embedders<br/>CLIP / BGE / DSE-Qwen2"]
+    end
+    subgraph "Ingestor tier (.NET)"
+      ingestor["omnivec-ingestor (.NET)<br/>change-feed watcher"]
+      dotnetworker["omnivec-dotnet-worker<br/>(Service Bus consumer)"]
+    end
+  end
+
+  subgraph "Azure managed services"
+    aoai["Azure OpenAI"]
+    cmeta["CosmosDB<br/>omnivec.metadata"]
+    kv["Azure Key Vault"]
+    sb["Azure Service Bus"]
+    appinsights["Azure Monitor<br/>App Insights"]
+  end
+
+  subgraph "Customer-owned (external trust)"
+    csrc["Customer CosmosDB<br/>(source w/ attachments)"]
+    bsrc["Customer Blob source"]
+    cvec["Customer CosmosDB<br/>(vectors destination)"]
+    blob["Customer Blob<br/>(attachments source)"]
+  end
+
+  user -->|HTTPS + Bearer token| web
+  user -->|HTTPS + Bearer token| api
+  api -->|JWKS fetch (cached)| aad
+  web --> api
+  web --> search
+  api --> cmeta
+  api --> kv
+  api --> sb
+  api --> router
+  search --> cvec
+  search -->|/embed (query)| router
+  search --> cmeta
+  router -->|API key OR AAD| aoai
+  router --> incluster
+  router --> cmeta
+  router --> pworker
+  pworker --> sb
+  pworker --> bsrc
+  pworker -->|fetch attachment binary| blob
+  pworker --> router
+  pworker --> cvec
+  ingestor -->|change-feed read| csrc
+  ingestor -->|fetch attachment binary| blob
+  ingestor -->|enumerate (azure-blob source)| bsrc
+  ingestor -->|pipeline / source config read| cmeta
+  ingestor -->|enqueue work (queue mode)| sb
+  ingestor -->|"/embed/batch (inline mode)"| router
+  ingestor -->|vector patch (inline mode)| csrc
+  dotnetworker -->|drain SB topic| sb
+  dotnetworker -->|"/embed/batch (queue mode)"| router
+  dotnetworker -->|vector write| cvec
+  dotnetworker -->|model record read| cmeta
+  api -->|telemetry| appinsights
+  search -->|telemetry| appinsights
+  ingestor -->|telemetry| appinsights
+  dotnetworker -->|telemetry| appinsights
+```
+
+## 2. Trust boundaries
+
+| Id | Boundary | Notes |
+|---|---|---|
+| TB-1 | Internet / AAD | Browser-side input, AAD SSO. |
+| TB-2 | AKS cluster | All cluster pods share NetworkPolicy default-deny + workload-identity SA bindings. |
+| TB-3 | Azure managed services | RBAC data-plane on each resource. Public-network-access enabled on AOAI / Blob / Cosmos today (no private endpoints). |
+| TB-4 | Customer-owned | We trust nothing about customer Cosmos / Blob: data, schemas, attachment names, MIME types, content. |
+
+## 3. Assets
+
+| Asset | Sensitivity | Where it lives |
+|---|---|---|
+| Customer document content (PDFs, Office, images) | High (may be PII) | Customer Blob → AKS (transient) → never persisted raw |
+| Vector embeddings of customer content | High (PII-derived) | `e2eblob.vectors` |
+| Source-of-truth pipeline / model definitions | Medium | `omnivec.metadata` |
+| **AOAI API keys** | High | `omnivec.metadata` model records (`api_key` field) ⚠️ |
+| Admin bearer token (`OMNIVEC_ADMIN_TOKEN`) | High | Pod env var; long-lived, no rotation ⚠️ |
+| Workload-identity federated credentials | High | AAD; rotated by AKS |
+| Service Bus messages | Medium (contain blob URLs + source IDs) | Service Bus queue |
+
+## 4. STRIDE — auto-generated risks (one row per applicable element)
+
+Legend: ✅ has mitigation in code · ⚠️ partial · ❌ open · — N/A
+
+### Processes
+
+| Element | S | T | R | I | D | E | Mitigations / Notes |
+|---|---|---|---|---|---|---|---|
+| omnivec-web | ⚠️ | ✅ | ✅ | ✅ | ⚠️ | ✅ | AAD SSO; CSP and output-encoding; **rate-limit at ingress is needed** |
+| omnivec-api | ⚠️ | ✅ | ✅ | ✅ | ⚠️ | ✅ | Pydantic schemas; admin token static (T-API-1) |
+| omnivec-search | ✅ | ✅ | ✅ | ✅ | ⚠️ | ✅ | Read-only RBAC on vectors; query length cap |
+| docgrok-router | ⚠️ | ✅ | ⚠️ | ❌ | ⚠️ | ✅ | Loads AOAI keys from Cosmos in-the-clear (T-RTR-1) |
+| pipeline-worker | ✅ | ✅ | ⚠️ | ✅ | ❌ | ⚠️ | Untrusted input parser; **needs sandboxing** (T-PWK-1) |
+| connector .NET | ✅ | ⚠️ | ❌ | ✅ | ⚠️ | ✅ | Lease container shared (T-CON-1); SSRF surface (T-CON-2) |
+
+### Data stores
+
+| Element | S | T | R | I | D | E | Mitigations |
+|---|---|---|---|---|---|---|---|
+| `omnivec.metadata` | — | ✅ | ✅ | ⚠️ | ✅ | ✅ | RBAC; **api_key field stored in cleartext** (T-MET-1) |
+| `e2eblob.vectors` | — | ✅ | ✅ | ⚠️ | ✅ | ✅ | RBAC; vectors are PII-derived → residency rules apply |
+| Blob (attachment store) | — | ✅ | ⚠️ | ⚠️ | ✅ | ✅ | RBAC; SAS short-lived; **no path-traversal allowlist** (T-BLB-1) |
+| Service Bus | — | ✅ | ✅ | ✅ | ✅ | ✅ | RBAC; dead-letter on poison messages |
+| Key Vault | — | ✅ | ✅ | ✅ | ✅ | ✅ | RBAC + soft-delete + purge protection |
+
+### External interactors / cross-trust flows
+
+| Crossing | Risk |
+|---|---|
+| Browser → omnivec-api | Static admin-token replay (T-API-1) |
+| omnivec-api → AOAI | Key-in-cleartext exfiltration if metadata DB breached (T-RTR-1, T-MET-1) |
+| pipeline-worker → customer Blob | Oversized / malformed-doc DoS, parser RCE (T-PWK-1) |
+| connector → customer Cosmos | Cross-tenant ingress, change-feed lease takeover (T-CON-1) |
+| connector attachment-resolver → arbitrary blob URL | SSRF if URL not allowlisted (T-CON-2) — partially mitigated by PR #128 |
+
+## 5. Top open risks (project-specific)
+
+> These are the ones a generic STRIDE template will **not** surface — they
+> require knowledge of this codebase. Prioritize these.
+
+### T-API-1 — Static admin bearer token
+- **Where:** `OMNIVEC_ADMIN_TOKEN` env var on `omnivec-api`. Single secret, no rotation, no per-call audit, used by web and CLI.
+- **Risk:** S/E/R — anyone with the token has full admin. No revocation mid-life.
+- **Mitigation:** migrate to AAD bearer (already done for cluster→Azure); add RBAC roles inside the API; rotate the token as a breakglass-only path.
+
+### T-RTR-1 / T-MET-1 — AOAI API keys live in CosmosDB metadata
+- **Where:** `omnivec.metadata.docgrok_model.api_key` is a **plaintext string** on the doc (we hit this today — that's why `mdl-ext-475483bb` was 401: empty `api_key`).
+- **Risk:** I/T — Cosmos breach or misissued read role exfiltrates keys. Also — **rotation requires a Cosmos `replace_item`**, no automation.
+- **Mitigation:** (a) drop key auth entirely now that AAD RBAC is granted (we did this 2026-05-05); (b) if keys must remain, store a Key Vault reference (`kv://…`) and have the router resolve it at request time.
+
+### T-PWK-1 — Pipeline-worker parses untrusted documents in-process
+- **Where:** `docgrok-pipeline-worker` ingests customer PDFs / Office / images via Python parsers (PyMuPDF, python-docx, Pillow). Same memory space as the embedding HTTP client.
+- **Risk:** D/E — a single malicious doc can OOM the pod or escape the parser (CVEs in Pillow/PyMuPDF appear yearly).
+- **Mitigation:** run parsing in a one-shot subprocess with `RLIMIT_AS` and a `seccomp` profile; impose hard page count + bytes cap before embed.
+
+### T-CON-1 — Change-feed lease container shared with metadata
+- **Where:** `connector .NET worker` uses Cosmos change-feed; if the lease container is in the same DB and writable by the same SA, an attacker who lands a write can DoS or replay ingestion.
+- **Mitigation:** isolate lease container to its own DB / RBAC scope; minimum required permissions only.
+
+### T-CON-2 — Attachment-source SSRF surface
+- **Where:** `Source.cs` resolves relative attachment URLs against an account derived from source config. PR #128 split `attachment_blob_container` from `container` to fix one confusion class.
+- **Residual risk:** the resolved blob URL is **not allowlisted by account name** — a malicious `_attachment.media` value could point at an attacker-controlled storage account that we then download from.
+- **Mitigation:** require `attachment_blob_account` config and reject URLs whose host doesn't match; OR pin to private endpoint only.
+
+### T-BLB-1 — No attachment-name validation
+- **Where:** Blob keys are built from `{docId}/{attachmentId}` taken from customer Cosmos. No normalization.
+- **Risk:** path-traversal-style `id="../foo"` could collide with system blobs, or create blobs we don't expect.
+- **Mitigation:** sanitize/encode attachment IDs (e.g., percent-encode), reject `/` and `..`.
+
+### T-VEC-1 — Vector PII residency
+- **Where:** `e2eblob.vectors` rows hold 1536-dim embeddings derived from customer content. Embeddings are reversible enough to leak content under inversion attacks.
+- **Mitigation:** treat as PII for residency, retention, and right-to-erasure. Add a `purge by source_ref` admin endpoint and document the data classification.
+
+### T-RL-1 — AOAI tier rate-limit DoS amplification
+- **Where:** S0 tier 429s today on a single 25-page attachment (we observed this). Concurrent pipelines × pages × retries can starve other pipelines.
+- **Mitigation:** per-pipeline embed concurrency cap (e.g., 4); exponential backoff with jitter; circuit-breaker per AOAI deployment.
+
+## 6. Mitigations checklist (what to do next)
+
+- [x] **High** Migration script `scripts/scrub_model_api_keys.py` clears legacy `api_key` from `docgrok_model` records (push to Key Vault first, fall back to `--force-clear` once AAD verified). *(T-MET-1, batch 1.)*
+- [x] **High** `OMNIVEC_ADMIN_TOKEN` → AAD bearer + role gating: audit-log + per-token last-used (batch 2) and dual-mode AAD JWT validation with group→role mapping (batch 4). *(T-API-1.)*
+- [x] **High** `attachment_blob_account_allowlist` config + mandatory pin: absolute attachment URLs are rejected unless host matches `account_url` or the allowlist. *(T-CON-2, batch 1.)*
+- [x] **Medium** Sandbox `pipeline-worker` parser in a subprocess with `RLIMIT_AS=1GB` and seccomp; cap pages-per-attachment to 200. *(Page cap shipped in batch 3; subprocess sandbox with `RLIMIT_AS` + `RLIMIT_CPU` + `RLIMIT_NOFILE` shipped in batch 4 behind `DOCGROK_PARSER_SANDBOX=1`. Full seccomp BPF profile remains a future hardening.)*
+- [x] **Medium** Isolate change-feed lease container into its own Cosmos DB with a separate SA. *(Batch 4: `LeaseCosmosEndpoint` / `LeaseCosmosDatabase` change-feed options route lease containers to a dedicated account when set; default behaviour unchanged for backwards compat.)*
+- [x] **Medium** Per-AOAI-deployment embed semaphore + jittered exponential backoff in pipeline-worker (`OMNIVEC_EMBED_CONCURRENCY`, default 4). *(T-RL-1, batch 1.)*
+- [x] **Medium** Cosmos source-connector hardening: parameterized `get_document` query (no f-string SQL) + `result_cap` on `list_documents`. *(T-CON-1, batch 4.)*
+- [x] **Low** Attachment IDs / blob keys validated: traversal segments (`..`, `.`), control chars, leading slashes, and empty segments are rejected; absolute-URL paths are sanitized after URL-decoding. *(T-BLB-1, batch 1.)*
+- [x] **Low** Document data classification of `e2eblob.vectors` as PII; add purge-by-source endpoint. *(Classification doc in batch 3; `DELETE /api/sources/{id}/vectors` admin-gated cascade-purge endpoint in batch 4 with `source_id` field persisted by both Cosmos and Postgres destination writers.)*
+- [x] **Low** Add CSP + rate-limit at omnivec-web ingress. *(Batch 3: in-process CSP + per-token sliding-window rate-limit. Batch 4: nginx-ingress `Ingress` template ships matching CSP/headers/rate-limit annotations as defence in depth.)*
+
+## 7. How to update this model
+
+1. Edit this file. Diff is the source of truth.
+2. Update the Mermaid DFD if the architecture changes.
+3. Re-run STRIDE table when adding a process / data store / external interactor.
+4. Add new project-specific risks under section 5 with a `T-XXX-N` id.
+5. Mark items in section 6 done as PRs land.
+
+## 8. Out-of-scope for this iteration
+
+- Threat model of CI/CD pipeline (GitHub Actions → ACR push). Tracked separately.
+- Threat model of Helm chart / Terraform infra. Tracked under `infra/`.
+- Customer-side hardening of source CosmosDB / Blob. We document the
+  contract; customers are responsible for their own perimeter.


### PR DESCRIPTION
Reviewers flagged the prior threat model as too detailed and lacking clarity from a security-design standpoint. This rewrite aligns with Microsoft Data Platform Security Services (DPSS) / SQL Security Review Board guidance.

**Structure**

The new doc answers the four key Threat-Modeling-Manifesto questions:

| Question | Section |
|---|---|
| What are we working on? | §1 Scope, §2 Collapsed DFD (6 zones / 4 boundaries) |
| What can go wrong? | §4 Top 10 boundary threats with SDL risk ratings |
| What are we going to do about it? | §5 Mitigation backlog (open items only) |
| Did we do enough? | §6 Review log |

**Key changes**

- STRIDE applied **at trust-boundary crossings**, not per-element. ~50 generic rows -> 10 curated boundary threats.
- Each threat carries an SDL risk rating (Critical/Important/Moderate/Low/DefenseInDepth), status (✅⚠️❌), and explicit residual-risk text.
- DFD collapsed to 6 logical zones; detailed 19-element view moved to Appendix A.
- Out-of-scope items named explicitly so reviewers don't expect them (CI/CD, code-level vulns, infra Helm/Bicep, customer perimeter).
- Sized to fit a 2-3 hr DPSS review meeting per their guidance.

**TM7 note**

Per DPSS guidance, **TMT auto-threat-generation should be disabled** (Settings -> Disable Threat Generation). The .tm7 artifact is the visualization; the .md is source of truth.

**Three new threats surfaced** by the inter-component audit:

- **T-SRCH-1** — \omnivec-search\ is exposed via plain-HTTP \LoadBalancer\; query embeddings (PII per T-VEC-1) and bearer tokens travel in cleartext over the public internet.
- **T-NET-1** — No NetworkPolicy in \helm/\; in-cluster traffic is plain HTTP on ClusterIP with no mTLS / mesh.
- **T-SUP-1** — Cosign signatures generated by build-images workflow but not verified at admission (Ratify/Kyverno not enabled by default).

**Archive**

Previous version preserved as \docs/security/threat-model.md.bak\ and referenced from Appendix B for historical context.