### PR TITLE
hotfix: SEARCH_INTERNAL_TOKEN on API pod + vector path double-slash

### DIFF
--- a/connectors/ingestion/dotnet/Services/SourceWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/SourceWatcher.cs
@@ -408,7 +408,7 @@ public class SourceWatcher : ISourceWatcher
 
                         // Inject pipeline's vector_index_path into destination config
                         var destConfig = new Dictionary<string, object>(dest.Config);
-                        destConfig["vector_field"] = pipeline.VectorIndexPath;
+                        destConfig["vector_field"] = pipeline.VectorIndexPath.TrimStart('/');
 
                         var msg = new EmbeddingMessage
                         {
@@ -715,7 +715,7 @@ public class SourceWatcher : ISourceWatcher
                     var floats = EmbeddingToFloatList(embedding);
                     var ops = new List<PatchOperation>
                     {
-                        PatchOperation.Set($"/{pipeline.VectorIndexPath}", floats),                        PatchOperation.Set("/embedded_at", now),
+                        PatchOperation.Set($"/{pipeline.VectorIndexPath.TrimStart('/')}", floats),                        PatchOperation.Set("/embedded_at", now),
                         PatchOperation.Set("/embedding_dims", floats.Count),
                         PatchOperation.Set("/pipeline_id", pipeline.Id),
                         PatchOperation.Set("/pipeline_name", pipeline.Name),
@@ -806,7 +806,7 @@ public class SourceWatcher : ISourceWatcher
 
         var ops = new List<PatchOperation>
         {
-            PatchOperation.Set($"/{pipeline.VectorIndexPath}", floats),
+            PatchOperation.Set($"/{pipeline.VectorIndexPath.TrimStart('/')}", floats),
             PatchOperation.Set("/embedded_at", DateTime.UtcNow.ToString("O")),
             PatchOperation.Set("/embedding_dims", floats.Count),
             PatchOperation.Set("/pipeline_id", pipeline.Id),

--- a/helm/omnivec/templates/api-deployment.yaml
+++ b/helm/omnivec/templates/api-deployment.yaml
@@ -58,6 +58,12 @@ spec:
             - name: OMNIVEC_ADMIN_TOKEN
               value: {{ .Values.api.adminToken | quote }}
             {{- end }}
+            {{- if .Values.search.internalToken }}
+            - name: SEARCH_INTERNAL_TOKEN
+              value: {{ .Values.search.internalToken | quote }}
+            {{- end }}
+            - name: SEARCH_SERVICE_URL
+              value: {{ .Values.api.searchServiceUrl | default "http://omnivec-search" | quote }}
             {{- if .Values.azure.keyVault.uri }}
             - name: KEY_VAULT_URI
               value: {{ .Values.azure.keyVault.uri | quote }}


### PR DESCRIPTION
Two production bugs reported from the e2e demo (linux-test env):

### Fix 5 — SEARCH_INTERNAL_TOKEN missing on API pod
The search service receives the token via Helm values, but the API pod (which proxies search calls) was never given it. values.yaml even has a 'shared with api deployment' comment but the wiring was never implemented. Result: every search call → 503 'Search service not configured (SEARCH_INTERNAL_TOKEN missing)'.

Adds the env block in api-deployment.yaml; also sets SEARCH_SERVICE_URL for completeness.

### Fix 6 — vector_index_path double-slash
SourceWatcher.cs prepends '/' to pipeline.VectorIndexPath when building Cosmos PatchOperation paths. CLI default is '/embedding' → '//embedding' → Cosmos rejects as BadRequest 400. Every CLI-created pipeline broke at first changefeed iteration.

Normalizes with TrimStart('/') in all 3 SourceWatcher sites (2 patch paths + 1 vector_field config injection).