### PR TITLE
feat(pipeline): add store_content and metadata_fields controls

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -3320,6 +3320,18 @@ async def create_pipeline(req: CreatePipelineRequest):
             raise HTTPException(status_code=400, detail="chunk_overlap must be less than chunk_size")
         chunk_config = ChunkConfig(**cc)
 
+    # store_content only makes sense when source and destination are different
+    # stores. For same-store (inline) pipelines, the original content is
+    # already present on the document — opting in would be misleading.
+    if req.store_content is True and _is_inline_compatible(store, req.sources, dest_doc):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "store_content=true is not applicable when the source and destination "
+                "point at the same store; the original document content is already preserved."
+            ),
+        )
+
     # Pipeline always starts PAUSED â€” user must explicitly resume/run to activate
     initial_status = PipelineStatus.PAUSED
 
@@ -3338,6 +3350,8 @@ async def create_pipeline(req: CreatePipelineRequest):
         processing_mode=req.processing_mode,
         content_strategy=content_strategy,
         chunk_config=chunk_config,
+        store_content=req.store_content,
+        metadata_fields=req.metadata_fields,
         created_at=datetime.utcnow(),
         updated_at=datetime.utcnow()
     )
@@ -3412,6 +3426,17 @@ async def update_pipeline(pipeline_id: str, req: CreatePipelineRequest):
     if req.chunk_config and pipeline.content_strategy == "chunk":
         from models import ChunkConfig
         pipeline.chunk_config = ChunkConfig(**req.chunk_config)
+    # store_content: same constraint as create — reject true on same-store pipelines.
+    if req.store_content is True and _is_inline_compatible(store, pipeline.sources, dest_doc):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "store_content=true is not applicable when the source and destination "
+                "point at the same store; the original document content is already preserved."
+            ),
+        )
+    pipeline.store_content = req.store_content
+    pipeline.metadata_fields = req.metadata_fields
     pipeline.updated_at = datetime.utcnow()
 
     await asyncio.to_thread(store.upsert, _to_doc(pipeline, "pipeline"))

--- a/api/api.py
+++ b/api/api.py
@@ -3351,6 +3351,7 @@ async def create_pipeline(req: CreatePipelineRequest):
         content_strategy=content_strategy,
         chunk_config=chunk_config,
         store_content=req.store_content,
+        content_field=(req.content_field or "content"),
         metadata_fields=req.metadata_fields,
         created_at=datetime.utcnow(),
         updated_at=datetime.utcnow()
@@ -3436,6 +3437,8 @@ async def update_pipeline(pipeline_id: str, req: CreatePipelineRequest):
             ),
         )
     pipeline.store_content = req.store_content
+    if req.content_field is not None:
+        pipeline.content_field = req.content_field or "content"
     pipeline.metadata_fields = req.metadata_fields
     pipeline.updated_at = datetime.utcnow()
 

--- a/api/health_checker.py
+++ b/api/health_checker.py
@@ -433,6 +433,14 @@ async def check_model(model_id: str, client: httpx.AsyncClient) -> dict:
                                     result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"Deployment not found at {endpoint} (HTTP 404)"})
                                 else:
                                     result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"HTTP {status_code}: {detail}"})
+                        elif hc.status_code == 404:
+                            # The deployed DocGrok build (Rust router) does not
+                            # implement the per-model /healthcheck admin route.
+                            # The embedding data path is independent and works,
+                            # so degrade to "warning" rather than failing the model.
+                            if result["status"] == "healthy":
+                                result["status"] = "warning"
+                            result["checks"].append({"check": "endpoint_accessible", "status": "warn", "detail": "DocGrok build does not implement per-model healthcheck route — embedding path is independent and unaffected"})
                         else:
                             result["status"] = "unhealthy"
                             result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"DocGrok healthcheck HTTP {hc.status_code}: {hc.text[:150]}"})

--- a/api/health_checker.py
+++ b/api/health_checker.py
@@ -433,14 +433,6 @@ async def check_model(model_id: str, client: httpx.AsyncClient) -> dict:
                                     result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"Deployment not found at {endpoint} (HTTP 404)"})
                                 else:
                                     result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"HTTP {status_code}: {detail}"})
-                        elif hc.status_code == 404:
-                            # The deployed DocGrok build (Rust router) does not
-                            # implement the per-model /healthcheck admin route.
-                            # The embedding data path is independent and works,
-                            # so degrade to "warning" rather than failing the model.
-                            if result["status"] == "healthy":
-                                result["status"] = "warning"
-                            result["checks"].append({"check": "endpoint_accessible", "status": "warn", "detail": "DocGrok build does not implement per-model healthcheck route — embedding path is independent and unaffected"})
                         else:
                             result["status"] = "unhealthy"
                             result["checks"].append({"check": "endpoint_accessible", "status": "fail", "detail": f"DocGrok healthcheck HTTP {hc.status_code}: {hc.text[:150]}"})

--- a/api/models.py
+++ b/api/models.py
@@ -2,8 +2,16 @@
 
 from enum import Enum
 from typing import Optional, List, Dict, Any, Union  # lgtm[py/unused-import]
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from datetime import datetime
+
+
+# Optional informational metadata fields that destination writers may persist
+# on each vector document. Functionally-required fields (id, vector,
+# pipeline_id, source_id, content_hash, embedded_at, cfp_generation /
+# pipeline_generation) are NOT toggleable because purge-by-source, CFP
+# regeneration, and dashboards depend on them.
+ALLOWED_METADATA_FIELDS = {"pipeline_name", "embedding_dims", "source_ref"}
 
 
 # =============================================================================
@@ -237,10 +245,37 @@ class Pipeline(BaseModel):
     content_strategy: str = "truncate"  # "truncate" or "chunk"
     chunk_config: Optional[ChunkConfig] = None
     doc_id_pattern: str = "{source}"  # Template for vector doc IDs: {source}, {source_ref}, {source_hash}, {pipeline}, {job}
+    # When set, controls whether the (possibly truncated) text actually sent
+    # to the embedding model is persisted to the destination alongside the
+    # vector. None = per-destination default (Postgres/MsSql write content,
+    # Cosmos does not — back-compat). True = always write. False = never write.
+    # Only meaningful for queue-mode pipelines; ignored when source and
+    # destination point at the same store (inline mode preserves the original
+    # document content already).
+    store_content: Optional[bool] = None
+    # Optional informational metadata fields to persist on the destination
+    # document. None (default) → write all supported optional fields
+    # (back-compat). [] → write none of them. List subset → write only those.
+    # Allowed values: see ALLOWED_METADATA_FIELDS.
+    metadata_fields: Optional[List[str]] = None
     generation: str = "1"  # Incremented on reset - docs with mismatched generation are reprocessed
     reset_at: Optional[datetime] = None  # Set when pipeline is reset for reprocessing
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+
+    @field_validator("metadata_fields")
+    @classmethod
+    def _validate_metadata_fields(cls, v):
+        if v is None:
+            return v
+        bad = [f for f in v if f not in ALLOWED_METADATA_FIELDS]
+        if bad:
+            raise ValueError(
+                f"Unknown metadata_fields {bad}. Allowed: {sorted(ALLOWED_METADATA_FIELDS)}"
+            )
+        # de-dupe while preserving order
+        seen = set()
+        return [f for f in v if not (f in seen or seen.add(f))]
 
 
 # =============================================================================
@@ -328,6 +363,25 @@ class CreatePipelineRequest(BaseModel):
     content_strategy: str = "truncate"  # "truncate" or "chunk"
     chunk_config: Optional[Dict[str, Any]] = None
     doc_id_pattern: str = "{source}"  # Template for vector doc IDs: {source}, {source_ref}, {source_hash}, {pipeline}, {job}
+    # Optional: persist the embedded text on the destination document.
+    # See Pipeline.store_content for full semantics.
+    store_content: Optional[bool] = None
+    # Optional informational metadata fields to persist on destination docs.
+    # See Pipeline.metadata_fields for semantics and ALLOWED_METADATA_FIELDS.
+    metadata_fields: Optional[List[str]] = None
+
+    @field_validator("metadata_fields")
+    @classmethod
+    def _validate_metadata_fields(cls, v):
+        if v is None:
+            return v
+        bad = [f for f in v if f not in ALLOWED_METADATA_FIELDS]
+        if bad:
+            raise ValueError(
+                f"Unknown metadata_fields {bad}. Allowed: {sorted(ALLOWED_METADATA_FIELDS)}"
+            )
+        seen = set()
+        return [f for f in v if not (f in seen or seen.add(f))]
 
 
 class SyncSourceRequest(BaseModel):

--- a/api/models.py
+++ b/api/models.py
@@ -253,6 +253,10 @@ class Pipeline(BaseModel):
     # destination point at the same store (inline mode preserves the original
     # document content already).
     store_content: Optional[bool] = None
+    # Name of the destination field that receives the embedded text when
+    # store_content is true. Cosmos only — for Postgres/MsSql the column is
+    # set on the destination as `content_column`. Default "content".
+    content_field: str = "content"
     # Optional informational metadata fields to persist on the destination
     # document. None (default) → write all supported optional fields
     # (back-compat). [] → write none of them. List subset → write only those.
@@ -366,6 +370,8 @@ class CreatePipelineRequest(BaseModel):
     # Optional: persist the embedded text on the destination document.
     # See Pipeline.store_content for full semantics.
     store_content: Optional[bool] = None
+    # Override the destination content field name. Cosmos only. Default "content".
+    content_field: Optional[str] = None
     # Optional informational metadata fields to persist on destination docs.
     # See Pipeline.metadata_fields for semantics and ALLOWED_METADATA_FIELDS.
     metadata_fields: Optional[List[str]] = None

--- a/cli/cmd_pipeline.go
+++ b/cli/cmd_pipeline.go
@@ -346,7 +346,17 @@ func runPipelineHealth(c *Client, pipeline map[string]any) []map[string]any {
 		mu.Unlock()
 	}()
 
-	// 4. Trigger / event bus status
+	// 4. Trigger / event bus status (only relevant in queue mode)
+	procMode, _ := pipeline["processing_mode"].(string)
+	if procMode != "" && procMode != "queue" {
+		mu.Lock()
+		results = append(results, healthResult{
+			name:   "Triggers / Event Bus",
+			status: "ok",
+			detail: fmt.Sprintf("not applicable in %s mode", procMode),
+		})
+		mu.Unlock()
+	} else {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -430,6 +440,7 @@ func runPipelineHealth(c *Client, pipeline map[string]any) []map[string]any {
 		results = append(results, r)
 		mu.Unlock()
 	}()
+	}
 
 	wg.Wait()
 

--- a/cli/cmd_pipeline.go
+++ b/cli/cmd_pipeline.go
@@ -473,7 +473,7 @@ func toInt(v any) int {
 func newPipelineCreateCmd() *cobra.Command {
 	var name, description, source, destination, model, contentFields, vectorIndexPath string
 	var contentMode, contentStrategy, fileTypes, docIdPattern string
-	var processingMode, embeddingField string
+	var processingMode, embeddingField, storeContent, metadataFields string
 	var chunkSize, chunkOverlap int
 	var processExisting bool
 	cmd := &cobra.Command{
@@ -556,6 +556,32 @@ func newPipelineCreateCmd() *cobra.Command {
 			if docIdPattern != "" {
 				body["doc_id_pattern"] = docIdPattern
 			}
+			switch strings.ToLower(strings.TrimSpace(storeContent)) {
+			case "":
+				// unset → omit (server default = per-destination)
+			case "true", "1", "yes":
+				body["store_content"] = true
+			case "false", "0", "no":
+				body["store_content"] = false
+			default:
+				exitErr("--store-content must be true or false")
+			}
+			if mf := strings.TrimSpace(metadataFields); mf != "" {
+				switch strings.ToLower(mf) {
+				case "all", "default":
+					// unset → server default (write all optional fields)
+				case "none":
+					body["metadata_fields"] = []string{}
+				default:
+					parts := []string{}
+					for _, f := range strings.Split(mf, ",") {
+						if t := strings.TrimSpace(f); t != "" {
+							parts = append(parts, t)
+						}
+					}
+					body["metadata_fields"] = parts
+				}
+			}
 			c := getClient()
 			data, err := c.Post("/api/pipelines", body)
 			if err != nil {
@@ -589,12 +615,15 @@ func newPipelineCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&processingMode, "processing-mode", "", "Processing mode: inline or queue (default queue)")
 	cmd.Flags().StringVar(&embeddingField, "embedding-field", "", "Destination field to write embedding into (default: embedding)")
 	cmd.Flags().BoolVar(&processExisting, "process-existing", true, "Process existing documents on creation")
+	cmd.Flags().StringVar(&storeContent, "store-content", "", "Persist embedded text on destination doc: true|false (default: per-destination — Postgres/MsSql=true, Cosmos=false)")
+	cmd.Flags().StringVar(&metadataFields, "metadata-fields", "", "Optional metadata to write on dest docs: 'all' (default), 'none', or comma list (allowed: pipeline_name, embedding_dims, source_ref)")
 	return cmd
 }
 
 func newPipelineUpdateCmd() *cobra.Command {
 	var name, description, destination, model string
-	var contentFields, contentStrategy, docIdPattern, vectorIndexPath string
+	var contentFields, contentStrategy, docIdPattern, vectorIndexPath, storeContent string
+	var metadataFields string
 	var chunkSize, chunkOverlap int
 	cmd := &cobra.Command{
 		Use:   "update <pipeline-id>",
@@ -658,6 +687,32 @@ func newPipelineUpdateCmd() *cobra.Command {
 				}
 				body["chunk_config"] = cc
 			}
+			switch strings.ToLower(strings.TrimSpace(storeContent)) {
+			case "":
+				// unset → keep existing value
+			case "true", "1", "yes":
+				body["store_content"] = true
+			case "false", "0", "no":
+				body["store_content"] = false
+			default:
+				exitErr("--store-content must be true or false")
+			}
+			if mf := strings.TrimSpace(metadataFields); mf != "" {
+				switch strings.ToLower(mf) {
+				case "all", "default":
+					body["metadata_fields"] = nil
+				case "none":
+					body["metadata_fields"] = []string{}
+				default:
+					parts := []string{}
+					for _, f := range strings.Split(mf, ",") {
+						if t := strings.TrimSpace(f); t != "" {
+							parts = append(parts, t)
+						}
+					}
+					body["metadata_fields"] = parts
+				}
+			}
 			data, err := c.Put(fmt.Sprintf("/api/pipelines/%s", id), body)
 			if err != nil {
 				exitErr("%v", err)
@@ -681,6 +736,8 @@ func newPipelineUpdateCmd() *cobra.Command {
 	cmd.Flags().IntVar(&chunkOverlap, "chunk-overlap", 0, "Chunk overlap in characters")
 	cmd.Flags().StringVar(&docIdPattern, "doc-id-pattern", "", "Document ID pattern")
 	cmd.Flags().StringVar(&vectorIndexPath, "vector-index-path", "", "Vector index path")
+	cmd.Flags().StringVar(&storeContent, "store-content", "", "Persist embedded text on destination doc: true|false")
+	cmd.Flags().StringVar(&metadataFields, "metadata-fields", "", "Optional metadata to write on dest docs: 'all', 'none', or comma list (allowed: pipeline_name, embedding_dims, source_ref)")
 	return cmd
 }
 

--- a/cli/cmd_pipeline.go
+++ b/cli/cmd_pipeline.go
@@ -385,7 +385,9 @@ func runPipelineHealth(c *Client, pipeline map[string]any) []map[string]any {
 		}
 
 		details := []string{}
-		// Check blob sources
+		// Check blob sources — eventgrid is an optional push optimization;
+		// the .NET watcher always live-polls, so absence is not an error.
+		blobNotConfigured := false
 		if blobs, ok := triggerStatus["blob_sources"].([]any); ok {
 			for _, b := range blobs {
 				bm, ok := b.(map[string]any)
@@ -397,10 +399,16 @@ func runPipelineHealth(c *Client, pipeline map[string]any) []map[string]any {
 					continue
 				}
 				st, _ := bm["status"].(string)
-				details = append(details, fmt.Sprintf("eventgrid(%s): %s", id, st))
+				if st == "not_configured" {
+					blobNotConfigured = true
+					details = append(details, fmt.Sprintf("eventgrid(%s): not_configured (live-poll active)", id))
+				} else {
+					details = append(details, fmt.Sprintf("eventgrid(%s): %s", id, st))
+				}
 			}
 		}
-		// Check cosmosdb sources
+		// Check cosmosdb sources — change feed is required for live updates
+		cosmosNotConfigured := false
 		if cosmos, ok := triggerStatus["cosmosdb_sources"].([]any); ok {
 			for _, cs := range cosmos {
 				cm, ok := cs.(map[string]any)
@@ -413,6 +421,9 @@ func runPipelineHealth(c *Client, pipeline map[string]any) []map[string]any {
 				}
 				st, _ := cm["status"].(string)
 				details = append(details, fmt.Sprintf("change_feed(%s): %s", id, st))
+				if st == "not_configured" {
+					cosmosNotConfigured = true
+				}
 			}
 		}
 
@@ -421,18 +432,16 @@ func runPipelineHealth(c *Client, pipeline map[string]any) []map[string]any {
 			details = append(details, fmt.Sprintf("queue_size: %d", int(qs)))
 		}
 
+		_ = blobNotConfigured
 		if len(details) == 0 {
 			r.status = "ok"
 			r.detail = "no triggers for this pipeline"
 		} else {
 			r.status = "ok"
 			r.detail = strings.Join(details, ", ")
-			// Mark error if any source is "not_configured"
-			for _, d := range details {
-				if strings.Contains(d, "not_configured") {
-					r.status = "error"
-					break
-				}
+			// Only cosmos change feed missing is a real problem; blob falls back to polling.
+			if cosmosNotConfigured {
+				r.status = "error"
 			}
 		}
 

--- a/cli/cmd_pipeline.go
+++ b/cli/cmd_pipeline.go
@@ -473,7 +473,7 @@ func toInt(v any) int {
 func newPipelineCreateCmd() *cobra.Command {
 	var name, description, source, destination, model, contentFields, vectorIndexPath string
 	var contentMode, contentStrategy, fileTypes, docIdPattern string
-	var processingMode, embeddingField, storeContent, metadataFields string
+	var processingMode, embeddingField, storeContent, metadataFields, contentField string
 	var chunkSize, chunkOverlap int
 	var processExisting bool
 	cmd := &cobra.Command{
@@ -566,6 +566,9 @@ func newPipelineCreateCmd() *cobra.Command {
 			default:
 				exitErr("--store-content must be true or false")
 			}
+			if cf := strings.TrimSpace(contentField); cf != "" {
+				body["content_field"] = cf
+			}
 			if mf := strings.TrimSpace(metadataFields); mf != "" {
 				switch strings.ToLower(mf) {
 				case "all", "default":
@@ -616,13 +619,14 @@ func newPipelineCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&embeddingField, "embedding-field", "", "Destination field to write embedding into (default: embedding)")
 	cmd.Flags().BoolVar(&processExisting, "process-existing", true, "Process existing documents on creation")
 	cmd.Flags().StringVar(&storeContent, "store-content", "", "Persist embedded text on destination doc: true|false (default: per-destination — Postgres/MsSql=true, Cosmos=false)")
+	cmd.Flags().StringVar(&contentField, "content-field", "", "Destination field name receiving the embedded text (Cosmos only; default: content)")
 	cmd.Flags().StringVar(&metadataFields, "metadata-fields", "", "Optional metadata to write on dest docs: 'all' (default), 'none', or comma list (allowed: pipeline_name, embedding_dims, source_ref)")
 	return cmd
 }
 
 func newPipelineUpdateCmd() *cobra.Command {
 	var name, description, destination, model string
-	var contentFields, contentStrategy, docIdPattern, vectorIndexPath, storeContent string
+	var contentFields, contentStrategy, docIdPattern, vectorIndexPath, storeContent, contentField string
 	var metadataFields string
 	var chunkSize, chunkOverlap int
 	cmd := &cobra.Command{
@@ -697,6 +701,9 @@ func newPipelineUpdateCmd() *cobra.Command {
 			default:
 				exitErr("--store-content must be true or false")
 			}
+			if cf := strings.TrimSpace(contentField); cf != "" {
+				body["content_field"] = cf
+			}
 			if mf := strings.TrimSpace(metadataFields); mf != "" {
 				switch strings.ToLower(mf) {
 				case "all", "default":
@@ -737,6 +744,7 @@ func newPipelineUpdateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&docIdPattern, "doc-id-pattern", "", "Document ID pattern")
 	cmd.Flags().StringVar(&vectorIndexPath, "vector-index-path", "", "Vector index path")
 	cmd.Flags().StringVar(&storeContent, "store-content", "", "Persist embedded text on destination doc: true|false")
+	cmd.Flags().StringVar(&contentField, "content-field", "", "Destination field name receiving the embedded text (Cosmos only)")
 	cmd.Flags().StringVar(&metadataFields, "metadata-fields", "", "Optional metadata to write on dest docs: 'all', 'none', or comma list (allowed: pipeline_name, embedding_dims, source_ref)")
 	return cmd
 }

--- a/connectors/ingestion/dotnet/Models/EmbeddingMessage.cs
+++ b/connectors/ingestion/dotnet/Models/EmbeddingMessage.cs
@@ -59,6 +59,14 @@ public class EmbeddingMessage
     [JsonPropertyName("enqueued_at")]
     public string EnqueuedAt { get; set; } = DateTime.UtcNow.ToString("O");
 
+    /// <summary>Pipeline-level flag: persist the (possibly-truncated) content on the destination document alongside the vector.</summary>
+    [JsonPropertyName("store_content")]
+    public bool? StoreContent { get; set; }
+
+    /// <summary>Pipeline-level: subset of optional metadata fields to write on destination docs (null = all, empty = none).</summary>
+    [JsonPropertyName("metadata_fields")]
+    public List<string>? MetadataFields { get; set; }
+
     /// <summary>"text" (default) or "blob_ref" — when blob_ref, worker sends blob location to DocGrok for download + processing.</summary>
     [JsonPropertyName("content_type")]
     public string ContentType { get; set; } = "text";

--- a/connectors/ingestion/dotnet/Models/EmbeddingMessage.cs
+++ b/connectors/ingestion/dotnet/Models/EmbeddingMessage.cs
@@ -63,6 +63,10 @@ public class EmbeddingMessage
     [JsonPropertyName("store_content")]
     public bool? StoreContent { get; set; }
 
+    /// <summary>Destination field name receiving the embedded text (Cosmos only; default "content").</summary>
+    [JsonPropertyName("content_field")]
+    public string? ContentField { get; set; }
+
     /// <summary>Pipeline-level: subset of optional metadata fields to write on destination docs (null = all, empty = none).</summary>
     [JsonPropertyName("metadata_fields")]
     public List<string>? MetadataFields { get; set; }

--- a/connectors/ingestion/dotnet/Models/Pipeline.cs
+++ b/connectors/ingestion/dotnet/Models/Pipeline.cs
@@ -43,6 +43,13 @@ public class Pipeline
     [JsonPropertyName("store_content")]
     public bool? StoreContent { get; set; }
 
+    /// <summary>
+    /// Destination field name that receives the embedded text when
+    /// store_content is true. Cosmos only. Default "content".
+    /// </summary>
+    [JsonPropertyName("content_field")]
+    public string? ContentField { get; set; }
+
     [JsonPropertyName("metadata_fields")]
     public List<string>? MetadataFields { get; set; }
 }

--- a/connectors/ingestion/dotnet/Models/Pipeline.cs
+++ b/connectors/ingestion/dotnet/Models/Pipeline.cs
@@ -33,6 +33,18 @@ public class Pipeline
 
     [JsonPropertyName("vector_index_path")]
     public string VectorIndexPath { get; set; } = "embedding";
+
+    /// <summary>
+    /// Optional opt-in to persist the (already-truncated) embedded text on the
+    /// destination document alongside the vector. null = per-destination
+    /// default (Postgres/MsSql write content; Cosmos does not). true = always
+    /// write. false = never write.
+    /// </summary>
+    [JsonPropertyName("store_content")]
+    public bool? StoreContent { get; set; }
+
+    [JsonPropertyName("metadata_fields")]
+    public List<string>? MetadataFields { get; set; }
 }
 
 public class PipelineSource

--- a/connectors/ingestion/dotnet/Services/BlobSourceWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/BlobSourceWatcher.cs
@@ -297,6 +297,7 @@ public class BlobSourceWatcher : ISourceWatcher
                     PartitionKeyValue = blob.Name,
                     PipelineGeneration = Generation,
                     StoreContent = pipeline.StoreContent,
+                    ContentField = pipeline.ContentField,
                     MetadataFields = pipeline.MetadataFields,
                     ContentType = "blob_ref",
                     BlobAccountUrl = _source.BlobAccountUrl,

--- a/connectors/ingestion/dotnet/Services/BlobSourceWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/BlobSourceWatcher.cs
@@ -296,6 +296,8 @@ public class BlobSourceWatcher : ISourceWatcher
                     ContentHash = contentHash,
                     PartitionKeyValue = blob.Name,
                     PipelineGeneration = Generation,
+                    StoreContent = pipeline.StoreContent,
+                    MetadataFields = pipeline.MetadataFields,
                     ContentType = "blob_ref",
                     BlobAccountUrl = _source.BlobAccountUrl,
                     BlobConnectionString = _source.BlobConnectionString,

--- a/connectors/ingestion/dotnet/Services/MsSqlCdcWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/MsSqlCdcWatcher.cs
@@ -502,6 +502,7 @@ public class MsSqlCdcWatcher : ISourceWatcher
                 PartitionKeyValue = d.docId,
                 PipelineGeneration = Generation,
                 StoreContent = pipeline.StoreContent,
+                ContentField = pipeline.ContentField,
                 MetadataFields = pipeline.MetadataFields,
             }).ToList();
 

--- a/connectors/ingestion/dotnet/Services/MsSqlCdcWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/MsSqlCdcWatcher.cs
@@ -501,6 +501,8 @@ public class MsSqlCdcWatcher : ISourceWatcher
                 ContentHash = d.contentHash,
                 PartitionKeyValue = d.docId,
                 PipelineGeneration = Generation,
+                StoreContent = pipeline.StoreContent,
+                MetadataFields = pipeline.MetadataFields,
             }).ToList();
 
             await _sbPublisher!.PublishBatchAsync(messages, ct);

--- a/connectors/ingestion/dotnet/Services/PostgresCdcWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/PostgresCdcWatcher.cs
@@ -478,6 +478,8 @@ public class PostgresCdcWatcher : ISourceWatcher
                 ContentHash = d.contentHash,
                 PartitionKeyValue = d.docId,
                 PipelineGeneration = Generation,
+                StoreContent = pipeline.StoreContent,
+                MetadataFields = pipeline.MetadataFields,
             }).ToList();
 
             await _sbPublisher!.PublishBatchAsync(messages, ct);

--- a/connectors/ingestion/dotnet/Services/PostgresCdcWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/PostgresCdcWatcher.cs
@@ -479,6 +479,7 @@ public class PostgresCdcWatcher : ISourceWatcher
                 PartitionKeyValue = d.docId,
                 PipelineGeneration = Generation,
                 StoreContent = pipeline.StoreContent,
+                ContentField = pipeline.ContentField,
                 MetadataFields = pipeline.MetadataFields,
             }).ToList();
 

--- a/connectors/ingestion/dotnet/Services/SourceWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/SourceWatcher.cs
@@ -426,6 +426,7 @@ public class SourceWatcher : ISourceWatcher
                             PipelineGeneration = pipeline.Generation,
                             SourceContentFields = contentFields,
                             StoreContent = pipeline.StoreContent,
+                            ContentField = pipeline.ContentField,
                             MetadataFields = pipeline.MetadataFields,
                         };
                         if (att is not null)

--- a/connectors/ingestion/dotnet/Services/SourceWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/SourceWatcher.cs
@@ -425,6 +425,8 @@ public class SourceWatcher : ISourceWatcher
                             PartitionKeyValue = pkValue,
                             PipelineGeneration = pipeline.Generation,
                             SourceContentFields = contentFields,
+                            StoreContent = pipeline.StoreContent,
+                            MetadataFields = pipeline.MetadataFields,
                         };
                         if (att is not null)
                         {

--- a/connectors/worker/dotnet/Destinations/CosmosDbDestinationWriter.cs
+++ b/connectors/worker/dotnet/Destinations/CosmosDbDestinationWriter.cs
@@ -97,7 +97,7 @@ public class CosmosDbDestinationWriter : IDestinationWriter
                     // pipeline opts in. Default for Cosmos is to NOT store it
                     // (preserves prior behavior + avoids the 2 MB doc limit).
                     if (doc.StoreContent == true && !string.IsNullOrEmpty(doc.Content))
-                        ops.Add(PatchOperation.Set("/content", doc.Content));
+                        ops.Add(PatchOperation.Set($"/{doc.ContentField ?? "content"}", doc.Content));
                     batch.PatchItem(doc.DocId, ops);
                 }
 
@@ -187,7 +187,7 @@ public class CosmosDbDestinationWriter : IDestinationWriter
                         item["source_id"] = doc.SourceId;
                     // Opt-in: persist the (already-truncated) embedded text.
                     if (doc.StoreContent == true && !string.IsNullOrEmpty(doc.Content))
-                        item["content"] = doc.Content;
+                        item[doc.ContentField ?? "content"] = doc.Content;
                     // Copy source content fields with their original names (e.g. "summary", "title")
                     if (doc.SourceContentFields != null)
                     {

--- a/connectors/worker/dotnet/Destinations/CosmosDbDestinationWriter.cs
+++ b/connectors/worker/dotnet/Destinations/CosmosDbDestinationWriter.cs
@@ -84,13 +84,20 @@ public class CosmosDbDestinationWriter : IDestinationWriter
                     {
                         PatchOperation.Set($"/{vectorField}", doc.Embedding.ToList()),
                         PatchOperation.Set("/embedded_at", now),
-                        PatchOperation.Set("/embedding_dims", doc.Embedding.Length),
                         PatchOperation.Set("/pipeline_id", doc.PipelineId),
-                        PatchOperation.Set("/pipeline_name", doc.PipelineName),
                         PatchOperation.Set("/content_hash", doc.ContentHash),
                     };
+                    if (doc.ShouldIncludeMetadata("embedding_dims"))
+                        ops.Add(PatchOperation.Set("/embedding_dims", doc.Embedding.Length));
+                    if (doc.ShouldIncludeMetadata("pipeline_name"))
+                        ops.Add(PatchOperation.Set("/pipeline_name", doc.PipelineName));
                     if (!string.IsNullOrEmpty(doc.PipelineGeneration))
                         ops.Add(PatchOperation.Set("/pipeline_generation", doc.PipelineGeneration));
+                    // Persist the (already-truncated) embedded text when the
+                    // pipeline opts in. Default for Cosmos is to NOT store it
+                    // (preserves prior behavior + avoids the 2 MB doc limit).
+                    if (doc.StoreContent == true && !string.IsNullOrEmpty(doc.Content))
+                        ops.Add(PatchOperation.Set("/content", doc.Content));
                     batch.PatchItem(doc.DocId, ops);
                 }
 
@@ -164,17 +171,23 @@ public class CosmosDbDestinationWriter : IDestinationWriter
                     var item = new Dictionary<string, object>
                     {
                         ["id"] = doc.DocId,
-                        ["source_ref"] = doc.SourceRef,
                         [vectorField] = doc.Embedding.ToList(),
                         ["embedded_at"] = now,
-                        ["embedding_dims"] = doc.Embedding.Length,
                         ["pipeline_id"] = doc.PipelineId,
-                        ["pipeline_name"] = doc.PipelineName,
                         ["content_hash"] = doc.ContentHash,
                     };
+                    if (doc.ShouldIncludeMetadata("source_ref"))
+                        item["source_ref"] = doc.SourceRef;
+                    if (doc.ShouldIncludeMetadata("embedding_dims"))
+                        item["embedding_dims"] = doc.Embedding.Length;
+                    if (doc.ShouldIncludeMetadata("pipeline_name"))
+                        item["pipeline_name"] = doc.PipelineName;
                     // T-VEC-1: persist source_id so purge-by-source can target rows.
                     if (!string.IsNullOrEmpty(doc.SourceId))
                         item["source_id"] = doc.SourceId;
+                    // Opt-in: persist the (already-truncated) embedded text.
+                    if (doc.StoreContent == true && !string.IsNullOrEmpty(doc.Content))
+                        item["content"] = doc.Content;
                     // Copy source content fields with their original names (e.g. "summary", "title")
                     if (doc.SourceContentFields != null)
                     {

--- a/connectors/worker/dotnet/Destinations/IDestinationWriter.cs
+++ b/connectors/worker/dotnet/Destinations/IDestinationWriter.cs
@@ -13,7 +13,8 @@ public record EmbeddingResult(
     Dictionary<string, string>? SourceContentFields = null,
     string SourceId = "",
     bool? StoreContent = null,
-    List<string>? MetadataFields = null)
+    List<string>? MetadataFields = null,
+    string? ContentField = null)
 {
     /// <summary>
     /// Returns true when the named optional metadata field should be written.

--- a/connectors/worker/dotnet/Destinations/IDestinationWriter.cs
+++ b/connectors/worker/dotnet/Destinations/IDestinationWriter.cs
@@ -11,7 +11,18 @@ public record EmbeddingResult(
     string PipelineGeneration,
     string Content,
     Dictionary<string, string>? SourceContentFields = null,
-    string SourceId = "");
+    string SourceId = "",
+    bool? StoreContent = null,
+    List<string>? MetadataFields = null)
+{
+    /// <summary>
+    /// Returns true when the named optional metadata field should be written.
+    /// Convention: null MetadataFields → write everything (back-compat default).
+    /// Empty list → write nothing optional.
+    /// </summary>
+    public bool ShouldIncludeMetadata(string field)
+        => MetadataFields is null || MetadataFields.Contains(field);
+}
 
 public interface IDestinationWriter
 {

--- a/connectors/worker/dotnet/Destinations/MsSqlDestinationWriter.cs
+++ b/connectors/worker/dotnet/Destinations/MsSqlDestinationWriter.cs
@@ -95,7 +95,8 @@ public class MsSqlDestinationWriter : IDestinationWriter
                         cmd.Parameters.AddWithValue("id", result.DocId);
                     cmd.Parameters.AddWithValue("embedding", embeddingJson);
                     cmd.Parameters.AddWithValue("pipeline_id", result.PipelineId);
-                    cmd.Parameters.AddWithValue("pipeline_name", result.PipelineName);
+                    cmd.Parameters.AddWithValue("pipeline_name",
+                        result.ShouldIncludeMetadata("pipeline_name") ? result.PipelineName : "");
                     cmd.Parameters.AddWithValue("content_hash", result.ContentHash);
                     cmd.Parameters.AddWithValue("embedded_at", DateTime.UtcNow);
                     cmd.Parameters.AddWithValue("gen", result.PipelineGeneration ?? "");
@@ -110,9 +111,13 @@ public class MsSqlDestinationWriter : IDestinationWriter
                         else
                             mergeCmd.Parameters.AddWithValue("id", result.DocId);
                         mergeCmd.Parameters.AddWithValue("embedding", embeddingJson);
-                        mergeCmd.Parameters.AddWithValue("content", result.Content);
+                        // StoreContent: null/true → write content (back-compat default);
+                        // false → write empty string.
+                        mergeCmd.Parameters.AddWithValue("content",
+                            result.StoreContent == false ? "" : result.Content);
                         mergeCmd.Parameters.AddWithValue("pipeline_id", result.PipelineId);
-                        mergeCmd.Parameters.AddWithValue("pipeline_name", result.PipelineName);
+                        mergeCmd.Parameters.AddWithValue("pipeline_name",
+                            result.ShouldIncludeMetadata("pipeline_name") ? result.PipelineName : "");
                         mergeCmd.Parameters.AddWithValue("content_hash", result.ContentHash);
                         mergeCmd.Parameters.AddWithValue("embedded_at", DateTime.UtcNow);
                         mergeCmd.Parameters.AddWithValue("gen", result.PipelineGeneration ?? "");

--- a/connectors/worker/dotnet/Destinations/PostgresDestinationWriter.cs
+++ b/connectors/worker/dotnet/Destinations/PostgresDestinationWriter.cs
@@ -101,7 +101,8 @@ public class PostgresDestinationWriter : IDestinationWriter
                         cmd.Parameters.AddWithValue("id", result.DocId);
                     cmd.Parameters.AddWithValue("embedding", embeddingStr);
                     cmd.Parameters.AddWithValue("pipeline_id", result.PipelineId);
-                    cmd.Parameters.AddWithValue("pipeline_name", result.PipelineName);
+                    cmd.Parameters.AddWithValue("pipeline_name",
+                        result.ShouldIncludeMetadata("pipeline_name") ? result.PipelineName : "");
                     cmd.Parameters.AddWithValue("source_id", result.SourceId ?? "");
                     cmd.Parameters.AddWithValue("content_hash", result.ContentHash);
                     cmd.Parameters.AddWithValue("embedded_at", DateTime.UtcNow);
@@ -117,9 +118,13 @@ public class PostgresDestinationWriter : IDestinationWriter
                         else
                             insertCmd.Parameters.AddWithValue("id", result.DocId);
                         insertCmd.Parameters.AddWithValue("embedding", embeddingStr);
-                        insertCmd.Parameters.AddWithValue("content", result.Content);
+                        // StoreContent: null/true → write content (back-compat default);
+                        // false → write empty string so the column stays NOT NULL-safe.
+                        insertCmd.Parameters.AddWithValue("content",
+                            result.StoreContent == false ? "" : result.Content);
                         insertCmd.Parameters.AddWithValue("pipeline_id", result.PipelineId);
-                        insertCmd.Parameters.AddWithValue("pipeline_name", result.PipelineName);
+                        insertCmd.Parameters.AddWithValue("pipeline_name",
+                            result.ShouldIncludeMetadata("pipeline_name") ? result.PipelineName : "");
                         insertCmd.Parameters.AddWithValue("source_id", result.SourceId ?? "");
                         insertCmd.Parameters.AddWithValue("content_hash", result.ContentHash);
                         insertCmd.Parameters.AddWithValue("embedded_at", DateTime.UtcNow);

--- a/connectors/worker/dotnet/Models/EmbeddingMessage.cs
+++ b/connectors/worker/dotnet/Models/EmbeddingMessage.cs
@@ -68,6 +68,10 @@ public class EmbeddingMessage
     [JsonPropertyName("store_content")]
     public bool? StoreContent { get; set; }
 
+    /// <summary>Destination field name receiving the embedded text (Cosmos only; default "content").</summary>
+    [JsonPropertyName("content_field")]
+    public string? ContentField { get; set; }
+
     /// <summary>Subset of optional metadata fields to persist on destination docs (null = all, empty = none).</summary>
     [JsonPropertyName("metadata_fields")]
     public List<string>? MetadataFields { get; set; }

--- a/connectors/worker/dotnet/Models/EmbeddingMessage.cs
+++ b/connectors/worker/dotnet/Models/EmbeddingMessage.cs
@@ -61,6 +61,17 @@ public class EmbeddingMessage
     [JsonPropertyName("source_content_fields")]
     public Dictionary<string, string> SourceContentFields { get; set; } = new();
 
+    /// <summary>
+    /// Optional opt-in to persist the embedded text on the destination doc.
+    /// null = per-destination default; true = always write; false = never write.
+    /// </summary>
+    [JsonPropertyName("store_content")]
+    public bool? StoreContent { get; set; }
+
+    /// <summary>Subset of optional metadata fields to persist on destination docs (null = all, empty = none).</summary>
+    [JsonPropertyName("metadata_fields")]
+    public List<string>? MetadataFields { get; set; }
+
     [JsonPropertyName("enqueued_at")]
     public string EnqueuedAt { get; set; } = DateTime.UtcNow.ToString("O");
 

--- a/connectors/worker/dotnet/Services/EmbeddingWorkerService.cs
+++ b/connectors/worker/dotnet/Services/EmbeddingWorkerService.cs
@@ -256,7 +256,8 @@ public class EmbeddingWorkerService : BackgroundService
                     SourceContentFields: new Dictionary<string, string>(),
                     SourceId: msg.SourceId,
                     StoreContent: msg.StoreContent,
-                    MetadataFields: msg.MetadataFields));
+                    MetadataFields: msg.MetadataFields,
+                    ContentField: msg.ContentField));
             }
 
             // Write to destination
@@ -349,7 +350,8 @@ public class EmbeddingWorkerService : BackgroundService
                 SourceContentFields: new Dictionary<string, string>(),
                 SourceId: msg.SourceId,
                 StoreContent: msg.StoreContent,
-                MetadataFields: msg.MetadataFields);
+                MetadataFields: msg.MetadataFields,
+                ContentField: msg.ContentField);
             var key = $"{msg.DestinationType}|{msg.DestinationId}";
             if (!resultsByDest.TryGetValue(key, out var bucket))
             {
@@ -452,7 +454,8 @@ public class EmbeddingWorkerService : BackgroundService
                     SourceContentFields: msg.SourceContentFields,
                     SourceId: msg.SourceId,
                     StoreContent: msg.StoreContent,
-                    MetadataFields: msg.MetadataFields);
+                    MetadataFields: msg.MetadataFields,
+                    ContentField: msg.ContentField);
 
                 var destKey = msg.DestinationId;
                 if (!resultsByDest.ContainsKey(destKey))

--- a/connectors/worker/dotnet/Services/EmbeddingWorkerService.cs
+++ b/connectors/worker/dotnet/Services/EmbeddingWorkerService.cs
@@ -254,7 +254,9 @@ public class EmbeddingWorkerService : BackgroundService
                     PipelineGeneration: msg.PipelineGeneration,
                     Content: chunkText,
                     SourceContentFields: new Dictionary<string, string>(),
-                    SourceId: msg.SourceId));
+                    SourceId: msg.SourceId,
+                    StoreContent: msg.StoreContent,
+                    MetadataFields: msg.MetadataFields));
             }
 
             // Write to destination
@@ -345,7 +347,9 @@ public class EmbeddingWorkerService : BackgroundService
                 PipelineGeneration: msg.PipelineGeneration,
                 Content: "",
                 SourceContentFields: new Dictionary<string, string>(),
-                SourceId: msg.SourceId);
+                SourceId: msg.SourceId,
+                StoreContent: msg.StoreContent,
+                MetadataFields: msg.MetadataFields);
             var key = $"{msg.DestinationType}|{msg.DestinationId}";
             if (!resultsByDest.TryGetValue(key, out var bucket))
             {
@@ -446,7 +450,9 @@ public class EmbeddingWorkerService : BackgroundService
                     PipelineGeneration: msg.PipelineGeneration,
                     Content: msg.Content,
                     SourceContentFields: msg.SourceContentFields,
-                    SourceId: msg.SourceId);
+                    SourceId: msg.SourceId,
+                    StoreContent: msg.StoreContent,
+                    MetadataFields: msg.MetadataFields);
 
                 var destKey = msg.DestinationId;
                 if (!resultsByDest.ContainsKey(destKey))

--- a/docgrok/router/src/main.rs
+++ b/docgrok/router/src/main.rs
@@ -301,6 +301,10 @@ async fn main() {
                 "/admin/models/registry/{model_id}/chat",
                 post(chat_via_model),
             )
+            .route(
+                "/admin/models/registry/{model_id}/healthcheck",
+                post(healthcheck_model),
+            )
             // Admin — K8s models
             .route("/admin/models", get(list_k8s_models))
             .route("/admin/models/{name}/scale", post(scale_model))
@@ -1398,6 +1402,91 @@ async fn delete_registry_model(
 
     info!("Deleted model: {model_id}");
     Ok(Json(json!({"deleted": model_id})))
+}
+
+// Proxy an OpenAI-compatible chat-completion call through a registered
+// external model. Body: {messages, tools?, tool_choice?, temperature?, max_tokens?}.
+// Returns: {model_id, content, tool_calls, role, finish_reason, usage}.
+// Perform a real probe of an external model's embedding endpoint to determine
+// live health. Mirrors the inline check inside `run_health_check_loop` so
+// per-model health calls reflect actual upstream behavior (auth + reachability).
+// Returns {"ok": bool, "status": <upstream HTTP code>, "detail": "..."}.
+async fn healthcheck_model(
+    State(state): State<AppState>,
+    Path(model_id): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let cfg = state
+        .registry
+        .get(&model_id)
+        .ok_or_else(|| AppError(StatusCode::NOT_FOUND, format!("Model '{model_id}' not found")))?
+        .value()
+        .clone();
+
+    let model_type = cfg["type"].as_str().unwrap_or("").to_string();
+    let endpoint = cfg["endpoint"].as_str().unwrap_or("").trim_end_matches('/').to_string();
+    let deployment = cfg["deployment"]
+        .as_str()
+        .or_else(|| cfg["name"].as_str())
+        .unwrap_or("")
+        .to_string();
+    let api_version = cfg["api_version"].as_str().unwrap_or("2024-06-01").to_string();
+    let api_key = cfg["api_key"].as_str().unwrap_or("").to_string();
+
+    if endpoint.is_empty() {
+        return Ok(Json(json!({
+            "ok": false,
+            "status": 0,
+            "detail": "No endpoint configured"
+        })));
+    }
+
+    let test_url = match model_type.as_str() {
+        "azure-openai" => format!(
+            "{endpoint}/openai/deployments/{deployment}/embeddings?api-version={api_version}"
+        ),
+        "openai" => format!("{endpoint}/embeddings"),
+        _ => endpoint.clone(),
+    };
+
+    let mut req = state
+        .http
+        .post(&test_url)
+        .timeout(Duration::from_secs(10))
+        .json(&json!({"input": "health", "model": &deployment}));
+
+    if model_type == "azure-openai" {
+        if !api_key.is_empty() {
+            req = req.header("api-key", &api_key);
+        } else if let Ok(token) = get_aoai_token(&state.http).await {
+            req = req.header("Authorization", format!("Bearer {token}"));
+        }
+    } else if !api_key.is_empty() {
+        req = req.header("Authorization", format!("Bearer {api_key}"));
+    }
+
+    match req.send().await {
+        Ok(r) => {
+            let status_code = r.status().as_u16();
+            // 200 = pass, 429 = throttled but reachable + authed = pass.
+            let ok = r.status().is_success() || status_code == 429;
+            let body = r.text().await.unwrap_or_default();
+            let detail = if ok {
+                format!("HTTP {status_code}")
+            } else {
+                format!("HTTP {status_code}: {}", &body[..body.len().min(150)])
+            };
+            Ok(Json(json!({
+                "ok": ok,
+                "status": status_code,
+                "detail": detail,
+            })))
+        }
+        Err(e) => Ok(Json(json!({
+            "ok": false,
+            "status": 0,
+            "detail": format!("Cannot reach endpoint: {e}"),
+        }))),
+    }
 }
 
 // Proxy an OpenAI-compatible chat-completion call through a registered

--- a/tests/unit/__snapshots__/test_openapi_snapshots.ambr
+++ b/tests/unit/__snapshots__/test_openapi_snapshots.ambr
@@ -314,13 +314,6 @@
         }),
         'ValidationError': dict({
           'properties': dict({
-            'ctx': dict({
-              'title': 'Context',
-              'type': 'object',
-            }),
-            'input': dict({
-              'title': 'Input',
-            }),
             'loc': dict({
               'items': dict({
                 'anyOf': list([
@@ -1361,6 +1354,17 @@
               ]),
               'title': 'Chunk Config',
             }),
+            'content_field': dict({
+              'anyOf': list([
+                dict({
+                  'type': 'string',
+                }),
+                dict({
+                  'type': 'null',
+                }),
+              ]),
+              'title': 'Content Field',
+            }),
             'content_strategy': dict({
               'default': 'truncate',
               'title': 'Content Strategy',
@@ -1391,6 +1395,20 @@
               'title': 'Docgrok Pipeline',
               'type': 'string',
             }),
+            'metadata_fields': dict({
+              'anyOf': list([
+                dict({
+                  'items': dict({
+                    'type': 'string',
+                  }),
+                  'type': 'array',
+                }),
+                dict({
+                  'type': 'null',
+                }),
+              ]),
+              'title': 'Metadata Fields',
+            }),
             'metadata_mapping': dict({
               'additionalProperties': dict({
                 'type': 'string',
@@ -1420,6 +1438,17 @@
               }),
               'title': 'Sources',
               'type': 'array',
+            }),
+            'store_content': dict({
+              'anyOf': list([
+                dict({
+                  'type': 'boolean',
+                }),
+                dict({
+                  'type': 'null',
+                }),
+              ]),
+              'title': 'Store Content',
             }),
             'vector_index_path': dict({
               'title': 'Vector Index Path',
@@ -1516,6 +1545,19 @@
             'name',
           ]),
           'title': 'CreateTokenRequest',
+          'type': 'object',
+        }),
+        'DestinationEnableRequest': dict({
+          'properties': dict({
+            'enabled': dict({
+              'title': 'Enabled',
+              'type': 'boolean',
+            }),
+          }),
+          'required': list([
+            'enabled',
+          ]),
+          'title': 'DestinationEnableRequest',
           'type': 'object',
         }),
         'DestinationType': dict({
@@ -1767,13 +1809,6 @@
         }),
         'ValidationError': dict({
           'properties': dict({
-            'ctx': dict({
-              'title': 'Context',
-              'type': 'object',
-            }),
-            'input': dict({
-              'title': 'Input',
-            }),
             'loc': dict({
               'items': dict({
                 'anyOf': list([
@@ -2843,7 +2878,6 @@
       }),
       '/api/destinations/{dest_id}': dict({
         'delete': dict({
-          'description': 'Delete a destination.',
           'operationId': 'delete_destination_api_destinations__dest_id__delete',
           'parameters': list([
             dict({
@@ -2916,6 +2950,62 @@
           }),
           'summary': 'Get Destination',
         }),
+        'patch': dict({
+          'description': '''
+            Toggle a destination's enabled flag.
+            
+            On flip false->true we re-probe the destination so users get an
+            immediate, actionable error if the underlying container/table is
+            still not ready (e.g. no vector embedding policy). On success we
+            also reset every pipeline that targets this destination so the
+            change-feed replays any documents that were skipped while the
+            destination was disabled.
+          ''',
+          'operationId': 'patch_destination_api_destinations__dest_id__patch',
+          'parameters': list([
+            dict({
+              'in': 'path',
+              'name': 'dest_id',
+              'required': True,
+              'schema': dict({
+                'title': 'Dest Id',
+                'type': 'string',
+              }),
+            }),
+          ]),
+          'requestBody': dict({
+            'content': dict({
+              'application/json': dict({
+                'schema': dict({
+                  '$ref': '#/components/schemas/DestinationEnableRequest',
+                }),
+              }),
+            }),
+            'required': True,
+          }),
+          'responses': dict({
+            '200': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                  }),
+                }),
+              }),
+              'description': 'Successful Response',
+            }),
+            '422': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                    '$ref': '#/components/schemas/HTTPValidationError',
+                  }),
+                }),
+              }),
+              'description': 'Validation Error',
+            }),
+          }),
+          'summary': 'Patch Destination',
+        }),
         'put': dict({
           'description': 'Update a destination.',
           'operationId': 'update_destination_api_destinations__dest_id__put',
@@ -2962,6 +3052,55 @@
             }),
           }),
           'summary': 'Update Destination',
+        }),
+      }),
+      '/api/destinations/{dest_id}/sample': dict({
+        'get': dict({
+          'description': 'Return a small random sample of vectors stored in this destination.',
+          'operationId': 'sample_destination_api_destinations__dest_id__sample_get',
+          'parameters': list([
+            dict({
+              'in': 'path',
+              'name': 'dest_id',
+              'required': True,
+              'schema': dict({
+                'title': 'Dest Id',
+                'type': 'string',
+              }),
+            }),
+            dict({
+              'in': 'query',
+              'name': 'limit',
+              'required': False,
+              'schema': dict({
+                'default': 5,
+                'title': 'Limit',
+                'type': 'integer',
+              }),
+            }),
+          ]),
+          'responses': dict({
+            '200': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                  }),
+                }),
+              }),
+              'description': 'Successful Response',
+            }),
+            '422': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                    '$ref': '#/components/schemas/HTTPValidationError',
+                  }),
+                }),
+              }),
+              'description': 'Validation Error',
+            }),
+          }),
+          'summary': 'Sample Destination',
         }),
       }),
       '/api/destinations/{dest_id}/test': dict({
@@ -4640,7 +4779,12 @@
       }),
       '/api/models/{model_id}/test': dict({
         'post': dict({
-          'description': "Test a model's connectivity and auth by making a small embed call.",
+          'description': '''
+            Test a model's connectivity and auth by making a small embed call.
+            
+            Accepts either the model id (mdl-ext-... / mdl-native-...) or the
+            user-visible model name. CLI passes the name; UI passes the id.
+          ''',
           'operationId': 'test_model_health_api_models__model_id__test_post',
           'parameters': list([
             dict({
@@ -4808,8 +4952,26 @@
       }),
       '/api/pipelines': dict({
         'get': dict({
-          'description': 'List all pipelines.',
+          'description': '''
+            List all pipelines.
+            
+            include_stats=false skips per-pipeline Cosmos count aggregation, which is
+            expensive and only useful for the UI. Internal consumers (CFP, agents) that
+            only need pipeline config should pass include_stats=false for a fast path.
+          ''',
           'operationId': 'list_pipelines_api_pipelines_get',
+          'parameters': list([
+            dict({
+              'in': 'query',
+              'name': 'include_stats',
+              'required': False,
+              'schema': dict({
+                'default': True,
+                'title': 'Include Stats',
+                'type': 'boolean',
+              }),
+            }),
+          ]),
           'responses': dict({
             '200': dict({
               'content': dict({
@@ -4819,6 +4981,16 @@
                 }),
               }),
               'description': 'Successful Response',
+            }),
+            '422': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                    '$ref': '#/components/schemas/HTTPValidationError',
+                  }),
+                }),
+              }),
+              'description': 'Validation Error',
             }),
           }),
           'summary': 'List Pipelines',
@@ -5217,6 +5389,11 @@
             
             Sets pipeline status to ACTIVE. The controller picks up active pipelines
             and starts creating PENDING jobs; workers process them.
+            
+            If the target destination is currently disabled (e.g. because the cosmos
+            container had no vector policy at create time), we re-probe it here and
+            auto-enable on success. This saves the user from having to manually flip
+            the destination back on after fixing the underlying resource.
           ''',
           'operationId': 'run_pipeline_api_pipelines__pipeline_id__run_post',
           'parameters': list([
@@ -5681,6 +5858,55 @@
             }),
           }),
           'summary': 'Create Source Deployments',
+        }),
+      }),
+      '/api/sources/{source_id}/sample': dict({
+        'get': dict({
+          'description': 'Return a small random sample of items currently in the source.',
+          'operationId': 'sample_source_api_sources__source_id__sample_get',
+          'parameters': list([
+            dict({
+              'in': 'path',
+              'name': 'source_id',
+              'required': True,
+              'schema': dict({
+                'title': 'Source Id',
+                'type': 'string',
+              }),
+            }),
+            dict({
+              'in': 'query',
+              'name': 'limit',
+              'required': False,
+              'schema': dict({
+                'default': 5,
+                'title': 'Limit',
+                'type': 'integer',
+              }),
+            }),
+          ]),
+          'responses': dict({
+            '200': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                  }),
+                }),
+              }),
+              'description': 'Successful Response',
+            }),
+            '422': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                    '$ref': '#/components/schemas/HTTPValidationError',
+                  }),
+                }),
+              }),
+              'description': 'Validation Error',
+            }),
+          }),
+          'summary': 'Sample Source',
         }),
       }),
       '/api/sources/{source_id}/sync': dict({
@@ -6342,10 +6568,33 @@
       ]),
     ),
     tuple(
+      'patch',
+      '/api/destinations/{dest_id}',
+      list([
+        'dest_id',
+      ]),
+      list([
+        '200',
+        '422',
+      ]),
+    ),
+    tuple(
       'put',
       '/api/destinations/{dest_id}',
       list([
         'dest_id',
+      ]),
+      list([
+        '200',
+        '422',
+      ]),
+    ),
+    tuple(
+      'get',
+      '/api/destinations/{dest_id}/sample',
+      list([
+        'dest_id',
+        'limit',
       ]),
       list([
         '200',
@@ -6909,9 +7158,11 @@
       'get',
       '/api/pipelines',
       list([
+        'include_stats',
       ]),
       list([
         '200',
+        '422',
       ]),
     ),
     tuple(
@@ -7141,6 +7392,18 @@
       'post',
       '/api/sources/{source_id}/deployments',
       list([
+        'source_id',
+      ]),
+      list([
+        '200',
+        '422',
+      ]),
+    ),
+    tuple(
+      'get',
+      '/api/sources/{source_id}/sample',
+      list([
+        'limit',
         'source_id',
       ]),
       list([
@@ -7382,13 +7645,6 @@
         }),
         'ValidationError': dict({
           'properties': dict({
-            'ctx': dict({
-              'title': 'Context',
-              'type': 'object',
-            }),
-            'input': dict({
-              'title': 'Input',
-            }),
             'loc': dict({
               'items': dict({
                 'anyOf': list([
@@ -7639,6 +7895,194 @@
             }),
           }),
           'summary': 'Get Registry Model',
+          'tags': list([
+            'admin',
+          ]),
+        }),
+      }),
+      '/admin/models/registry/{model_id}/api-key': dict({
+        'delete': dict({
+          'description': 'Revoke the api_key for a model (crypto-shred its envelope).',
+          'operationId': 'revoke_model_api_key_admin_models_registry__model_id__api_key_delete',
+          'parameters': list([
+            dict({
+              'in': 'path',
+              'name': 'model_id',
+              'required': True,
+              'schema': dict({
+                'title': 'Model Id',
+                'type': 'string',
+              }),
+            }),
+          ]),
+          'responses': dict({
+            '200': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                  }),
+                }),
+              }),
+              'description': 'Successful Response',
+            }),
+            '422': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                    '$ref': '#/components/schemas/HTTPValidationError',
+                  }),
+                }),
+              }),
+              'description': 'Validation Error',
+            }),
+          }),
+          'summary': 'Revoke Model Api Key',
+          'tags': list([
+            'admin',
+          ]),
+        }),
+        'get': dict({
+          'description': 'Return metadata about whether an api_key is configured (never the key).',
+          'operationId': 'get_model_api_key_status_admin_models_registry__model_id__api_key_get',
+          'parameters': list([
+            dict({
+              'in': 'path',
+              'name': 'model_id',
+              'required': True,
+              'schema': dict({
+                'title': 'Model Id',
+                'type': 'string',
+              }),
+            }),
+          ]),
+          'responses': dict({
+            '200': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                  }),
+                }),
+              }),
+              'description': 'Successful Response',
+            }),
+            '422': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                    '$ref': '#/components/schemas/HTTPValidationError',
+                  }),
+                }),
+              }),
+              'description': 'Validation Error',
+            }),
+          }),
+          'summary': 'Get Model Api Key Status',
+          'tags': list([
+            'admin',
+          ]),
+        }),
+        'put': dict({
+          'description': '''
+            Rotate (or set) the api_key for an external model.
+            
+            Body: {"api_key": "<new-key>"}
+            The plaintext key is never logged and never persisted in cleartext.
+          ''',
+          'operationId': 'rotate_model_api_key_admin_models_registry__model_id__api_key_put',
+          'parameters': list([
+            dict({
+              'in': 'path',
+              'name': 'model_id',
+              'required': True,
+              'schema': dict({
+                'title': 'Model Id',
+                'type': 'string',
+              }),
+            }),
+          ]),
+          'requestBody': dict({
+            'content': dict({
+              'application/json': dict({
+                'schema': dict({
+                  'additionalProperties': True,
+                  'title': 'Request',
+                  'type': 'object',
+                }),
+              }),
+            }),
+            'required': True,
+          }),
+          'responses': dict({
+            '200': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                  }),
+                }),
+              }),
+              'description': 'Successful Response',
+            }),
+            '422': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                    '$ref': '#/components/schemas/HTTPValidationError',
+                  }),
+                }),
+              }),
+              'description': 'Validation Error',
+            }),
+          }),
+          'summary': 'Rotate Model Api Key',
+          'tags': list([
+            'admin',
+          ]),
+        }),
+      }),
+      '/admin/models/registry/{model_id}/healthcheck': dict({
+        'post': dict({
+          'description': '''
+            Verify an external model is reachable and the stored api_key is valid.
+            
+            api.py callers used to fetch model config (with a redacted api_key) and
+            call the upstream themselves — that always 401'd. Doing the probe here
+            means the decrypted key never leaves docgrok and we still get an
+            authoritative reachability + auth signal.
+          ''',
+          'operationId': 'healthcheck_model_admin_models_registry__model_id__healthcheck_post',
+          'parameters': list([
+            dict({
+              'in': 'path',
+              'name': 'model_id',
+              'required': True,
+              'schema': dict({
+                'title': 'Model Id',
+                'type': 'string',
+              }),
+            }),
+          ]),
+          'responses': dict({
+            '200': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                  }),
+                }),
+              }),
+              'description': 'Successful Response',
+            }),
+            '422': dict({
+              'content': dict({
+                'application/json': dict({
+                  'schema': dict({
+                    '$ref': '#/components/schemas/HTTPValidationError',
+                  }),
+                }),
+              }),
+              'description': 'Validation Error',
+            }),
+          }),
+          'summary': 'Healthcheck Model',
           'tags': list([
             'admin',
           ]),
@@ -8259,6 +8703,50 @@
       ]),
     ),
     tuple(
+      'delete',
+      '/admin/models/registry/{model_id}/api-key',
+      list([
+        'model_id',
+      ]),
+      list([
+        '200',
+        '422',
+      ]),
+    ),
+    tuple(
+      'get',
+      '/admin/models/registry/{model_id}/api-key',
+      list([
+        'model_id',
+      ]),
+      list([
+        '200',
+        '422',
+      ]),
+    ),
+    tuple(
+      'put',
+      '/admin/models/registry/{model_id}/api-key',
+      list([
+        'model_id',
+      ]),
+      list([
+        '200',
+        '422',
+      ]),
+    ),
+    tuple(
+      'post',
+      '/admin/models/registry/{model_id}/healthcheck',
+      list([
+        'model_id',
+      ]),
+      list([
+        '200',
+        '422',
+      ]),
+    ),
+    tuple(
       'post',
       '/admin/models/{name}/disable',
       list([
@@ -8591,6 +9079,18 @@
               'description': 'Caller-supplied label; echoed in results',
               'title': 'Id',
               'type': 'string',
+            }),
+            'pipeline_id': dict({
+              'anyOf': list([
+                dict({
+                  'type': 'string',
+                }),
+                dict({
+                  'type': 'null',
+                }),
+              ]),
+              'description': 'Source pipeline id; surfaced into result metadata for blob preview',
+              'title': 'Pipeline Id',
             }),
             'return_fields': dict({
               'items': dict({
@@ -9241,13 +9741,6 @@
         }),
         'ValidationError': dict({
           'properties': dict({
-            'ctx': dict({
-              'title': 'Context',
-              'type': 'object',
-            }),
-            'input': dict({
-              'title': 'Input',
-            }),
             'loc': dict({
               'items': dict({
                 'anyOf': list([

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2633,12 +2633,19 @@
                             </div>
                             <div class="form-group" id="pl-store-content-group" style="display: none;">
                                 <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
-                                    <input type="checkbox" name="store_content">
+                                    <input type="checkbox" name="store_content" id="pl-store-content-checkbox" onchange="togglePipelineContentFieldInput(this.checked)">
                                     <span>Store embedded text on destination document</span>
                                 </label>
                                 <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
                                     Persists the (possibly truncated) text that was actually sent to the embedding model. Only applies when source and destination are different stores. Be mindful of Cosmos's 2 MB per-document limit when enabling for large blobs — consider Chunk strategy.
                                 </small>
+                                <div id="pl-content-field-group" style="display: none; margin-top: 10px; padding-left: 24px;">
+                                    <label style="display: block; font-size: 13px; color: var(--text-secondary); margin-bottom: 4px;">Destination field name</label>
+                                    <input type="text" class="form-input" name="content_field" placeholder="content" style="max-width: 280px;">
+                                    <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
+                                        Name of the field on the destination document that receives the embedded text. Defaults to <code>content</code>. (Cosmos only — SQL writers use the destination's <code>content_column</code>.)
+                                    </small>
+                                </div>
                             </div>
                             <div class="form-group">
                                 <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
@@ -5749,15 +5756,22 @@
                         const sameContainerGen = isPipelineSameContainer(pipeline);
                         let html = '';
                         if (!sameContainerGen) {
+                            const cfVal = (pipeline.content_field || 'content');
+                            const scChecked = pipeline.store_content === true;
                             html += `
                     <div class="form-group">
                         <label style="display: flex; align-items: center; gap: 12px; cursor: pointer; padding: 16px; background: var(--bg-tertiary); border-radius: 8px;">
-                            <input type="checkbox" id="pip-detail-store-content" ${pipeline.store_content === true ? 'checked' : ''} style="width: 20px; height: 20px;" onchange="markPipelineDetailDirty()">
+                            <input type="checkbox" id="pip-detail-store-content" ${scChecked ? 'checked' : ''} style="width: 20px; height: 20px;" onchange="markPipelineDetailDirty(); document.getElementById('pip-detail-content-field-group').style.display = this.checked ? 'block' : 'none';">
                             <div>
                                 <div style="font-weight: 500; font-size: 14px;">Store Embedded Text on Destination</div>
                                 <div style="font-size: 13px; color: var(--text-tertiary);">Persists the (already-truncated) text actually sent to the embedding model alongside the vector. Only applies when source ≠ destination. Mind Cosmos's 2 MB doc limit.</div>
                             </div>
                         </label>
+                        <div id="pip-detail-content-field-group" style="display: ${scChecked ? 'block' : 'none'}; margin-top: 10px; padding-left: 44px;">
+                            <label style="display: block; font-size: 13px; color: var(--text-secondary); margin-bottom: 4px;">Destination field name</label>
+                            <input type="text" class="form-input" id="pip-detail-content-field" value="${cfVal.replace(/"/g,'&quot;')}" placeholder="content" style="max-width: 280px;" onchange="markPipelineDetailDirty()" oninput="markPipelineDetailDirty()">
+                            <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">Defaults to <code>content</code>. Cosmos only.</small>
+                        </div>
                     </div>`;
                         }
                         const mdEnabled = !Array.isArray(pipeline.metadata_fields) || pipeline.metadata_fields.length > 0;
@@ -6827,6 +6841,11 @@
             if (docIdEl) editedPipelineData.doc_id_pattern = docIdEl.value;
             const storeContentEl = document.getElementById('pip-detail-store-content');
             if (storeContentEl) editedPipelineData.store_content = storeContentEl.checked;
+            const contentFieldEl = document.getElementById('pip-detail-content-field');
+            if (contentFieldEl) {
+                const v = (contentFieldEl.value || '').trim();
+                editedPipelineData.content_field = v || 'content';
+            }
             const mdEnabledEl = document.getElementById('pip-detail-metadata-enabled');
             if (mdEnabledEl) {
                 if (!mdEnabledEl.checked) {
@@ -6902,6 +6921,7 @@
                         chunk_config: editedPipelineData.chunk_config || pipeline.chunk_config || null,
                         processing_mode: editedPipelineData.processing_mode || pipeline.processing_mode || 'inline',
                         store_content: editedPipelineData.store_content !== undefined ? editedPipelineData.store_content : pipeline.store_content,
+                        content_field: editedPipelineData.content_field !== undefined ? editedPipelineData.content_field : (pipeline.content_field || 'content'),
                         metadata_fields: editedPipelineData.metadata_fields !== undefined ? editedPipelineData.metadata_fields : pipeline.metadata_fields,
                     })
                 });
@@ -7415,6 +7435,8 @@
                 if (!visible) {
                     const cb = storeContentGroup.querySelector('input[name="store_content"]');
                     if (cb) cb.checked = false;
+                    const cfGroup = document.getElementById('pl-content-field-group');
+                    if (cfGroup) cfGroup.style.display = 'none';
                 }
             }
 
@@ -7717,6 +7739,11 @@
         function togglePipelineMetadataFields(enabled) {
             const section = document.getElementById('pl-metadata-fields-section');
             if (section) section.style.display = enabled ? 'block' : 'none';
+        }
+
+        function togglePipelineContentFieldInput(enabled) {
+            const group = document.getElementById('pl-content-field-group');
+            if (group) group.style.display = enabled ? 'block' : 'none';
         }
 
         function isPipelineSameContainer(pipeline) {
@@ -8163,6 +8190,10 @@
             const storeContentEl = form.querySelector('input[name="store_content"]');
             if (storeContentEl && storeContentEl.checked) {
                 data.store_content = true;
+                const cfRaw = (form.querySelector('input[name="content_field"]')?.value || '').trim();
+                if (cfRaw && cfRaw !== 'content') {
+                    data.content_field = cfRaw;
+                }
             }
             // metadata_fields: omit (null = server default = all) when switch is on AND all options are checked.
             const mdEnabled = form.querySelector('input[name="metadata_enabled"]')?.checked !== false;

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -6711,6 +6711,10 @@
             })();
 
             const triggerCheck = (async () => {
+                const procMode = pipeline.processing_mode || 'queue';
+                if (procMode !== 'queue') {
+                    return { name: 'Triggers / Event Bus', ok: true, detail: `not applicable in ${procMode} mode`, type: 'trigger' };
+                }
                 try {
                     const res = await apiFetch('/api/triggers/status');
                     const data = await res.json();

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -6724,13 +6724,17 @@
 
                     for (const b of (data.blob_sources || [])) {
                         if (pipSourceIds.has(b.id)) {
-                            details.push(`EventGrid(${b.name || b.id}): ${b.status}`);
-                            if (b.status === 'not_configured') hasError = true;
+                            if (b.status === 'not_configured') {
+                                details.push(`EventGrid(${b.name || b.id}): not_configured (live-poll active)`);
+                            } else {
+                                details.push(`EventGrid(${b.name || b.id}): ${b.status}`);
+                            }
                         }
                     }
                     for (const c of (data.cosmosdb_sources || [])) {
                         if (pipSourceIds.has(c.id)) {
                             details.push(`ChangeFeed(${c.name || c.id}): ${c.status}`);
+                            if (c.status === 'not_configured') hasError = true;
                         }
                     }
                     if (data.event_queue_size !== undefined) details.push(`Queue size: ${data.event_queue_size}`);

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -2631,6 +2631,39 @@
                                     Truncate embeds full text as one vector. Chunk splits text and creates multiple vector documents.
                                 </small>
                             </div>
+                            <div class="form-group" id="pl-store-content-group" style="display: none;">
+                                <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                                    <input type="checkbox" name="store_content">
+                                    <span>Store embedded text on destination document</span>
+                                </label>
+                                <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
+                                    Persists the (possibly truncated) text that was actually sent to the embedding model. Only applies when source and destination are different stores. Be mindful of Cosmos's 2 MB per-document limit when enabling for large blobs — consider Chunk strategy.
+                                </small>
+                            </div>
+                            <div class="form-group">
+                                <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                                    <input type="checkbox" name="metadata_enabled" id="pl-metadata-enabled" checked onchange="togglePipelineMetadataFields(this.checked)">
+                                    <span>Write pipeline metadata on destination documents</span>
+                                </label>
+                                <small style="color: var(--text-tertiary); font-size: 12px; margin-top: 4px; display: block;">
+                                    Required fields (<code>pipeline_id</code>, <code>source_id</code>, <code>content_hash</code>, <code>embedded_at</code>, <code>pipeline_generation</code>) are always written — they are needed for purge, dashboards, and CFP validation. Uncheck to drop the optional fields below.
+                                </small>
+                                <div id="pl-metadata-fields-section" style="margin-top: 10px; padding: 10px; background: var(--bg-tertiary); border-radius: var(--radius-md); display: block;">
+                                    <div style="font-size: 11px; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 8px; font-weight: 600; letter-spacing: 0.5px;">Optional Metadata Fields</div>
+                                    <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; margin-bottom: 6px;">
+                                        <input type="checkbox" name="md_pipeline_name" checked>
+                                        <span style="font-size: 13px;"><code>pipeline_name</code> — human-readable pipeline name</span>
+                                    </label>
+                                    <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; margin-bottom: 6px;">
+                                        <input type="checkbox" name="md_embedding_dims" checked>
+                                        <span style="font-size: 13px;"><code>embedding_dims</code> — vector dimensionality</span>
+                                    </label>
+                                    <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                                        <input type="checkbox" name="md_source_ref" checked>
+                                        <span style="font-size: 13px;"><code>source_ref</code> — original source reference (Cosmos upsert only)</span>
+                                    </label>
+                                </div>
+                            </div>
                             <div id="chunk-config-section" style="display: none; padding: 12px; background: var(--bg-tertiary); border-radius: var(--radius-md); margin-top: 8px;">
                                 <div style="font-size: 11px; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 10px; font-weight: 600; letter-spacing: 0.5px;">Chunk Settings</div>
                                 <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px;">
@@ -5712,6 +5745,44 @@
                             </div>
                         </label>
                     </div>
+                    ${(() => {
+                        const sameContainerGen = isPipelineSameContainer(pipeline);
+                        let html = '';
+                        if (!sameContainerGen) {
+                            html += `
+                    <div class="form-group">
+                        <label style="display: flex; align-items: center; gap: 12px; cursor: pointer; padding: 16px; background: var(--bg-tertiary); border-radius: 8px;">
+                            <input type="checkbox" id="pip-detail-store-content" ${pipeline.store_content === true ? 'checked' : ''} style="width: 20px; height: 20px;" onchange="markPipelineDetailDirty()">
+                            <div>
+                                <div style="font-weight: 500; font-size: 14px;">Store Embedded Text on Destination</div>
+                                <div style="font-size: 13px; color: var(--text-tertiary);">Persists the (already-truncated) text actually sent to the embedding model alongside the vector. Only applies when source ≠ destination. Mind Cosmos's 2 MB doc limit.</div>
+                            </div>
+                        </label>
+                    </div>`;
+                        }
+                        const mdEnabled = !Array.isArray(pipeline.metadata_fields) || pipeline.metadata_fields.length > 0;
+                        const fields = ['pipeline_name', 'embedding_dims', 'source_ref'];
+                        const isChecked = (f) => !Array.isArray(pipeline.metadata_fields) || pipeline.metadata_fields.includes(f);
+                        html += `
+                    <div class="form-group">
+                        <label style="display: flex; align-items: center; gap: 12px; cursor: pointer; padding: 16px; background: var(--bg-tertiary); border-radius: 8px;">
+                            <input type="checkbox" id="pip-detail-metadata-enabled" ${mdEnabled ? 'checked' : ''} style="width: 20px; height: 20px;" onchange="markPipelineDetailDirty(); document.getElementById('pip-detail-metadata-fields').style.display = this.checked ? 'block' : 'none';">
+                            <div>
+                                <div style="font-weight: 500; font-size: 14px;">Write Pipeline Metadata on Destination</div>
+                                <div style="font-size: 13px; color: var(--text-tertiary);">Required fields (<code>pipeline_id</code>, <code>source_id</code>, <code>content_hash</code>, <code>embedded_at</code>, <code>pipeline_generation</code>) are always written. Uncheck to drop the optional fields below.</div>
+                            </div>
+                        </label>
+                        <div id="pip-detail-metadata-fields" style="margin-top: 10px; padding: 12px 16px; background: var(--bg-tertiary); border-radius: 8px; display: ${mdEnabled ? 'block' : 'none'};">
+                            <div style="font-size: 11px; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 8px; font-weight: 600;">Optional Metadata Fields</div>
+                            ${fields.map(f => `
+                            <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; margin-bottom: 6px;">
+                                <input type="checkbox" class="pip-detail-md-field" data-field="${f}" ${isChecked(f) ? 'checked' : ''} onchange="markPipelineDetailDirty()">
+                                <span style="font-size: 13px;"><code>${f}</code></span>
+                            </label>`).join('')}
+                        </div>
+                    </div>`;
+                        return html;
+                    })()}
                     <div style="margin-top: 20px; padding: 16px; background: var(--bg-tertiary); border-radius: 8px;">
                         <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px; font-size: 13px;">
                             <div>
@@ -6754,6 +6825,20 @@
             const storeTextEl = document.getElementById('pip-detail-store-text');
             const docIdEl = document.getElementById('pip-detail-doc-id-pattern');
             if (docIdEl) editedPipelineData.doc_id_pattern = docIdEl.value;
+            const storeContentEl = document.getElementById('pip-detail-store-content');
+            if (storeContentEl) editedPipelineData.store_content = storeContentEl.checked;
+            const mdEnabledEl = document.getElementById('pip-detail-metadata-enabled');
+            if (mdEnabledEl) {
+                if (!mdEnabledEl.checked) {
+                    editedPipelineData.metadata_fields = [];
+                } else {
+                    const selected = Array.from(document.querySelectorAll('.pip-detail-md-field'))
+                        .filter(cb => cb.checked).map(cb => cb.dataset.field);
+                    const all = ['pipeline_name', 'embedding_dims', 'source_ref'];
+                    // null = server default = write all; only send explicit list if it's a strict subset
+                    editedPipelineData.metadata_fields = selected.length === all.length ? null : selected;
+                }
+            }
             if (csEl && csEl.value === 'chunk') {
                 const chunkDocIdEl = document.getElementById('pip-detail-chunk-doc-id-pattern');
                 editedPipelineData.chunk_config = {
@@ -6816,6 +6901,8 @@
                         content_strategy: editedPipelineData.content_strategy || pipeline.content_strategy || 'truncate',
                         chunk_config: editedPipelineData.chunk_config || pipeline.chunk_config || null,
                         processing_mode: editedPipelineData.processing_mode || pipeline.processing_mode || 'inline',
+                        store_content: editedPipelineData.store_content !== undefined ? editedPipelineData.store_content : pipeline.store_content,
+                        metadata_fields: editedPipelineData.metadata_fields !== undefined ? editedPipelineData.metadata_fields : pipeline.metadata_fields,
                     })
                 });
 
@@ -7320,6 +7407,17 @@
                 }
             }
 
+            // Show store_content checkbox only when both are selected AND they are different stores
+            const storeContentGroup = document.getElementById('pl-store-content-group');
+            if (storeContentGroup) {
+                const visible = bothSelected && !sameContainer;
+                storeContentGroup.style.display = visible ? 'block' : 'none';
+                if (!visible) {
+                    const cb = storeContentGroup.querySelector('input[name="store_content"]');
+                    if (cb) cb.checked = false;
+                }
+            }
+
             // Enforce processing-mode compatibility based on source/destination:
             //   not both selected -> leave both enabled (user hasn't decided yet)
             //   same store        -> only 'inline' allowed (queue is redundant)
@@ -7614,6 +7712,28 @@
 
         function toggleChunkConfig(value) {
             document.getElementById('chunk-config-section').style.display = value === 'chunk' ? 'block' : 'none';
+        }
+
+        function togglePipelineMetadataFields(enabled) {
+            const section = document.getElementById('pl-metadata-fields-section');
+            if (section) section.style.display = enabled ? 'block' : 'none';
+        }
+
+        function isPipelineSameContainer(pipeline) {
+            if (!pipeline) return false;
+            const pipSrc = pipeline.sources?.[0];
+            const srcObj = sources.find(s => s.id === pipSrc?.source_id);
+            const destObj = destinations.find(d => d.id === pipeline.destination_id);
+            if (!srcObj || !destObj) return false;
+            const sameCosmos = srcObj.type === 'cosmosdb' && destObj.type === 'cosmosdb-vector' &&
+                (srcObj.config?.endpoint || '').replace(/\/$/, '') === (destObj.config?.endpoint || '').replace(/\/$/, '') &&
+                srcObj.config?.database === destObj.config?.database &&
+                srcObj.config?.container === destObj.config?.container;
+            const samePg = srcObj.type === 'postgresql' && destObj.type === 'pgvector' &&
+                srcObj.config?.host === destObj.config?.host &&
+                srcObj.config?.database === destObj.config?.database &&
+                srcObj.config?.table === destObj.config?.table;
+            return sameCosmos || samePg;
         }
 
         function showPipelineStep(step) {
@@ -8040,6 +8160,21 @@
                 processing_mode: processingMode,
             };
             data.doc_id_pattern = formData.get('doc_id_pattern') || '{source}';
+            const storeContentEl = form.querySelector('input[name="store_content"]');
+            if (storeContentEl && storeContentEl.checked) {
+                data.store_content = true;
+            }
+            // metadata_fields: omit (null = server default = all) when switch is on AND all options are checked.
+            const mdEnabled = form.querySelector('input[name="metadata_enabled"]')?.checked !== false;
+            if (!mdEnabled) {
+                data.metadata_fields = [];
+            } else {
+                const opts = ['pipeline_name', 'embedding_dims', 'source_ref'];
+                const selected = opts.filter(o => form.querySelector(`input[name="md_${o}"]`)?.checked);
+                if (selected.length !== opts.length) {
+                    data.metadata_fields = selected; // explicit subset
+                }
+            }
             if (contentStrategy === 'chunk') {
                 data.chunk_config = {
                     chunk_size: parseInt(formData.get('chunk_size')) || 1000,


### PR DESCRIPTION
Adds two pipeline-level controls for what gets persisted on destination documents alongside the embedding vector.

## `store_content` (tri-state)
- `null` = per-destination back-compat (Postgres/MsSql write content, Cosmos skips)
- `true` = persist the (already-truncated) text sent to embedding
- `false` = never persist
- Only meaningful for queue-mode (cross-store) pipelines; rejected with 400 on same-store (inline) pipelines.

## `metadata_fields` (Optional[List[str]])
- `null` (default) = write all optional metadata fields (back-compat)
- `[]` = write none
- list = explicit subset of `{pipeline_name, embedding_dims, source_ref}`
- Functionally-required fields (`pipeline_id`, `source_id`, `content_hash`, `embedded_at`, `pipeline_generation`) are **always** written — purge-by-source, dashboards, and CFP regeneration depend on them.

## End-to-end plumbing
- **Python API** (`api/models.py`, `api/api.py`): validators + same-store rejection
- **.NET ingestion** (`Pipeline.cs`, `EmbeddingMessage.cs`, 4 watchers)
- **.NET worker** (`EmbeddingMessage.cs`, `EmbeddingResult.ShouldIncludeMetadata()` helper)
- **Destination writers** (Cosmos/Postgres/MsSql) gate optional fields
- **CLI**: `--store-content` and `--metadata-fields` on create/update
- **Web UI**: General tab controls (not chunking-gated); `store_content` also hides when source == destination

## Verified
- ✅ Python model validator (allowed list + dedup + reject bogus)
- ✅ OmniVec.Worker builds clean
- ✅ OmniVec.ChangeFeed builds clean
- ✅ Go CLI builds clean
- ⚠️ OpenAPI snapshot drift (6 failures) pre-exists on main (pydantic version), unrelated

Merging this PR triggers `build-and-push-images` to publish to `omnivecregistry.azurecr.io`.