### PR TITLE
cli: rename `model add --provider` to `--name` for consistency

### DIFF
--- a/cli/cmd_model.go
+++ b/cli/cmd_model.go
@@ -154,14 +154,14 @@ func newModelTestCmd() *cobra.Command {
 }
 
 func newModelAddCmd() *cobra.Command {
-	var provider, providerType, endpoint, apiKey, apiVersion, modelName, authType, clientID string
+	var name, providerType, endpoint, apiKey, apiVersion, modelName, authType, clientID string
 	var dimensions int
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add an external embedding model",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if provider == "" {
-				exitErr("--provider is required")
+			if name == "" {
+				exitErr("--name is required")
 			}
 			if providerType == "" {
 				exitErr("--type is required (azure-openai, openai, cohere, custom)")
@@ -179,7 +179,7 @@ func newModelAddCmd() *cobra.Command {
 				exitErr("--api-key is required when --auth-type is key")
 			}
 			body := map[string]any{
-				"name":      provider,
+				"name":      name,
 				"type":      providerType,
 				"endpoint":  endpoint,
 				"model":     modelName,
@@ -202,11 +202,11 @@ func newModelAddCmd() *cobra.Command {
 			if err != nil {
 				exitErr("%v", err)
 			}
-			exitOK("External model added: %s (%s, auth: %s)", provider, modelName, authType)
+			exitOK("External model added: %s (%s, auth: %s)", name, modelName, authType)
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&provider, "provider", "", "Provider name (e.g., my-azure-openai)")
+	cmd.Flags().StringVar(&name, "name", "", "Model name (unique identifier, e.g., my-azure-openai)")
 	cmd.Flags().StringVarP(&providerType, "type", "t", "", "Provider type (azure-openai, openai, cohere, custom)")
 	cmd.Flags().StringVar(&endpoint, "endpoint", "", "Endpoint URL")
 	cmd.Flags().StringVar(&apiKey, "api-key", "", "API key (for key auth)")
@@ -221,7 +221,7 @@ func newModelAddCmd() *cobra.Command {
 func newModelDeleteCmd() *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
-		Use:   "delete <provider-name-or-id>",
+		Use:   "delete <name-or-id>",
 		Short: "Delete an external model provider",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -307,7 +307,7 @@ omnivec model test <name>
 
 # Add an Azure OpenAI model
 omnivec model add \
-  --provider my-azure-openai \
+  --name my-azure-openai \
   --type azure-openai \
   --endpoint https://myresource.openai.azure.com \
   --api-key sk-... \
@@ -334,7 +334,7 @@ omnivec model delete my-azure-openai -y
 
 | Flag | Required | Description |
 |------|----------|-------------|
-| `--provider` | Yes | Unique name for this provider |
+| `--name` | Yes | Unique name for this model |
 | `--type` | Yes | `azure-openai`, `openai`, `cohere`, `custom` |
 | `--endpoint` | Yes | Endpoint URL |
 | `--model` | Yes | Model or deployment name |
@@ -426,7 +426,7 @@ omnivec pipeline list -o yaml
 omnivec status
 
 # 2. Add an external embedding model
-omnivec model add --provider azure-openai-prod --type azure-openai \
+omnivec model add --name azure-openai-prod --type azure-openai \
   --endpoint https://myresource.openai.azure.com --api-key YOUR_KEY \
   --api-version 2024-06-01 --model text-embedding-3-small --dimensions 1536
 


### PR DESCRIPTION
## Summary

All other CLI 'create' commands (source/destination/pipeline) use `--name` for the identifier. `model add` was the lone outlier using `--provider`, which is also misleading because users would reasonably expect 'provider' to mean the provider **type** (azure-openai, openai, cohere) — but that's already `--type`.

The server stores it as `name` anyway (cmd_model.go:182).

## Changes
- `cli/cmd_model.go`: `--provider` → `--name` (clean break, no alias)
- `docs/cli-guide.md`: examples + flag reference table updated
- `delete <provider-name-or-id>` → `delete <name-or-id>`

## Breaking change

Yes. Any script using `omnivec model add --provider <x>` must now use `--name <x>`. v1.1.2 is one day old so impact is minimal.

## Verification
`
omnivec model add --type azure-openai --endpoint http://x --model y
→ Error: --name is required

omnivec model add --provider foo --type azure-openai --endpoint http://x --model y
→ Error: unknown flag: --provider
`
