### PR TITLE
hotfix(postprovision): sanitize Azure-reserved words in PublicIP DNS label

### DIFF
--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -65,6 +65,23 @@ $KEYVAULT_URI = Get-AzdValue "AZURE_KEYVAULT_URI"
 $APPINSIGHTS_CS = Get-AzdValue "AZURE_APPINSIGHTS_CONNECTION_STRING"
 $LOG_ANALYTICS_WS = Get-AzdValue "AZURE_LOG_ANALYTICS_WORKSPACE_ID"
 
+# Azure rejects PublicIP DNS labels containing reserved trademarks
+# (windows, microsoft, azure, xbox, login, bing, apple) with
+# DomainNameLabelReserved (400). When the INSTANCE_ID happens to contain
+# one of these, fall back to an empty label so the Helm chart skips the
+# service.beta.kubernetes.io/azure-dns-label-name annotation and the LB
+# is reachable via its public IP instead of an azurewebsites FQDN.
+$WEB_DNS_LABEL = $INSTANCE_ID
+$DNS_LABEL_RESERVED = ""
+$lcId = ([string]$INSTANCE_ID).ToLowerInvariant()
+foreach ($_w in @('microsoft','windows','azure','xbox','login','bing','apple')) {
+    if ($lcId -like "*$_w*") {
+        $WEB_DNS_LABEL = ""
+        $DNS_LABEL_RESERVED = $_w
+        break
+    }
+}
+
 # Validate required vars
 foreach ($var in @("INSTANCE_ID","AKS_CLUSTER","ACR_LOGIN_SERVER","ACR_NAME","COSMOS_ENDPOINT","IDENTITY_CLIENT_ID","RESOURCE_GROUP")) {
     if (-not (Get-Variable $var -ValueOnly)) {
@@ -90,6 +107,10 @@ if ($ENABLE_BLOB_SOURCE -eq "true") {
 }
 Write-Host "  Identity:        $IDENTITY_CLIENT_ID"
 Write-Host "  Build mode:      $BUILD_MODE"
+if ($DNS_LABEL_RESERVED) {
+    Write-Host "  `e[33mNote: instance id contains reserved word '$DNS_LABEL_RESERVED'`e[0m"
+    Write-Host "  `e[33m      — Azure DNS label disabled; web LB will use IP only.`e[0m"
+}
 
 # -- Store config as RG tags (enables cross-machine config sync) --
 Write-Host "`n`e[36mSaving config to resource group tags...`e[0m"
@@ -610,7 +631,7 @@ $helmArgs = @(
     "--set", "search.bootstrapToken=$SEARCH_BOOTSTRAP_TOKEN",
     "--set", "search.internalToken=$SEARCH_INTERNAL_TOKEN",
     "--set", "dotnetWorker.enabled=true",
-    "--set", "web.service.dnsLabel=$INSTANCE_ID"
+    "--set", "web.service.dnsLabel=$WEB_DNS_LABEL"
 )
 
 if ($KEYVAULT_URI) {
@@ -753,7 +774,7 @@ if ($skipHelm) {
         'RequestTimeout','OperationTimedOut','503','502','504',
         'Service Unavailable','Temporary failure','Connection reset',
         'TLS handshake','InternalServerError','i/o timeout',
-        'context deadline exceeded'
+        'context deadline exceeded','no such host','dial tcp'
     )
     $helmRc = 1
     for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -88,6 +88,25 @@ COSMOS_ENDPOINT=$(get_azd_value "AZURE_COSMOS_ENDPOINT")
 IDENTITY_CLIENT_ID=$(get_azd_value "AZURE_IDENTITY_CLIENT_ID")
 RESOURCE_GROUP=$(get_azd_value "AZURE_RESOURCE_GROUP")
 BUILD_MODE=$(get_azd_value "OMNIVEC_BUILD_MODE")
+
+# Azure rejects PublicIP DNS labels containing reserved trademarks
+# (windows, microsoft, azure, xbox, login, bing, apple) with
+# DomainNameLabelReserved (400). When the INSTANCE_ID happens to contain
+# one of these, fall back to an empty label so the Helm chart skips the
+# service.beta.kubernetes.io/azure-dns-label-name annotation and the LB
+# is reachable via its public IP instead of an azurewebsites FQDN.
+_lc_id=$(printf '%s' "$INSTANCE_ID" | tr '[:upper:]' '[:lower:]')
+WEB_DNS_LABEL="$INSTANCE_ID"
+for _w in microsoft windows azure xbox login bing apple; do
+  case "$_lc_id" in
+    *"$_w"*)
+      WEB_DNS_LABEL=""
+      DNS_LABEL_RESERVED="$_w"
+      break
+      ;;
+  esac
+done
+unset _lc_id _w
 if [ -z "$BUILD_MODE" ]; then
   if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
     BUILD_MODE="docker"
@@ -133,6 +152,10 @@ if [ "$ENABLE_BLOB_SOURCE" = "true" ]; then
 fi
 echo "  Identity:        $IDENTITY_CLIENT_ID"
 echo "  Build mode:      $BUILD_MODE"
+if [ -n "${DNS_LABEL_RESERVED:-}" ]; then
+  printf "  ${YELLOW}Note: instance id contains reserved word '${DNS_LABEL_RESERVED}'${NC}\n"
+  printf "  ${YELLOW}      — Azure DNS label disabled; web LB will use IP only.${NC}\n"
+fi
 
 # -- Store config as RG tags (enables cross-machine config sync) --
 printf "\n${CYAN}Saving config to resource group tags...${NC}\n"
@@ -690,7 +713,7 @@ web:
   image:
     tag: "${IMAGE_TAG}"
   service:
-    dnsLabel: "${INSTANCE_ID}"
+    dnsLabel: "${WEB_DNS_LABEL}"
 changefeed:
   image:
     tag: "${IMAGE_TAG}"


### PR DESCRIPTION
Reproducer: \zd env new windows-test && azd up\. Azure rejects the public-IP DNS label with DomainNameLabelReserved because 'windows' is a Microsoft trademark; the web LB stays \<pending>\ and helm --wait times out forever.

Fix mirrored in both hooks/postprovision.sh and hooks/postprovision.ps1: detect reserved tokens (windows/microsoft/azure/xbox/login/bing/apple) in INSTANCE_ID and emit an empty \web.service.dnsLabel\ — the chart already conditionally skips the annotation, so the LB then just picks up a vanilla IP. Banner shows a yellow note when the fallback engages.

Bonus: ps1 helm-retry now treats 'no such host' / 'dial tcp' as transient (we hit a brief DNS blip against the AKS control plane on a retry attempt).