### PR TITLE
fix(preprovision): block Azure-reserved trademarks in AZURE_ENV_NAME

### DIFF
--- a/hooks/preprovision.ps1
+++ b/hooks/preprovision.ps1
@@ -26,6 +26,22 @@ if ($envName -notmatch '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$') {
     Write-Host "  Recommended: lowercase letters, digits, and dashes (no leading/trailing dash)."
 }
 
+# -- Block Azure-trademark reserved words. Azure rejects PublicIP DNS labels
+# containing these (DomainNameLabelReserved 400), which makes the web LB
+# unable to acquire an IP and causes helm --wait to time out. Fail fast
+# here so the user picks a clean name instead of debugging a stuck deploy.
+$lcEnv = $envName.ToLowerInvariant()
+foreach ($_w in @('microsoft','windows','azure','xbox','login','bing','apple')) {
+    if ($lcEnv -like "*$_w*") {
+        Write-Host "`n`e[31mERROR: AZURE_ENV_NAME='$envName' contains the reserved word '$_w'.`e[0m"
+        Write-Host "  Azure rejects PublicIP DNS labels containing trademarks"
+        Write-Host "  (microsoft, windows, azure, xbox, login, bing, apple) with"
+        Write-Host "  DomainNameLabelReserved (400). Pick a name that doesn't contain any of these."
+        Write-Host "  Fix with:  `e[36mazd env new <new-name>`e[0m"
+        exit 1
+    }
+}
+
 # -- Repair .env if prior run left embedded newlines / stray quotes --
 # Symptom: `loading .env: unexpected character "\"" in variable name near "...\n"`
 # Cause: a previous azd env set wrote a multi-line value; subsequent runs can't parse it.

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -39,6 +39,25 @@ case "$_env_name" in
     ;;
 esac
 
+# ── Block Azure-trademark reserved words. Azure rejects PublicIP DNS labels
+# containing these (DomainNameLabelReserved 400), which makes the web LB
+# unable to acquire an IP and causes helm --wait to time out. Fail fast
+# here so the user picks a clean name instead of debugging a stuck deploy.
+_lc_env=$(printf '%s' "$_env_name" | tr '[:upper:]' '[:lower:]')
+for _w in microsoft windows azure xbox login bing apple; do
+  case "$_lc_env" in
+    *"$_w"*)
+      printf "\n${RED}ERROR: AZURE_ENV_NAME='${_env_name}' contains the reserved word '${_w}'.${NC}\n" >&2
+      printf "  Azure rejects PublicIP DNS labels containing trademarks\n" >&2
+      printf "  (microsoft, windows, azure, xbox, login, bing, apple) with\n" >&2
+      printf "  DomainNameLabelReserved (400). Pick a name that doesn't contain any of these.\n" >&2
+      printf "  Fix with:  ${CYAN}azd env new <new-name>${NC}\n" >&2
+      exit 1
+      ;;
+  esac
+done
+unset _lc_env _w
+
 # ── Repair .env if prior run left embedded newlines / stray quotes ──────────
 # Symptom: `loading .env: unexpected character "\"" in variable name near "...\n"`
 # Cause: a previous azd env set wrote a multi-line value; subsequent runs can't parse it.


### PR DESCRIPTION
Fail fast at preprovision when the env name contains a substring Azure rejects as a reserved DNS label (windows/microsoft/azure/xbox/login/bing/apple). Prevents the entire deploy from stalling on a stuck PublicIP and helm --wait timeout. Both .sh and .ps1 updated.