### PR TITLE
hotfix: agent build context + agent-internal secret + AKS API 2026-01-02-preview + B4ms default

### DIFF
--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -260,7 +260,7 @@ build_all_images() {
   build_image "omnivec-web" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest"
   build_image "omnivec-changefeed" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest"
   build_image "omnivec-dotnet-worker" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest"
-  build_image "omnivec-agent" "${ROOT_DIR}/agent/Dockerfile" "${ROOT_DIR}/agent/" "latest"
+  build_image "omnivec-agent" "${ROOT_DIR}/agent/Dockerfile" "$ROOT_DIR" "latest"
   if [ -f "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" ]; then
     build_image "docgrok-pipeline-worker" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "latest"
   fi
@@ -277,7 +277,7 @@ build_missing_images() {
       omnivec-web)              build_image "$image" "${ROOT_DIR}/web/Dockerfile" "${ROOT_DIR}/web/" "latest" ;;
       omnivec-changefeed)       build_image "$image" "${ROOT_DIR}/connectors/ingestion/dotnet/Dockerfile" "${ROOT_DIR}/connectors/ingestion/dotnet/" "latest" ;;
       omnivec-dotnet-worker)    build_image "$image" "${ROOT_DIR}/connectors/worker/dotnet/Dockerfile" "${ROOT_DIR}/connectors/worker/dotnet/" "latest" ;;
-      omnivec-agent)            build_image "$image" "${ROOT_DIR}/agent/Dockerfile" "${ROOT_DIR}/agent/" "latest" ;;
+      omnivec-agent)            build_image "$image" "${ROOT_DIR}/agent/Dockerfile" "$ROOT_DIR" "latest" ;;
       docgrok-pipeline-worker)
         if [ -f "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" ]; then
           build_image "$image" "${ROOT_DIR}/docgrok/pipeline-worker/Dockerfile" "${ROOT_DIR}/docgrok/pipeline-worker/" "latest"
@@ -591,6 +591,18 @@ if [ "$ENABLE_BLOB_SOURCE" = "true" ]; then
     --dry-run=client -o yaml | kubectl_omnivec apply -f -
   printf "  ${GREEN}omnivec-storage secret created.${NC}\n"
 fi
+
+# Agent internal token secret (used for agent <-> API service-to-service auth)
+AGENT_INTERNAL_TOKEN=$(get_azd_value "OMNIVEC_AGENT_INTERNAL_TOKEN")
+if [ -z "$AGENT_INTERNAL_TOKEN" ]; then
+  AGENT_INTERNAL_TOKEN=$(head -c 32 /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c 44)
+  azd env set OMNIVEC_AGENT_INTERNAL_TOKEN "$AGENT_INTERNAL_TOKEN" </dev/null
+fi
+kubectl_omnivec create secret generic omnivec-agent-internal \
+  --namespace omnivec \
+  --from-literal=token="$AGENT_INTERNAL_TOKEN" \
+  --dry-run=client -o yaml | kubectl_omnivec apply -f -
+printf "  ${GREEN}omnivec-agent-internal secret created.${NC}\n"
 
 printf "${GREEN}Namespaces and secrets created.${NC}\n"
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -17,7 +17,7 @@ param location string
 param kubernetesVersion string = '1.33'
 
 @description('VM size for AKS system node pool')
-param systemNodeVmSize string = 'Standard_D4s_v3'
+param systemNodeVmSize string = 'Standard_B4ms'
 
 @description('Initial system node count. Kept as string so azd env substitution (which always produces a string, even for ints) never breaks ARM type-coercion. Parsed/defaulted below.')
 param systemNodeCount string = '2'

--- a/infra/modules/aks.bicep
+++ b/infra/modules/aks.bicep
@@ -29,7 +29,7 @@ var gpuPool = gpuNodeCount > 0 ? [
   }
 ] : []
 
-resource aks 'Microsoft.ContainerService/managedClusters@2024-02-01' = {
+resource aks 'Microsoft.ContainerService/managedClusters@2026-01-02-preview' = {
   name: clusterName
   location: location
   identity: {


### PR DESCRIPTION
Applies omnivec-fixes.patch from QA:

- `hooks/postprovision.sh`: build `omnivec-agent` with repo root as docker context (was `agent/`); needed for the Dockerfile to access shared code paths.
- `hooks/postprovision.sh`: create `omnivec-agent-internal` k8s secret holding a 32-byte token for agent <-> API service-to-service auth. Token is persisted to azd env (`OMNIVEC_AGENT_INTERNAL_TOKEN`) so reruns are idempotent.
- `infra/modules/aks.bicep`: bump `Microsoft.ContainerService/managedClusters` API version `2024-02-01` -> `2026-01-02-preview`.
- `infra/main.bicep`: default `systemNodeVmSize` `Standard_D4s_v3` -> `Standard_B4ms` for cheaper dev/test deploys.