### PR TITLE
hotfix: import omnivec-agent image; dotnet-worker liveness -> TCP

### DIFF
--- a/helm/omnivec/templates/dotnet-worker-deployment.yaml
+++ b/helm/omnivec/templates/dotnet-worker-deployment.yaml
@@ -57,8 +57,7 @@ spec:
               containerPort: {{ .Values.dotnetWorker.healthPort | default 8080 }}
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: {{ .Values.dotnetWorker.healthPort | default 8080 }}
             initialDelaySeconds: {{ .Values.dotnetWorker.probes.liveness.initialDelaySeconds | default 30 }}
             periodSeconds: {{ .Values.dotnetWorker.probes.liveness.periodSeconds | default 30 }}
@@ -73,8 +72,7 @@ spec:
             timeoutSeconds: {{ .Values.dotnetWorker.probes.readiness.timeoutSeconds | default 3 }}
             failureThreshold: {{ .Values.dotnetWorker.probes.readiness.failureThreshold | default 6 }}
           startupProbe:
-            httpGet:
-              path: /healthz
+            tcpSocket:
               port: {{ .Values.dotnetWorker.healthPort | default 8080 }}
             initialDelaySeconds: 5
             periodSeconds: 5

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -130,6 +130,7 @@ $IMAGES = @(
     "omnivec-web",
     "omnivec-changefeed",
     "omnivec-dotnet-worker",
+    "omnivec-agent",
     "docgrok-pipeline-worker",
     "docgrok-router"
 )
@@ -221,6 +222,7 @@ function Build-AllImages {
     Build-Image -Name "omnivec-web" -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag "latest"
     Build-Image -Name "omnivec-changefeed" -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag "latest"
     Build-Image -Name "omnivec-dotnet-worker" -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag "latest"
+    Build-Image -Name "omnivec-agent" -Dockerfile "$RootDir/agent/Dockerfile" -Context "$RootDir/agent/" -Tag "latest"
 
     if (Test-Path "$RootDir/docgrok/pipeline-worker/Dockerfile") {
         Build-Image -Name "docgrok-pipeline-worker" -Dockerfile "$RootDir/docgrok/pipeline-worker/Dockerfile" -Context "$RootDir/docgrok/pipeline-worker/" -Tag "latest"
@@ -240,6 +242,7 @@ function Build-MissingImages {
             "omnivec-web"             { Build-Image -Name $image -Dockerfile "$RootDir/web/Dockerfile" -Context "$RootDir/web/" -Tag "latest" }
             "omnivec-changefeed"      { Build-Image -Name $image -Dockerfile "$RootDir/connectors/ingestion/dotnet/Dockerfile" -Context "$RootDir/connectors/ingestion/dotnet/" -Tag "latest" }
             "omnivec-dotnet-worker"   { Build-Image -Name $image -Dockerfile "$RootDir/connectors/worker/dotnet/Dockerfile" -Context "$RootDir/connectors/worker/dotnet/" -Tag "latest" }
+            "omnivec-agent"           { Build-Image -Name $image -Dockerfile "$RootDir/agent/Dockerfile" -Context "$RootDir/agent/" -Tag "latest" }
             "docgrok-pipeline-worker" {
                 if (Test-Path "$RootDir/docgrok/pipeline-worker/Dockerfile") {
                     Build-Image -Name $image -Dockerfile "$RootDir/docgrok/pipeline-worker/Dockerfile" -Context "$RootDir/docgrok/pipeline-worker/" -Tag "latest"

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -170,7 +170,7 @@ OMNIVEC_BUILD=${OMNIVEC_BUILD:-false}
 FORCE_IMPORT=${OMNIVEC_FORCE_IMPORT:-false}
 
 # Images to import/build
-IMAGES="omnivec-api omnivec-search omnivec-web omnivec-changefeed omnivec-dotnet-worker docgrok-pipeline-worker docgrok-router"
+IMAGES="omnivec-api omnivec-search omnivec-web omnivec-changefeed omnivec-dotnet-worker omnivec-agent docgrok-pipeline-worker docgrok-router"
 
 # Release channel tag (stable / dev / sha-xxxxxxx / vX.Y.Z / latest).
 # Used for BOTH the acr import step AND the helm --set overrides so the
@@ -260,6 +260,7 @@ build_all_images() {
   build_image "omnivec-web" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest"
   build_image "omnivec-changefeed" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest"
   build_image "omnivec-dotnet-worker" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest"
+  build_image "omnivec-agent" "${ROOT_DIR}/agent/Dockerfile" "${ROOT_DIR}/agent/" "latest"
   if [ -f "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" ]; then
     build_image "docgrok-pipeline-worker" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "latest"
   fi
@@ -276,6 +277,7 @@ build_missing_images() {
       omnivec-web)              build_image "$image" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest" ;;
       omnivec-changefeed)       build_image "$image" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest" ;;
       omnivec-dotnet-worker)    build_image "$image" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest" ;;
+      omnivec-agent)            build_image "$image" "${ROOT_DIR}/agent/Dockerfile" "${ROOT_DIR}/agent/" "latest" ;;
       docgrok-pipeline-worker)
         if [ -f "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" ]; then
           build_image "$image" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "latest"


### PR DESCRIPTION
Fixes the two failures seen in the last fresh deploy:

- `omnivec-agent` ImagePullBackOff because it was missing from the IMAGES list in `hooks/postprovision.{sh,ps1}` -> never imported/built into the per-deploy ACR. Added to IMAGES + both build branches. Dockerfile: `./agent/Dockerfile`.
- `omnivec-dotnet-worker` CrashLoopBackOff because the HTTP `/healthz` liveness probe returned 503 when Service Bus was unconfigured (idle worker). Switched liveness + startup to `tcpSocket` on the health port. Readiness stays on `/ready` so the pod is correctly NotReady until SB is configured, but the container is no longer killed every 30s.