### PR TITLE
security(helm): close T-SRCH-1 (search TLS) and T-NET-1 (NetworkPolicy)

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -97,8 +97,8 @@ Selected manually at boundary crossings. Risk rating uses the SDL scale: **Criti
 | **T-CON-1** | TB-2 (lease container) | T/D | Change-feed lease container shares Cosmos DB with metadata; cross-write can DoS or replay ingestion | **Moderate** | ✅ | Optional `LeaseCosmosEndpoint` / `LeaseCosmosDatabase` route lease to dedicated account (batch 4). Residual: not enabled by default. |
 | **T-VEC-1** | TB-4 (data at rest) | I | Vectors are PII-derived and partially invertible (embedding-inversion attacks); residency / right-to-erasure obligations apply | **Moderate** | ✅ | Documented PII classification; `DELETE /api/sources/{id}/vectors` cascade-purge endpoint (batch 4). Residual: classification doc must propagate to customer-facing data agreements. |
 | **T-RL-1** | TB-3 (router → AOAI) | D | One pipeline saturates AOAI tier RPM → 429 cascade starves other pipelines | **Moderate** | ✅ | Per-deployment embed semaphore (`OMNIVEC_EMBED_CONCURRENCY=4` default) + jittered exponential backoff (batch 1). Residual: no circuit-breaker yet. |
-| **T-SRCH-1** | TB-1 → search | I/T | `omnivec-search` Service is type `LoadBalancer` on plain HTTP — query embeddings (PII per T-VEC-1) and bearer tokens travel in cleartext over public internet | **Important** | ❌ | **Open.** Front search behind the omnivec ingress with TLS, OR put it behind App Gateway / Front Door, OR switch service to ClusterIP + dedicated TLS ingress. |
-| **T-NET-1** | TB-2 (in-cluster) | S/T/I | No `NetworkPolicy` in `helm/`; all in-cluster traffic plain HTTP on ClusterIP. A compromised pod can call any service unauth (no mTLS, no service mesh) | **Moderate** | ❌ | **Open.** Add default-deny `NetworkPolicy` per namespace + per-tier allow rules. mTLS/service-mesh is roadmap. |
+| **T-SRCH-1** | TB-1 → search | I/T | `omnivec-search` Service is type `LoadBalancer` on plain HTTP — query embeddings (PII per T-VEC-1) and bearer tokens travel in cleartext over public internet | **Important** | ✅ | Default service type changed to `ClusterIP`; new `searchIngress` template provides TLS-terminating ingress on a dedicated host. Operators who keep `type: LoadBalancer` are responsible for terminating TLS at the LB themselves. |
+| **T-NET-1** | TB-2 (in-cluster) | S/T/I | No `NetworkPolicy` in `helm/`; all in-cluster traffic plain HTTP on ClusterIP. A compromised pod can call any service unauth (no mTLS, no service mesh) | **Moderate** | ✅ | `templates/networkpolicy.yaml` ships default-deny + per-tier allow rules behind `networkPolicy.enabled` toggle (off by default to avoid breaking clusters whose CNI doesn't support NetworkPolicy). Residual: mTLS / service-mesh still roadmap. |
 | **T-SUP-1** | Pre-cluster (image source) | T | Compromised registry or MITM swaps an OmniVec image; cluster pulls and runs malicious code | **Moderate** | ⚠️ | Cosign keyless signing on every push (RES-3, batch 4 build pipeline); Helm template `cosign-policy.yaml` exists. **Residual: cluster admission verification (Ratify/Kyverno) not enforced by default — signature is generated but not yet checked at deploy.** |
 
 > The CI/CD pipeline itself (the GitHub Actions runner that produces those signatures) has its own threat model in [`cicd-threat-model.md`](./cicd-threat-model.md).
@@ -109,11 +109,10 @@ Open items only — closed items are the ✅ rows above.
 
 | Threat | Action | Owner | ETA |
 |---|---|---|---|
-| T-SRCH-1 | Front `omnivec-search` behind shared ingress + TLS, or add dedicated TLS ingress; remove public LoadBalancer in default values | OmniVec | next batch |
-| T-NET-1 | Author default-deny + per-tier `NetworkPolicy` for `omnivec` and `docgrok` namespaces | OmniVec | next batch |
 | T-PWK-1 | Switch `DOCGROK_PARSER_SANDBOX` default to `1`; ship seccomp-bpf profile and require it via PSA `restricted` | DocGrok / OmniVec | next batch |
 | T-SUP-1 | Add Ratify or Kyverno admission-controller chart that requires cosign signature on every OmniVec image | OmniVec | follow-up |
 | T-API-1 (residual) | Document admin-token rotation runbook + deletion-after-AAD-cutover policy | OmniVec | follow-up |
+| T-NET-1 (residual) | mTLS or service-mesh between tiers (defence in depth on top of NetworkPolicy) | OmniVec | follow-up |
 
 ## 6. Did we do enough? (review log)
 
@@ -121,6 +120,7 @@ Open items only — closed items are the ✅ rows above.
 |---|---|---|---|
 | 2026-05-06 | Internal | Initial STRIDE-per-element pass | See `threat-model.md.bak` (pre-DPSS-refactor structure) |
 | 2026-05-11 | Internal (DPSS-style refactor) | Trimmed to 10 boundary threats; collapsed DFD; surfaced T-SRCH-1, T-NET-1, T-SUP-1 from inter-component audit | Ready for SQL Security Review Board submission |
+| 2026-05-11 | Internal (T-SRCH-1, T-NET-1 closure) | Search default switched to `ClusterIP` + new `searchIngress` template; `templates/networkpolicy.yaml` adds default-deny + per-tier allow rules behind `networkPolicy.enabled` toggle | Both threats now ✅ |
 
 **To request a Threat Model Review:** upload `threat-model.tm7` + this `.md` via the Threat Modeling Portal ([aka.ms/dpgtrack](https://aka.ms/dpgtrack)). Per DPSS guidance, the review meeting is a 2–3 hour call; this document is sized to fit.
 

--- a/helm/omnivec/templates/networkpolicy.yaml
+++ b/helm/omnivec/templates/networkpolicy.yaml
@@ -1,0 +1,142 @@
+{{- /*
+  T-NET-1: default-deny + per-tier ingress allow rules.
+
+  Renders only when `networkPolicy.enabled=true`. Egress is left
+  unrestricted because the workload talks to Azure-managed services
+  whose IP ranges shift over time; lock egress down at the cluster
+  egress gateway / Azure Firewall instead.
+
+  Pod selectors below match the `app: omnivec-*` labels set by each
+  deployment template in this chart.
+*/ -}}
+{{- if .Values.networkPolicy.enabled }}
+{{- $ns := .Release.Namespace -}}
+{{- $ingNsSel := .Values.networkPolicy.ingressControllerNamespaceSelector | default (dict "matchLabels" (dict "kubernetes.io/metadata.name" "ingress-nginx")) -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: omnivec-default-deny
+  namespace: {{ $ns }}
+spec:
+  podSelector: {}
+  policyTypes: [Ingress]
+  # No ingress rules → all ingress denied unless another policy allows it.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: omnivec-api-allow
+  namespace: {{ $ns }}
+spec:
+  podSelector:
+    matchLabels:
+      app: omnivec-api
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            {{- toYaml $ingNsSel | nindent 12 }}
+        - podSelector:
+            matchLabels:
+              app: omnivec-web
+        - podSelector:
+            matchLabels:
+              app: omnivec-search
+      ports:
+        - protocol: TCP
+          port: 8000
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: omnivec-search-allow
+  namespace: {{ $ns }}
+spec:
+  podSelector:
+    matchLabels:
+      app: omnivec-search
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            {{- toYaml $ingNsSel | nindent 12 }}
+        - podSelector:
+            matchLabels:
+              app: omnivec-api
+        - podSelector:
+            matchLabels:
+              app: omnivec-web
+      ports:
+        - protocol: TCP
+          port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: omnivec-web-allow
+  namespace: {{ $ns }}
+spec:
+  podSelector:
+    matchLabels:
+      app: omnivec-web
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            {{- toYaml $ingNsSel | nindent 12 }}
+      ports:
+        - protocol: TCP
+          port: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: docgrok-router-allow
+  namespace: {{ $ns }}
+spec:
+  podSelector:
+    matchLabels:
+      app: docgrok-router
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: omnivec-api
+        - podSelector:
+            matchLabels:
+              app: omnivec-search
+        - podSelector:
+            matchLabels:
+              app: omnivec-ingestor
+        - podSelector:
+            matchLabels:
+              app: omnivec-dotnet-worker
+        - podSelector:
+            matchLabels:
+              app: docgrok-pipeline-worker
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: docgrok-embedders-allow
+  namespace: {{ $ns }}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values: [clip, bge, dse-qwen2, docgrok-pipeline-worker]
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: docgrok-router
+{{- end }}

--- a/helm/omnivec/templates/search-ingress.yaml
+++ b/helm/omnivec/templates/search-ingress.yaml
@@ -1,0 +1,49 @@
+{{- /*
+  T-SRCH-1: separate TLS-terminating ingress for omnivec-search.
+
+  Only renders when `searchIngress.enabled=true`. The Service backing this
+  ingress is `omnivec-search` (rendered by search-deployment.yaml as
+  ClusterIP by default per T-SRCH-1).
+
+  This is intentionally a separate Ingress resource from the main one
+  (templates/ingress.yaml) so search can run on a dedicated host with its
+  own cert and rate-limit policy without disturbing the API ingress.
+*/ -}}
+{{- if .Values.searchIngress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "omnivec.fullname" . | default "omnivec" }}-search
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: omnivec-search
+  annotations:
+    {{- /* security defaults — defence in depth on top of in-process headers */}}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "Referrer-Policy: strict-origin-when-cross-origin";
+    {{- with .Values.searchIngress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.searchIngress.className | default "nginx" }}
+  {{- if .Values.searchIngress.tls }}
+  tls:
+    {{- toYaml .Values.searchIngress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.searchIngress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: omnivec-search
+                port:
+                  number: 80
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/omnivec/values.yaml
+++ b/helm/omnivec/values.yaml
@@ -83,10 +83,14 @@ search:
     tag: latest
     pullPolicy: Always
   service:
-    type: LoadBalancer     # external public IP
+    # T-SRCH-1: default to ClusterIP so search is not exposed over plain HTTP.
+    # Public exposure is via `searchIngress` below (TLS-terminated by the
+    # ingress controller). Operators who want a direct LB endpoint can
+    # override to `LoadBalancer`, but should also wire TLS at that LB.
+    type: ClusterIP
     port: 80
     targetPort: 8080
-    dnsLabel: ""           # optional: <label>.<region>.cloudapp.azure.com
+    dnsLabel: ""           # only used when type=LoadBalancer
   resources:
     requests:
       memory: "256Mi"
@@ -528,6 +532,58 @@ ingress:
     enabled: false
     rps: 50          # nginx.ingress.kubernetes.io/limit-rps
     connections: 20  # nginx.ingress.kubernetes.io/limit-connections
+
+# =============================================================================
+# SEARCH INGRESS (T-SRCH-1)
+# =============================================================================
+# Separate ingress for omnivec-search. Search is on its own host/path so it
+# can have a different TLS cert / rate-limit policy from the API. Disabled
+# by default — enable + supply hosts/tls in your values overlay.
+#
+# When `searchIngress.enabled=false` and `search.service.type=ClusterIP`
+# (the new default), search is reachable only from inside the cluster.
+# Operators who flip `search.service.type` back to `LoadBalancer` are
+# responsible for terminating TLS at that LB themselves.
+searchIngress:
+  enabled: false
+  className: nginx
+  annotations: {}
+  hosts:
+    - host: search.omnivec.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+    # - hosts:
+    #     - search.omnivec.example.com
+    #   secretName: omnivec-search-tls
+
+# =============================================================================
+# NETWORK POLICY (T-NET-1)
+# =============================================================================
+# Default-deny ingress + explicit per-tier allow rules. Off by default
+# because deployments without a CNI that supports NetworkPolicy (e.g.
+# kubenet) will silently drop traffic. Enable on AKS with Azure CNI +
+# Calico/Cilium, or any other CNI advertising NetworkPolicy support.
+#
+# When enabled, the chart renders one NetworkPolicy resource per tier:
+#   * default-deny     — deny all ingress not explicitly allowed
+#   * api-allow        — ingress controller + omnivec-web + omnivec-search
+#   * search-allow     — ingress controller + omnivec-api + omnivec-web
+#   * web-allow        — ingress controller only
+#   * docgrok-router-allow — api, search, ingestor, dotnet-worker,
+#                            pipeline-worker
+#   * embedders-allow  — docgrok-router only
+# Egress is left unrestricted (Azure managed services, AOAI, etc.).
+networkPolicy:
+  enabled: false
+  # Label selector for the ingress controller namespace (used in the
+  # `from` clause of allow rules). Default matches the kubernetes.io
+  # convention for the kube-system namespace where most ingress
+  # controllers run; override if your controller lives elsewhere.
+  ingressControllerNamespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: ingress-nginx
 
 # =============================================================================
 # SERVICE ACCOUNT


### PR DESCRIPTION
Closes the two open ❌ items from the DPSS-refactored threat model (PR #143).

## T-SRCH-1 — search exposed over plain HTTP (Important)

\omnivec-search\ shipped as Service \	ype=LoadBalancer\ on plain HTTP, exposing query embeddings (PII per T-VEC-1) and bearer tokens in cleartext over the public internet.

- \search.service.type\ default flipped from \LoadBalancer\ → \ClusterIP\
- New \searchIngress\ block in values + \	emplates/search-ingress.yaml\ provides a dedicated TLS-terminating ingress on its own host (separate from the API ingress so it can have its own cert / rate-limit policy)
- Disabled by default; operators populate \searchIngress.hosts\ and \searchIngress.tls\ in their values overlay
- Operators who keep \	ype: LoadBalancer\ are now responsible for terminating TLS at the LB themselves (documented inline)

## T-NET-1 — no NetworkPolicy / mTLS (Moderate)

No NetworkPolicy in \helm/\; all in-cluster traffic plain HTTP on ClusterIP. A compromised pod could call any service unauth.

New \	emplates/networkpolicy.yaml\ renders six policies behind \
etworkPolicy.enabled\ toggle:

| Policy | Allows ingress from |
|---|---|
| \omnivec-default-deny\ | (none — default deny) |
| \omnivec-api-allow\ | ingress controller + web + search |
| \omnivec-search-allow\ | ingress controller + api + web |
| \omnivec-web-allow\ | ingress controller only |
| \docgrok-router-allow\ | api + search + ingestor + dotnet-worker + pipeline-worker |
| \docgrok-embedders-allow\ | router only |

- Egress unrestricted (Azure managed-service IPs shift; lock down at egress firewall instead)
- Off by default to avoid breaking clusters whose CNI doesn't support NetworkPolicy (kubenet etc.). On AKS with Azure CNI + Calico/Cilium, set \
etworkPolicy.enabled=true\
- Residual: mTLS / service mesh remains roadmap

## Verification

\\\
helm template omnivec helm/omnivec --set networkPolicy.enabled=true --set searchIngress.enabled=true --set ingress.enabled=true
\\\

renders 6 NetworkPolicy + 2 Ingress resources with no errors.

## Threat model updates

\docs/security/threat-model.md\: T-SRCH-1 and T-NET-1 rows flipped from ❌ to ✅; mitigation backlog rows removed; review log extended with closure entry.