### PR TITLE
cli: add install scripts (macOS/Linux/Windows) + Homebrew formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ This removes the resource group, all Azure services, and local environment confi
 | Want to... | Go to |
 |-----------|-------|
 | Manage pipelines via CLI | [CLI Guide](docs/cli-guide.md) |
+| Install the CLI (one line) | [CLI Install](docs/cli-guide.md#installation) |
 | Understand the architecture | [Architecture](docs/architecture.md) |
 | Use the web UI in depth | [User Guide](docs/user-guide.md) |
 | Run the automated E2E test suite | [E2E Demo](#automated-e2e-demo) below |

--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -6,19 +6,53 @@ The OmniVec CLI (`omnivec`) is a standalone binary for managing the OmniVec plat
 
 ## Installation
 
+### Quick install (recommended)
+
+**macOS & Linux** (auto-detects OS + arch, strips macOS quarantine, installs to `~/.local/bin`):
+```bash
+curl -fsSL https://github.com/AzureCosmosDB/OmniVec/raw/main/scripts/install.sh | bash
+```
+
+**macOS via Homebrew:**
+```bash
+brew install --formula https://raw.githubusercontent.com/AzureCosmosDB/OmniVec/main/scripts/omnivec.rb
+```
+(A dedicated `AzureCosmosDB/homebrew-omnivec` tap is planned; once published, the command will simplify to `brew install AzureCosmosDB/omnivec/omnivec`.)
+
+**Windows** (installs to `%USERPROFILE%\.omnivec\bin` and updates user PATH):
+```powershell
+irm https://github.com/AzureCosmosDB/OmniVec/raw/main/scripts/install.ps1 | iex
+```
+
+### Manual download
+
+Grab the binary for your platform from the [latest release](https://github.com/AzureCosmosDB/OmniVec/releases/latest):
+
 | Platform | Binary |
 |----------|--------|
-| Linux (amd64) | `omnivec-linux-amd64` |
-| macOS (Apple Silicon) | `omnivec-darwin-arm64` |
-| macOS (Intel) | `omnivec-darwin-amd64` |
-| Windows (amd64) | `omnivec-windows-amd64.exe` |
+| Linux (amd64) | `omnivec-vX.Y.Z-linux-amd64` |
+| Linux (arm64) | `omnivec-vX.Y.Z-linux-arm64` |
+| macOS (Apple Silicon) | `omnivec-vX.Y.Z-darwin-arm64` |
+| macOS (Intel) | `omnivec-vX.Y.Z-darwin-amd64` |
+| Windows (amd64) | `omnivec-vX.Y.Z-windows-amd64.exe` |
+| Windows (arm64) | `omnivec-vX.Y.Z-windows-arm64.exe` |
 
 ```bash
-# Make executable (Linux/macOS)
-chmod +x omnivec
-sudo mv omnivec /usr/local/bin/
+# Linux / macOS
+chmod +x omnivec-*
+sudo mv omnivec-* /usr/local/bin/omnivec
+```
 
-# Or build from source (requires Go 1.24+)
+> **macOS Gatekeeper note:** if you see *"cannot be opened because the developer cannot be verified"*, strip the quarantine flag before running:
+> ```bash
+> xattr -dr com.apple.quarantine /usr/local/bin/omnivec
+> ```
+> The quick-install script and Homebrew formula handle this automatically.
+
+### Build from source
+
+Requires Go 1.24+.
+```bash
 cd cli && go build -o ../bin/omnivec . && cd ..
 ```
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,80 @@
+<#
+.SYNOPSIS
+  OmniVec CLI installer for Windows.
+
+.DESCRIPTION
+  Downloads the OmniVec CLI for Windows (amd64 or arm64) from the GitHub
+  release and installs it to a user-writable directory. No admin required.
+
+.EXAMPLE
+  irm https://github.com/AzureCosmosDB/OmniVec/raw/main/scripts/install.ps1 | iex
+
+.EXAMPLE
+  $env:OMNIVEC_VERSION = 'v1.1.3'; irm https://github.com/AzureCosmosDB/OmniVec/raw/main/scripts/install.ps1 | iex
+
+.NOTES
+  Env vars:
+    OMNIVEC_VERSION       Pin specific version (default: latest)
+    OMNIVEC_INSTALL_DIR   Install location (default: $env:USERPROFILE\.omnivec\bin)
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$repo        = 'AzureCosmosDB/OmniVec'
+$version     = if ($env:OMNIVEC_VERSION) { $env:OMNIVEC_VERSION } else { 'latest' }
+$installDir  = if ($env:OMNIVEC_INSTALL_DIR) { $env:OMNIVEC_INSTALL_DIR } else { Join-Path $env:USERPROFILE '.omnivec\bin' }
+
+# ---------- detect arch ----------
+$arch = switch -Wildcard ($env:PROCESSOR_ARCHITECTURE) {
+  'ARM64' { 'arm64'; break }
+  default { 'amd64' }
+}
+
+# ---------- resolve version ----------
+if ($version -eq 'latest') {
+  try {
+    $latest = Invoke-RestMethod -Uri "https://api.github.com/repos/$repo/releases/latest" -UseBasicParsing
+    $version = $latest.tag_name
+  } catch {
+    Write-Error "Could not resolve latest release tag. Set `$env:OMNIVEC_VERSION explicitly."
+  }
+}
+
+$asset = "omnivec-$version-windows-$arch.exe"
+$url   = "https://github.com/$repo/releases/download/$version/$asset"
+
+Write-Host "Installing OmniVec CLI $version for windows/$arch" -ForegroundColor Cyan
+Write-Host "  source : $url"
+Write-Host "  target : $installDir\omnivec.exe"
+Write-Host ""
+
+# ---------- download ----------
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+$dest = Join-Path $installDir 'omnivec.exe'
+try {
+  Invoke-WebRequest -Uri $url -OutFile $dest -UseBasicParsing
+} catch {
+  Write-Error "Download failed. Asset may not exist for this platform: $asset"
+}
+
+# ---------- unblock (removes Zone.Identifier from MOTW) ----------
+try { Unblock-File -Path $dest -ErrorAction SilentlyContinue } catch {}
+
+Write-Host "Installed: $dest" -ForegroundColor Green
+
+# ---------- PATH guidance ----------
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+if (-not ($userPath -split ';' | Where-Object { $_ -eq $installDir })) {
+  Write-Host ""
+  Write-Host "$installDir is not on your User PATH." -ForegroundColor Yellow
+  Write-Host "Adding it now (new shells only — restart your terminal after this)."
+  [Environment]::SetEnvironmentVariable('Path', "$userPath;$installDir", 'User')
+}
+
+Write-Host ""
+& $dest --help 2>$null | Out-Null
+if ($LASTEXITCODE -eq 0 -or $LASTEXITCODE -eq 2) {
+  Write-Host "Verified - try: omnivec --help" -ForegroundColor Green
+} else {
+  Write-Warning "omnivec installed but did not run cleanly. Inspect: $dest"
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# OmniVec CLI installer (macOS + Linux)
+#
+# Usage:
+#   curl -fsSL https://github.com/AzureCosmosDB/OmniVec/raw/main/scripts/install.sh | bash
+#   curl -fsSL https://github.com/AzureCosmosDB/OmniVec/raw/main/scripts/install.sh | bash -s -- v1.1.3
+#
+# Env vars:
+#   OMNIVEC_VERSION   pin a specific version (default: latest release)
+#   OMNIVEC_INSTALL_DIR  install location (default: $HOME/.local/bin)
+#
+# What this does:
+#   1. Detects OS (darwin/linux) + arch (amd64/arm64)
+#   2. Downloads the matching omnivec binary from the GitHub release
+#   3. Strips the macOS quarantine xattr (so Gatekeeper doesn't block it)
+#   4. chmod +x and moves to INSTALL_DIR
+#   5. Prints PATH guidance if INSTALL_DIR isn't on $PATH
+
+set -euo pipefail
+
+REPO="AzureCosmosDB/OmniVec"
+VERSION="${1:-${OMNIVEC_VERSION:-latest}}"
+INSTALL_DIR="${OMNIVEC_INSTALL_DIR:-$HOME/.local/bin}"
+
+bold()  { printf "\033[1m%s\033[0m\n" "$*"; }
+green() { printf "\033[32m%s\033[0m\n" "$*"; }
+red()   { printf "\033[31m%s\033[0m\n" "$*" >&2; }
+warn()  { printf "\033[33m%s\033[0m\n" "$*" >&2; }
+
+# ---------- detect OS/arch ----------
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$OS" in
+  darwin) OS="darwin" ;;
+  linux)  OS="linux" ;;
+  *) red "Unsupported OS: $OS. Use the Windows installer or download manually."; exit 1 ;;
+esac
+
+ARCH_RAW="$(uname -m)"
+case "$ARCH_RAW" in
+  x86_64|amd64) ARCH="amd64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *) red "Unsupported architecture: $ARCH_RAW"; exit 1 ;;
+esac
+
+# ---------- resolve version ----------
+if [ "$VERSION" = "latest" ]; then
+  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' | head -1 | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+  if [ -z "$VERSION" ]; then
+    red "Could not resolve latest release tag. Set OMNIVEC_VERSION explicitly."
+    exit 1
+  fi
+fi
+
+ASSET="omnivec-${VERSION}-${OS}-${ARCH}"
+URL="https://github.com/${REPO}/releases/download/${VERSION}/${ASSET}"
+
+bold "Installing OmniVec CLI ${VERSION} for ${OS}/${ARCH}"
+echo "  source : ${URL}"
+echo "  target : ${INSTALL_DIR}/omnivec"
+echo
+
+# ---------- download ----------
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+if ! curl -fL --progress-bar -o "${TMP}/omnivec" "$URL"; then
+  red "Download failed. Asset may not exist for this platform: $ASSET"
+  exit 1
+fi
+
+# ---------- strip macOS quarantine ----------
+if [ "$OS" = "darwin" ] && command -v xattr >/dev/null 2>&1; then
+  xattr -dr com.apple.quarantine "${TMP}/omnivec" 2>/dev/null || true
+fi
+
+chmod +x "${TMP}/omnivec"
+
+# ---------- install ----------
+mkdir -p "$INSTALL_DIR"
+mv "${TMP}/omnivec" "${INSTALL_DIR}/omnivec"
+
+green "Installed: ${INSTALL_DIR}/omnivec"
+
+# ---------- PATH guidance ----------
+case ":$PATH:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *)
+    echo
+    warn "${INSTALL_DIR} is not on your PATH."
+    echo "  Add this to your shell profile (e.g. ~/.zshrc, ~/.bashrc):"
+    echo
+    echo "    export PATH=\"${INSTALL_DIR}:\$PATH\""
+    echo
+    ;;
+esac
+
+echo
+"${INSTALL_DIR}/omnivec" --help >/dev/null 2>&1 && green "Verified — try: omnivec --help"

--- a/scripts/omnivec.rb
+++ b/scripts/omnivec.rb
@@ -1,0 +1,46 @@
+# Homebrew formula for the OmniVec CLI.
+#
+# Source of truth for the Homebrew tap at:
+#   https://github.com/AzureCosmosDB/homebrew-omnivec
+#
+# This copy lives in the main repo so it ships with the source and can be
+# diffed alongside CLI changes. After every release, copy this file to
+# `Formula/omnivec.rb` in the tap repo.
+class Omnivec < Formula
+  desc "Manage OmniVec ingestion pipelines, sources, destinations and embedding models"
+  homepage "https://github.com/AzureCosmosDB/OmniVec"
+  version "1.1.3"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/AzureCosmosDB/OmniVec/releases/download/v#{version}/omnivec-v#{version}-darwin-arm64"
+      sha256 "af3edb5f4173c5726304d3dfb2fa8491ac801b3f87f29e57eb4dbbd38e0a69ed"
+    end
+    on_intel do
+      url "https://github.com/AzureCosmosDB/OmniVec/releases/download/v#{version}/omnivec-v#{version}-darwin-amd64"
+      sha256 "b7a45c3536103424e5401de9a406d5c7184632579557dfe06ec68058db96ad14"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/AzureCosmosDB/OmniVec/releases/download/v#{version}/omnivec-v#{version}-linux-arm64"
+      sha256 "d502edefafdb76c35c3858384f48e95ed7bc7e7c2248020e1e4b90ab366dc178"
+    end
+    on_intel do
+      url "https://github.com/AzureCosmosDB/OmniVec/releases/download/v#{version}/omnivec-v#{version}-linux-amd64"
+      sha256 "fe60b096207eee58e36d5e6bbe5e72109f32e3a9fd41656e9617175570e2c249"
+    end
+  end
+
+  def install
+    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
+    os   = OS.mac? ? "darwin" : "linux"
+    bin.install "omnivec-v#{version}-#{os}-#{arch}" => "omnivec"
+  end
+
+  test do
+    assert_match "omnivec", shell_output("#{bin}/omnivec --help 2>&1", 0).downcase
+  end
+end


### PR DESCRIPTION
## Summary

Resolves macOS Gatekeeper friction (`cannot be opened because the developer cannot be verified`) when users download the CLI directly from the GitHub release.

Adds three install paths:

| Path | Command |
|---|---|
| **macOS/Linux** | `curl -fsSL https://github.com/AzureCosmosDB/OmniVec/raw/main/scripts/install.sh \| bash` |
| **Homebrew** | `brew install --formula https://raw.githubusercontent.com/AzureCosmosDB/OmniVec/main/scripts/omnivec.rb` |
| **Windows** | `irm https://github.com/AzureCosmosDB/OmniVec/raw/main/scripts/install.ps1 \| iex` |

## Files

- `scripts/install.sh` -- auto-detects OS/arch, strips `com.apple.quarantine`, chmod +x, installs to `~/.local/bin` (override via OMNIVEC_INSTALL_DIR)
- `scripts/install.ps1` -- installs to %USERPROFILE%\.omnivec\bin, updates user PATH, calls Unblock-File
- `scripts/omnivec.rb` -- Homebrew formula with sha256 of all 4 mac/linux v1.1.3 assets
- `docs/cli-guide.md` -- updated install section + macOS quarantine callout
- `README.md` -- added CLI Install link in Next Steps table
