### PR TITLE
release: cli v1.1.1 + docgrok envelope encryption + registry sync fixes

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -2722,8 +2722,8 @@ async def patch_destination(dest_id: str, req: DestinationEnableRequest):
         "destination": destination,
         "replayed_pipelines": replayed_pipelines,
     }
+@app.delete("/api/destinations/{dest_id}")
 def delete_destination(dest_id: str):
-    """Delete a destination."""
     store = get_store()
     doc = store.get(dest_id, "destination")
     if not doc:
@@ -4769,7 +4769,7 @@ async def create_model(payload: dict):
             "endpoint": payload.get("endpoint", "").strip(),
             "auth_type": auth_type,
             "api_key": payload.get("api_key", "").strip(),
-            "deployment": payload.get("deployment", payload.get("name", "")).strip(),
+            "deployment": payload.get("deployment", payload.get("model", payload.get("name", ""))).strip(),
             "embedding_dim": int(payload.get("embedding_dim", payload.get("dimensions", 1536))),
             "api_version": payload.get("api_version", "2024-06-01"),
         }
@@ -4815,27 +4815,25 @@ async def create_model(payload: dict):
             result = {"id": model_id, "name": model_name, "kind": "external",
                       "model_category": model_category, **persist_doc}
         else:
-            # Send full payload (including api_key) to DocGrok for in-memory use
+            # Send full payload (including api_key) to DocGrok for in-memory use.
+            # DocGrok handles CosmosDB persistence with envelope-encrypted api_key,
+            # so api.py must NOT overwrite that doc (would strip the envelope).
             resp = await http_client.post(f"{DOCGROK_URL}/admin/models/registry", json=reg_payload)
             if resp.status_code >= 400:
                 raise HTTPException(status_code=resp.status_code, detail=resp.text)
             result = resp.json()
 
-            # Persist to CosmosDB (without api_key) for durability
+            # DocGrok doesn't know about model_category — patch only that field
+            # onto the existing doc without disturbing api_key_envelope.
             model_id = result.get("id", "")
             if model_id.startswith("mdl-ext-"):
-                persist_doc = {k: v for k, v in reg_payload.items() if k != "api_key"}
-                if api_key_value and set_model_api_key(model_id, api_key_value):
-                    persist_doc["api_key_source"] = "keyvault"
-                else:
-                    persist_doc["api_key"] = api_key_value  # Fallback
-                store.upsert({
-                    "id": model_id,
-                    "doc_type": "docgrok_model",
-                    **persist_doc,
-                    "model_category": model_category,
-                    "stored_at": datetime.utcnow().isoformat(),
-                })
+                try:
+                    existing = store.get(model_id, "docgrok_model")
+                    if existing and existing.get("model_category") != model_category:
+                        existing["model_category"] = model_category
+                        store.upsert(existing)
+                except Exception:  # lgtm[py/empty-except]
+                    pass
             result["model_category"] = model_category
 
         return result
@@ -4876,8 +4874,11 @@ async def update_model(model_id: str, payload: dict):
     if not changed:
         raise HTTPException(status_code=400, detail="No updatable fields provided")
 
-    # Handle API key update — Key Vault if available, else CosmosDB
-    if new_api_key:
+    is_chat = doc.get("model_category") == "chat"
+
+    # For embedding models DocGrok owns the api_key (envelope-encrypted).
+    # For chat models DocGrok is bypassed, so api.py handles the key via Key Vault.
+    if new_api_key and is_chat:
         from keyvault_client import set_model_api_key
         if set_model_api_key(model_id, new_api_key):
             doc["api_key_source"] = "keyvault"
@@ -4887,10 +4888,10 @@ async def update_model(model_id: str, payload: dict):
             doc.pop("api_key_source", None)
 
     doc["updated_at"] = datetime.utcnow().isoformat()
-    store.upsert(doc)
 
-    # Re-register with DocGrok if it's an embedding model (so DocGrok picks up new key/endpoint)
-    if doc.get("model_category") != "chat":
+    # For embedding models, push everything (including the new key) to DocGrok and
+    # let DocGrok re-encrypt + persist. Don't double-write from api.py.
+    if not is_chat:
         try:
             reg_payload = {
                 "id": model_id,
@@ -4898,20 +4899,19 @@ async def update_model(model_id: str, payload: dict):
                 "type": doc.get("type", "azure-openai"),
                 "endpoint": doc.get("endpoint", ""),
                 "auth_type": doc.get("auth_type", "key"),
-                "api_key": new_api_key or doc.get("api_key", ""),
+                "api_key": new_api_key or "",  # empty → DocGrok preserves existing envelope
                 "deployment": doc.get("deployment", ""),
                 "embedding_dim": int(doc.get("embedding_dim", 1536)),
                 "api_version": doc.get("api_version", "2024-06-01"),
             }
-            # If key was in Key Vault, read it for DocGrok registration
-            if not reg_payload["api_key"] and doc.get("api_key_source") == "keyvault":
-                from keyvault_client import get_model_api_key
-                reg_payload["api_key"] = get_model_api_key(model_id) or ""
             resp = await http_client.post(f"{DOCGROK_URL}/admin/models/registry", json=reg_payload)
             if resp.status_code >= 400:
                 logger.warning(f"DocGrok re-register failed: {resp.text}")
         except Exception as e:
             logger.warning(f"DocGrok re-register error: {e}")
+    else:
+        # Chat-only path: api.py owns the persisted doc
+        store.upsert(doc)
 
     return {"status": "updated", "id": model_id, "fields_updated": changed}
 
@@ -4994,11 +4994,16 @@ async def delete_model(model_id: str):
 
 @app.post("/api/models/{model_id}/test")
 async def test_model_health(model_id: str):
-    """Test a model's connectivity and auth by making a small embed call."""
+    """Test a model's connectivity and auth by making a small embed call.
+
+    Accepts either the model id (mdl-ext-... / mdl-native-...) or the
+    user-visible model name. CLI passes the name; UI passes the id.
+    """
     from health_checker import run_health_checks
     result = await run_health_checks(section="models")
-    for m in result.get("models", []):
-        if m["id"] == model_id:
+    models = result.get("models", [])
+    for m in models:
+        if m.get("id") == model_id or m.get("name") == model_id:
             return m  # lgtm[py/stack-trace-exposure]
     return {"id": model_id, "status": "unknown", "checks": [], "detail": "Model not found in health results"}
 

--- a/api/health_checker.py
+++ b/api/health_checker.py
@@ -406,62 +406,39 @@ async def check_model(model_id: str, client: httpx.AsyncClient) -> dict:
                 # External model — check it's configured
                 result["checks"].append({"check": "model_registered", "status": "pass", "detail": f"Model '{result['name']}' registered in DocGrok (type: {model_info.get('type', '?')})"})
 
-                # Test external model endpoint accessibility
                 endpoint = model_info.get("endpoint", "")
-                api_key = model_info.get("api_key", "")
-                # DocGrok masks api_key in its GET response. If we got nothing
-                # back (or the obvious "***" placeholder), fall back to the
-                # canonical KeyVault copy so the health probe can authenticate.
-                if not api_key or set(api_key) <= {"*"}:
-                    try:
-                        from keyvault_client import get_model_api_key
-                        kv_key = get_model_api_key(model_id)
-                        if kv_key:
-                            api_key = kv_key
-                    except Exception as kv_err:
-                        logger.debug("health: keyvault fallback failed for %s: %s", model_id, kv_err)
-                deployment = model_info.get("deployment", "")
-                api_version = model_info.get("api_version", "2024-06-01")
-
-                if endpoint:
-                    try:
-                        # Try to reach the endpoint (HEAD or GET to base URL)
-                        test_url = endpoint.rstrip("/")
-                        if deployment:
-                            test_url = f"{test_url}/openai/deployments/{deployment}/embeddings?api-version={api_version}"
-                        headers = {}
-                        if api_key:
-                            headers["api-key"] = api_key
-
-                        # Send a minimal request to verify the endpoint is reachable and auth works
-                        # Use POST with a tiny payload to get a real response (not just DNS check)
-                        test_resp = await client.post(
-                            test_url,
-                            headers=headers,
-                            json={"input": "health check", "model": deployment or result["name"]},
-                            timeout=CHECK_TIMEOUT,
-                        )
-                        if test_resp.status_code == 200:
-                            result["checks"].append({"check": "endpoint_accessible", "status": "pass", "detail": f"Endpoint reachable, auth valid ({endpoint})"})
-                        elif test_resp.status_code == 401 or test_resp.status_code == 403:
-                            result["status"] = "unhealthy"
-                            body = test_resp.text[:150]
-                            result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"Auth failed (HTTP {test_resp.status_code}): {body}"})
-                        elif test_resp.status_code == 404:
-                            result["status"] = "unhealthy"
-                            result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"Deployment '{deployment}' not found at {endpoint} (HTTP 404)"})
-                        elif test_resp.status_code == 429:
-                            result["checks"].append({"check": "endpoint_accessible", "status": "pass", "detail": f"Endpoint reachable (rate limited, HTTP 429) — auth is valid"})
-                        else:
-                            result["status"] = "warning"
-                            body = test_resp.text[:150]
-                            result["checks"].append({"check": "endpoint_accessible", "status": "warn", "detail": f"Endpoint returned HTTP {test_resp.status_code}: {body}"})
-                    except Exception as ep_err:
-                        result["status"] = "unhealthy"
-                        result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"Cannot reach endpoint {endpoint}: {str(ep_err)[:150]}"})
-                else:
+                if not endpoint:
                     result["status"] = "warning"
                     result["checks"].append({"check": "endpoint_accessible", "status": "warn", "detail": "No endpoint configured for external model"})
+                else:
+                    # Delegate the actual auth probe to DocGrok — it owns the
+                    # decrypted api_key (envelope) and never exposes it to api.py.
+                    try:
+                        hc = await client.post(
+                            f"{DOCGROK_URL}/admin/models/registry/{model_id}/healthcheck",
+                            timeout=CHECK_TIMEOUT,
+                        )
+                        if hc.status_code == 200:
+                            hcd = hc.json()
+                            ok = hcd.get("ok", False)
+                            detail = hcd.get("detail", "")
+                            status_code = hcd.get("status", 0)
+                            if ok:
+                                result["checks"].append({"check": "endpoint_accessible", "status": "pass", "detail": detail or f"HTTP {status_code}"})
+                            else:
+                                result["status"] = "unhealthy"
+                                if status_code in (401, 403):
+                                    result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"Auth failed (HTTP {status_code}): {detail}"})
+                                elif status_code == 404:
+                                    result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"Deployment not found at {endpoint} (HTTP 404)"})
+                                else:
+                                    result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"HTTP {status_code}: {detail}"})
+                        else:
+                            result["status"] = "unhealthy"
+                            result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"DocGrok healthcheck HTTP {hc.status_code}: {hc.text[:150]}"})
+                    except Exception as ep_err:
+                        result["status"] = "unhealthy"
+                        result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"healthcheck failed: {str(ep_err)[:150]}"})
 
         elif resp.status_code == 404:
             result["status"] = "unhealthy"

--- a/cli/cmd_model.go
+++ b/cli/cmd_model.go
@@ -44,7 +44,7 @@ func newModelListCmd() *cobra.Command {
 		Short: "List all models",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c := getClient()
-			data, err := c.Get("/api/docgrok/models", nil)
+			data, err := c.Get("/api/models", nil)
 			if err != nil {
 				exitErr("%v", err)
 			}
@@ -56,10 +56,10 @@ func newModelListCmd() *cobra.Command {
 				return nil
 			}
 
-			// Models can be returned as a list or wrapped
+			// /api/models returns {"models": [...]} mixing internal (docgrok deployments)
+			// and external (registered via `model add`) entries.
 			var items []map[string]any
 			if err := json.Unmarshal(data, &items); err != nil {
-				// Try wrapped
 				items = parseJSONList(data, "models")
 			}
 			_, _, _, mdlH := fetchHealthMap(c)

--- a/cli/cmd_pipeline.go
+++ b/cli/cmd_pipeline.go
@@ -473,6 +473,7 @@ func toInt(v any) int {
 func newPipelineCreateCmd() *cobra.Command {
 	var name, description, source, destination, model, contentFields, vectorIndexPath string
 	var contentMode, contentStrategy, fileTypes, docIdPattern string
+	var processingMode, embeddingField string
 	var chunkSize, chunkOverlap int
 	var processExisting bool
 	cmd := &cobra.Command{
@@ -531,6 +532,12 @@ func newPipelineCreateCmd() *cobra.Command {
 			if description != "" {
 				body["description"] = description
 			}
+			if processingMode != "" {
+				body["processing_mode"] = processingMode
+			}
+			if embeddingField != "" {
+				body["embedding_field"] = embeddingField
+			}
 			if contentStrategy != "" {
 				body["content_strategy"] = contentStrategy
 			}
@@ -579,6 +586,8 @@ func newPipelineCreateCmd() *cobra.Command {
 	cmd.Flags().IntVar(&chunkOverlap, "chunk-overlap", 0, "Chunk overlap in characters")
 	cmd.Flags().StringVar(&docIdPattern, "doc-id-pattern", "", "Document ID pattern (e.g., {source}-chunk-{chunk})")
 	cmd.Flags().StringVar(&vectorIndexPath, "vector-index-path", "", "Vector index path from destination's vector policy (required)")
+	cmd.Flags().StringVar(&processingMode, "processing-mode", "", "Processing mode: inline or queue (default queue)")
+	cmd.Flags().StringVar(&embeddingField, "embedding-field", "", "Destination field to write embedding into (default: embedding)")
 	cmd.Flags().BoolVar(&processExisting, "process-existing", true, "Process existing documents on creation")
 	return cmd
 }

--- a/docgrok/Dockerfile
+++ b/docgrok/Dockerfile
@@ -16,6 +16,7 @@ COPY api.py .
 COPY admin.py .
 COPY pipelines.py .
 COPY model_store.py .
+COPY envelope_crypto.py .
 COPY static/ ./static/
 
 EXPOSE 8080

--- a/docgrok/admin.py
+++ b/docgrok/admin.py
@@ -58,6 +58,58 @@ def _generate_ext_id() -> str:
     return f"mdl-ext-{uuid.uuid4().hex[:8]}"
 
 
+def resolve_model(model_id: str) -> Optional[dict]:
+    """Return model config, lazy-loading from the persistent store on cache miss.
+
+    Each pipeline-worker replica has its own in-memory _MODEL_REGISTRY. Writes
+    via POST /admin/models/registry only update the replica that received the
+    request; other replicas would otherwise see stale state until restart. By
+    falling back to the shared store on miss, every replica converges without
+    needing a broadcast or restart.
+    """
+    cfg = _MODEL_REGISTRY.get(model_id)
+    if cfg is not None:
+        return cfg
+    if _store is None or not model_id.startswith("mdl-ext-"):
+        return None
+    try:
+        cfg = _store.get_model(model_id)
+    except Exception:
+        cfg = None
+    if cfg:
+        _MODEL_REGISTRY[model_id] = cfg
+    return cfg
+
+
+def forget_model(model_id: str) -> None:
+    """Remove a model from the local in-memory cache (used after deletes)."""
+    _MODEL_REGISTRY.pop(model_id, None)
+
+
+def sync_cache_from_store() -> None:
+    """Reconcile the local in-memory cache against the persistent store.
+
+    Each pipeline-worker replica caches the registry independently. After a
+    write hits one replica, the others diverge until restart. Calling this on
+    the read path (LIST, name-based duplicate check) makes the cache eventually
+    consistent without requiring broadcast or sticky sessions.
+    """
+    if _store is None:
+        return
+    try:
+        persisted = _store.list_models()
+    except Exception:
+        return
+    # Add or refresh entries that exist in the store
+    for mid, cfg in persisted.items():
+        _MODEL_REGISTRY[mid] = cfg
+    # Drop entries that were deleted on another replica
+    stale = [mid for mid in _MODEL_REGISTRY
+             if mid.startswith("mdl-ext-") and mid not in persisted]
+    for mid in stale:
+        _MODEL_REGISTRY.pop(mid, None)
+
+
 class ScaleRequest(BaseModel):
     replicas: int
 
@@ -69,6 +121,7 @@ class ScaleRequest(BaseModel):
 @router.get("/models/registry")
 async def list_registry_models():
     """List all models — native (K8s) + registered external."""
+    sync_cache_from_store()
     models = []
 
     # Native models from K8s deployments
@@ -162,7 +215,9 @@ async def register_model(request: dict):
         if client_id:
             cfg_data["client_id"] = client_id
 
-    # Check for duplicate name — update existing
+    # Check for duplicate name — update existing.
+    # Refresh from store so we see models registered by other replicas.
+    sync_cache_from_store()
     for mid, cfg in _MODEL_REGISTRY.items():
         if cfg.get("name") == name:
             cfg_data["api_key"] = request.get("api_key", cfg.get("api_key", ""))
@@ -184,8 +239,8 @@ async def register_model(request: dict):
 async def get_registry_model(model_id: str):
     """Get a single model by ID."""
     # External model
-    if model_id in _MODEL_REGISTRY:
-        cfg = _MODEL_REGISTRY[model_id]
+    cfg = resolve_model(model_id)
+    if cfg is not None:
         return {"id": model_id, **{k: v for k, v in cfg.items() if k != "api_key"}}
 
     # Native model
@@ -221,13 +276,126 @@ async def get_registry_model(model_id: str):
 @router.delete("/models/registry/{model_id}")
 async def delete_registry_model(model_id: str):
     """Delete an external model from the registry."""
-    if model_id not in _MODEL_REGISTRY:
+    cfg = resolve_model(model_id)
+    if cfg is None:
         raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found")
-    name = _MODEL_REGISTRY[model_id].get("name", "")
+    name = cfg.get("name", "")
     if _store:
         _store.delete_model(model_id)
-    del _MODEL_REGISTRY[model_id]
+    forget_model(model_id)
     return {"deleted": model_id, "name": name}
+
+
+@router.post("/models/registry/{model_id}/healthcheck")
+async def healthcheck_model(model_id: str):
+    """Verify an external model is reachable and the stored api_key is valid.
+
+    api.py callers used to fetch model config (with a redacted api_key) and
+    call the upstream themselves — that always 401'd. Doing the probe here
+    means the decrypted key never leaves docgrok and we still get an
+    authoritative reachability + auth signal.
+    """
+    cfg = resolve_model(model_id)
+    if cfg is None:
+        raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found")
+
+    endpoint = cfg.get("endpoint", "").rstrip("/")
+    deployment = cfg.get("deployment", cfg.get("name", ""))
+    api_version = cfg.get("api_version", "2024-06-01")
+    api_key = cfg.get("api_key", "")
+    auth_type = cfg.get("auth_type", "key")
+    model_type = cfg.get("type", "azure-openai")
+
+    if not endpoint or not deployment:
+        return {"ok": False, "status": 0, "detail": "endpoint or deployment not configured"}
+
+    if model_type != "azure-openai":
+        return {"ok": False, "status": 0, "detail": f"healthcheck only supports azure-openai (got {model_type})"}
+
+    url = f"{endpoint}/openai/deployments/{deployment}/embeddings?api-version={api_version}"
+    headers = {"Content-Type": "application/json"}
+    if auth_type == "managed-identity":
+        try:
+            from azure.identity import DefaultAzureCredential
+            client_id = cfg.get("client_id") or os.environ.get("AZURE_CLIENT_ID")
+            cred = DefaultAzureCredential(managed_identity_client_id=client_id) if client_id else DefaultAzureCredential()
+            token = cred.get_token("https://cognitiveservices.azure.com/.default").token
+            headers["Authorization"] = f"Bearer {token}"
+        except Exception as e:
+            return {"ok": False, "status": 0, "detail": f"failed to acquire MI token: {str(e)[:150]}"}
+    else:
+        if not api_key:
+            return {"ok": False, "status": 0, "detail": "no api_key configured"}
+        headers["api-key"] = api_key
+
+    import httpx as _httpx
+    async with _httpx.AsyncClient(timeout=15.0) as c:
+        try:
+            r = await c.post(url, headers=headers, json={"input": "health check", "model": deployment})
+        except Exception as e:
+            return {"ok": False, "status": 0, "detail": f"request failed: {str(e)[:150]}"}
+
+    body = r.text[:200]
+    if r.status_code == 200:
+        return {"ok": True, "status": 200, "detail": "endpoint reachable, auth valid"}
+    if r.status_code == 429:
+        return {"ok": True, "status": 429, "detail": "rate limited — auth is valid"}
+    return {"ok": False, "status": r.status_code, "detail": body}
+
+
+# ============================================================================
+# API KEY MANAGEMENT (rotate / revoke / status)
+# ============================================================================
+#
+# Plain rotation flow: PUT a new api_key in. model_store encrypts at rest using
+# envelope encryption (see docgrok/crypto.py); the hot embed path decrypts
+# locally against a cached DEK so we don't pay a Key Vault RTT per embed.
+
+@router.put("/models/registry/{model_id}/api-key")
+async def rotate_model_api_key(model_id: str, request: dict):
+    """Rotate (or set) the api_key for an external model.
+
+    Body: {"api_key": "<new-key>"}
+    The plaintext key is never logged and never persisted in cleartext.
+    """
+    cfg = resolve_model(model_id)
+    if cfg is None:
+        raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found")
+    new_key = (request.get("api_key") or "").strip()
+    if not new_key:
+        raise HTTPException(status_code=400, detail="'api_key' is required")
+    cfg["api_key"] = new_key
+    if _store:
+        _store.upsert_model(model_id, cfg)
+    return {"id": model_id, "rotated": True}
+
+
+@router.delete("/models/registry/{model_id}/api-key")
+async def revoke_model_api_key(model_id: str):
+    """Revoke the api_key for a model (crypto-shred its envelope)."""
+    cfg = resolve_model(model_id)
+    if cfg is None:
+        raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found")
+    cfg["api_key"] = ""
+    if _store:
+        shred = dict(cfg)
+        shred["api_key"] = ""
+        shred["_clear_api_key"] = True
+        _store.upsert_model(model_id, shred)
+    return {"id": model_id, "revoked": True}
+
+
+@router.get("/models/registry/{model_id}/api-key")
+async def get_model_api_key_status(model_id: str):
+    """Return metadata about whether an api_key is configured (never the key)."""
+    cfg = resolve_model(model_id)
+    if cfg is None:
+        raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found")
+    return {
+        "id": model_id,
+        "has_api_key": bool(cfg.get("api_key")),
+        "auth_type": cfg.get("auth_type", "key"),
+    }
 
 
 # ============================================================================

--- a/docgrok/api.py
+++ b/docgrok/api.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from pipelines import PIPELINES, PipelineExecutor, StepType
-from admin import _MODEL_REGISTRY, _NATIVE_MODEL_URLS
+from admin import _MODEL_REGISTRY, _NATIVE_MODEL_URLS, resolve_model
 
 # Backend URLs for local models
 DSE_QWEN2_URL = os.getenv("DSE_QWEN2_URL", "http://dse-qwen2-svc:8000")
@@ -219,10 +219,10 @@ async def call_model(model_id: str, text, request_id: str = "") -> dict:
 
     # External model
     if model_id.startswith("mdl-ext-"):
-        if model_id not in _MODEL_REGISTRY:
+        cfg = resolve_model(model_id)
+        if cfg is None:
             raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found in registry")
 
-        cfg = _MODEL_REGISTRY[model_id]
         model_type = cfg.get("type", "")
         endpoint = cfg["endpoint"]
         api_key = cfg.get("api_key", "")

--- a/docgrok/envelope_crypto.py
+++ b/docgrok/envelope_crypto.py
@@ -1,0 +1,305 @@
+"""Envelope encryption for sensitive per-model secrets (api_keys).
+
+Why envelope encryption (and not "just put it in Key Vault" / "just put it in
+a k8s Secret" / "just store ciphertext in Cosmos"):
+
+  * 10k+ models: a single Key Vault holds at most ~25k secrets and is rate
+    limited to ~2k ops/sec. Storing each api_key as a KV secret puts the hot
+    embed path one network hop away from a throttled, shared resource.
+  * k8s Secrets don't scale across cluster boundaries, can't be rotated via
+    API without a pod roll, and tie persistence to the orchestrator.
+  * Plain ciphertext in Cosmos with no KMS gives no rotation story and no
+    way to crypto-shred a tenant.
+
+Design:
+  * Key Vault holds ONE long-lived Key Encryption Key (KEK), HSM-backed and
+    audited. Default name: `docgrok-model-kek`.
+  * Per call to `encrypt()` we generate a fresh 32-byte Data Encryption Key
+    (DEK), encrypt the plaintext with AES-256-GCM, then wrap the DEK with
+    the KEK (RSA-OAEP-256) and store the wrapped DEK alongside the
+    ciphertext.
+  * Decryption unwraps the DEK via the KEK once per (model, kek_version)
+    and caches the plaintext DEK in-process behind a TTL (default 1h). The
+    hot embed path is therefore a local AES-GCM decrypt (microseconds) and
+    never touches Key Vault.
+  * Rotating the api_key is a single Cosmos write — generate a new envelope
+    with the same KEK and overwrite the doc.
+  * Rotating the KEK is opaque to data: Key Vault auto-rotates, future
+    writes use the new version, old envelopes still decrypt with the old
+    version (we record `kek_version` per envelope).
+  * Crypto-shredding a tenant: delete/disable the KEK version they used in
+    Key Vault — all envelopes wrapped with it become permanently
+    undecryptable.
+
+Configuration (env vars):
+  KEY_VAULT_URI          Vault URI (required for envelope mode).
+  MODEL_KEK_NAME         KEK key name. Default: docgrok-model-kek.
+  AZURE_CLIENT_ID        Workload-identity client id. Optional.
+  MODEL_DEK_CACHE_TTL    DEK cache TTL in seconds. Default: 3600.
+
+Fallback:
+  When KEY_VAULT_URI is unset the module returns a `NullCipher` which
+  preserves plaintext (only for local dev / unit tests). Production
+  deployments MUST set KEY_VAULT_URI.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import secrets
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Magic header so we can tell envelope blobs apart from anything else that
+# might one day end up in the same field (plaintext, base64, etc.).
+ENVELOPE_VERSION = 1
+ENVELOPE_PREFIX = "ev1:"
+_KEK_WRAP_ALGO = "RSA-OAEP-256"
+
+
+@dataclass(frozen=True)
+class Envelope:
+    """Serializable envelope structure (everything below is non-secret)."""
+    version: int
+    nonce_b64: str
+    ciphertext_b64: str
+    dek_wrapped_b64: str
+    kek_version: str  # the Key Vault key version used to wrap the DEK
+
+    def serialize(self) -> str:
+        payload = {
+            "v": self.version,
+            "n": self.nonce_b64,
+            "c": self.ciphertext_b64,
+            "w": self.dek_wrapped_b64,
+            "k": self.kek_version,
+            "a": _KEK_WRAP_ALGO,
+        }
+        return ENVELOPE_PREFIX + base64.b64encode(
+            json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        ).decode("ascii")
+
+    @classmethod
+    def parse(cls, blob: str) -> "Envelope":
+        if not blob.startswith(ENVELOPE_PREFIX):
+            raise ValueError("not an envelope blob")
+        raw = base64.b64decode(blob[len(ENVELOPE_PREFIX):])
+        d = json.loads(raw)
+        return cls(
+            version=int(d["v"]),
+            nonce_b64=d["n"],
+            ciphertext_b64=d["c"],
+            dek_wrapped_b64=d["w"],
+            kek_version=d["k"],
+        )
+
+
+class CipherError(Exception):
+    """Raised for any envelope encryption/decryption failure."""
+
+
+class Cipher:
+    """Abstract API. Implementations must be thread-safe."""
+
+    def encrypt(self, plaintext: str) -> str:
+        raise NotImplementedError
+
+    def decrypt(self, blob: str) -> str:
+        raise NotImplementedError
+
+    def is_envelope(self, value: Optional[str]) -> bool:
+        return isinstance(value, str) and value.startswith(ENVELOPE_PREFIX)
+
+
+class NullCipher(Cipher):
+    """No-op cipher for local dev / tests when KEY_VAULT_URI is unset."""
+
+    def encrypt(self, plaintext: str) -> str:
+        # Returned as-is; callers MUST treat the column as sensitive anyway.
+        return plaintext
+
+    def decrypt(self, blob: str) -> str:
+        if self.is_envelope(blob):
+            raise CipherError(
+                "Received an envelope blob but no KEY_VAULT_URI is configured."
+            )
+        return blob
+
+
+class EnvelopeCipher(Cipher):
+    """Envelope encryption backed by Azure Key Vault Keys (KEK)."""
+
+    def __init__(self, vault_uri: str, kek_name: str, dek_cache_ttl: int = 3600):
+        from azure.identity import DefaultAzureCredential
+        from azure.keyvault.keys import KeyClient
+        from azure.keyvault.keys.crypto import CryptographyClient
+
+        client_id = os.environ.get("AZURE_CLIENT_ID")
+        cred = (
+            DefaultAzureCredential(managed_identity_client_id=client_id)
+            if client_id else DefaultAzureCredential()
+        )
+        self._credential = cred
+        self._key_client = KeyClient(vault_url=vault_uri, credential=cred)
+        self._kek_name = kek_name
+
+        # Resolve the active KEK (creating one only if explicitly enabled).
+        try:
+            self._kek = self._key_client.get_key(kek_name)
+        except Exception as e:
+            if os.environ.get("MODEL_KEK_AUTOCREATE", "").lower() == "true":
+                logger.warning(
+                    "KEK %s not found; auto-creating (MODEL_KEK_AUTOCREATE=true)",
+                    kek_name,
+                )
+                self._kek = self._key_client.create_rsa_key(kek_name, size=3072)
+            else:
+                raise CipherError(
+                    f"KEK '{kek_name}' not found in {vault_uri} and "
+                    f"MODEL_KEK_AUTOCREATE is not enabled."
+                ) from e
+
+        self._crypto = CryptographyClient(self._kek, credential=cred)
+        self._dek_cache_ttl = dek_cache_ttl
+        # cache: { (kek_version, dek_wrapped_b64) : (dek_bytes, expires_at) }
+        self._dek_cache: dict[tuple[str, str], tuple[bytes, float]] = {}
+        self._cache_lock = threading.Lock()
+
+    # ---- public Cipher API -------------------------------------------------
+
+    @property
+    def kek_version(self) -> str:
+        return self._kek.properties.version or ""
+
+    def encrypt(self, plaintext: str) -> str:
+        if plaintext is None:
+            raise CipherError("plaintext must not be None")
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+        dek = secrets.token_bytes(32)              # AES-256 key
+        nonce = secrets.token_bytes(12)            # 96-bit nonce (GCM standard)
+        aesgcm = AESGCM(dek)
+        ct = aesgcm.encrypt(nonce, plaintext.encode("utf-8"), associated_data=None)
+
+        wrap = self._crypto.wrap_key(_KEK_WRAP_ALGO, dek)
+        env = Envelope(
+            version=ENVELOPE_VERSION,
+            nonce_b64=base64.b64encode(nonce).decode("ascii"),
+            ciphertext_b64=base64.b64encode(ct).decode("ascii"),
+            dek_wrapped_b64=base64.b64encode(wrap.encrypted_key).decode("ascii"),
+            kek_version=self.kek_version,
+        )
+        return env.serialize()
+
+    def decrypt(self, blob: str) -> str:
+        if not self.is_envelope(blob):
+            # Legacy data path: docs written before envelope encryption have
+            # the raw api_key (or empty string). Return as-is — callers can
+            # detect and migrate.
+            return blob
+
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+        env = Envelope.parse(blob)
+
+        cache_key = (env.kek_version, env.dek_wrapped_b64)
+        now = time.time()
+        with self._cache_lock:
+            cached = self._dek_cache.get(cache_key)
+            if cached and cached[1] > now:
+                dek = cached[0]
+            else:
+                dek = None
+
+        if dek is None:
+            wrapped = base64.b64decode(env.dek_wrapped_b64)
+            crypto = self._crypto_for_version(env.kek_version)
+            try:
+                unwrap = crypto.unwrap_key(_KEK_WRAP_ALGO, wrapped)
+            except Exception as e:
+                raise CipherError(f"KEK unwrap failed: {e}") from e
+            dek = unwrap.key
+            with self._cache_lock:
+                self._dek_cache[cache_key] = (dek, now + self._dek_cache_ttl)
+
+        try:
+            aesgcm = AESGCM(dek)
+            pt = aesgcm.decrypt(
+                base64.b64decode(env.nonce_b64),
+                base64.b64decode(env.ciphertext_b64),
+                associated_data=None,
+            )
+        except Exception as e:
+            raise CipherError(f"AES-GCM decrypt failed: {e}") from e
+        return pt.decode("utf-8")
+
+    # ---- helpers -----------------------------------------------------------
+
+    def _crypto_for_version(self, version: str):
+        """Return a CryptographyClient bound to a specific KEK version.
+
+        Required to decrypt envelopes wrapped by an older KEK version after a
+        rotation.
+        """
+        from azure.keyvault.keys.crypto import CryptographyClient
+        if not version or version == self.kek_version:
+            return self._crypto
+        # The versioned key id is <vault>/keys/<name>/<version>
+        kid = f"{self._kek.id.rsplit('/', 1)[0]}/{version}"
+        return CryptographyClient(kid, credential=self._credential)
+
+
+# ---- module-level singleton --------------------------------------------------
+
+_cipher: Optional[Cipher] = None
+_cipher_lock = threading.Lock()
+
+
+def get_cipher() -> Cipher:
+    """Return the process-wide Cipher (envelope if KEY_VAULT_URI is set)."""
+    global _cipher
+    if _cipher is not None:
+        return _cipher
+    with _cipher_lock:
+        if _cipher is not None:
+            return _cipher
+
+        vault_uri = os.environ.get("KEY_VAULT_URI", "").strip()
+        kek_name = os.environ.get("MODEL_KEK_NAME", "docgrok-model-kek")
+        ttl = int(os.environ.get("MODEL_DEK_CACHE_TTL", "3600"))
+
+        if not vault_uri:
+            logger.warning(
+                "KEY_VAULT_URI is not set — model api_keys will be stored as "
+                "PLAINTEXT in Cosmos. This is acceptable only for local dev."
+            )
+            _cipher = NullCipher()
+            return _cipher
+
+        try:
+            _cipher = EnvelopeCipher(vault_uri, kek_name, dek_cache_ttl=ttl)
+            logger.info(
+                "EnvelopeCipher initialized (vault=%s, kek=%s, kek_version=%s, ttl=%ds)",
+                vault_uri, kek_name, _cipher.kek_version, ttl,
+            )
+        except Exception as e:
+            logger.exception(
+                "EnvelopeCipher init failed; falling back to NullCipher. "
+                "api_keys will not be encrypted at rest until this is fixed: %s",
+                e,
+            )
+            _cipher = NullCipher()
+        return _cipher
+
+
+def reset_cipher_for_tests() -> None:
+    """Test hook — drop the singleton so the next get_cipher() reinitializes."""
+    global _cipher
+    with _cipher_lock:
+        _cipher = None

--- a/docgrok/model_store.py
+++ b/docgrok/model_store.py
@@ -61,6 +61,8 @@ class CosmosDBStore(ModelStore):
         self._container = client.get_database_client(database).get_container_client(container)
 
     def list_models(self) -> dict[str, dict]:
+        from envelope_crypto import get_cipher, CipherError
+        cipher = get_cipher()
         docs = list(self._container.query_items(
             "SELECT * FROM c WHERE c.doc_type = 'docgrok_model'",
             partition_key="docgrok_model"
@@ -69,27 +71,66 @@ class CosmosDBStore(ModelStore):
         for doc in docs:
             model_id = doc["id"]
             cfg = {k: v for k, v in doc.items()
-                   if k not in ("doc_type", "stored_at") and not k.startswith("_")}
+                   if k not in ("doc_type", "stored_at", "api_key_envelope")
+                   and not k.startswith("_")}
             cfg.pop("id", None)
+            envelope = doc.get("api_key_envelope") or ""
+            if envelope:
+                try:
+                    cfg["api_key"] = cipher.decrypt(envelope)
+                except CipherError as e:
+                    print(f"WARNING: failed to decrypt api_key for {model_id}: {e}")
+                    cfg["api_key"] = ""
+            else:
+                cfg.setdefault("api_key", "")
             result[model_id] = cfg
         return result
 
     def get_model(self, model_id: str) -> dict | None:
+        from envelope_crypto import get_cipher, CipherError
         try:
             doc = self._container.read_item(model_id, partition_key="docgrok_model")
-            cfg = {k: v for k, v in doc.items()
-                   if k not in ("doc_type", "stored_at") and not k.startswith("_")}
-            cfg.pop("id", None)
-            return cfg
         except Exception:
             return None
+        cipher = get_cipher()
+        cfg = {k: v for k, v in doc.items()
+               if k not in ("doc_type", "stored_at", "api_key_envelope")
+               and not k.startswith("_")}
+        cfg.pop("id", None)
+        envelope = doc.get("api_key_envelope") or ""
+        if envelope:
+            try:
+                cfg["api_key"] = cipher.decrypt(envelope)
+            except CipherError as e:
+                print(f"WARNING: failed to decrypt api_key for {model_id}: {e}")
+                cfg["api_key"] = ""
+        else:
+            cfg.setdefault("api_key", "")
+        return cfg
 
     def upsert_model(self, model_id: str, config: dict) -> None:
         from datetime import datetime
+        from envelope_crypto import get_cipher
+        cipher = get_cipher()
+        api_key = config.get("api_key") or ""
+        envelope = ""
+        if api_key:
+            envelope = cipher.encrypt(api_key)
+        # Preserve existing envelope if caller updates without a new key,
+        # UNLESS _clear_api_key is set (explicit revoke).
+        clear = bool(config.get("_clear_api_key"))
+        if not api_key and not clear:
+            try:
+                existing = self._container.read_item(model_id, partition_key="docgrok_model")
+                envelope = existing.get("api_key_envelope", "")
+            except Exception:
+                envelope = ""
+
         doc = {
             "id": model_id,
             "doc_type": "docgrok_model",
-            **{k: v for k, v in config.items() if k != "api_key"},
+            **{k: v for k, v in config.items() if k not in ("api_key", "_clear_api_key")},
+            "api_key_envelope": envelope,
             "stored_at": datetime.utcnow().isoformat(),
         }
         self._container.upsert_item(doc)

--- a/docgrok/requirements.txt
+++ b/docgrok/requirements.txt
@@ -8,3 +8,5 @@ kubernetes>=28.1.0
 Pillow>=10.0.0
 azure-cosmos>=4.5.0
 azure-identity>=1.14.0
+azure-keyvault-keys>=4.8.0
+cryptography>=42.0.0

--- a/helm/docgrok/templates/docgrok.yaml
+++ b/helm/docgrok/templates/docgrok.yaml
@@ -51,6 +51,14 @@ spec:
           value: {{ .Values.azure.cosmos.database | quote }}
         - name: COSMOS_CONTAINER
           value: {{ .Values.azure.cosmos.container | quote }}
+        {{- if .Values.azure.keyVault.uri }}
+        - name: KEY_VAULT_URI
+          value: {{ .Values.azure.keyVault.uri | quote }}
+        - name: MODEL_KEK_NAME
+          value: {{ .Values.azure.keyVault.modelKekName | default "docgrok-model-kek" | quote }}
+        - name: MODEL_KEK_AUTOCREATE
+          value: {{ .Values.azure.keyVault.autoCreateKek | default "true" | quote }}
+        {{- end }}
         - name: DOCGROK_CONTROLLER_URL
           value: "http://docgrok-controller:{{ .Values.controller.port }}"
         {{- range $name, $provider := .Values.providers }}

--- a/helm/docgrok/values.yaml
+++ b/helm/docgrok/values.yaml
@@ -14,6 +14,10 @@ azure:
     endpoint: "" # Set from Bicep output
     database: "omnivec"
     container: "metadata"
+  keyVault:
+    uri: "" # Set from Bicep output. When set, model api_keys are envelope-encrypted (AES-GCM/RSA-OAEP) at rest.
+    modelKekName: "docgrok-model-kek"
+    autoCreateKek: "true" # set false in prod once the KEK exists
 
 # =============================================================================
 # MODEL REGISTRY


### PR DESCRIPTION
Promote dev to main for v1.1.1 CLI release.

Includes:
- CLI: pipeline create --processing-mode / --embedding-field, model list shows externals (#154)
- DocGrok: envelope-encrypted api keys via Key Vault KEK, registry cache sync across replicas, server-side healthcheck
- API: no more double-write clobbering envelope, health probe delegated to docgrok
- Helm: keyVault wiring on docgrok

Tag v1.1.1 will be cut from main after this merges.