### PR TITLE
feat(eventgrid): push-based blob ingestion via Service Bus queue + delete propagation

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -3358,7 +3358,34 @@ async def create_pipeline(req: CreatePipelineRequest):
     )
     store.upsert(_to_doc(pipeline, "pipeline"))
 
-    return {"success": True, "pipeline": pipeline}
+    # Best-effort: auto-provision Event Grid subscription for any azure-blob
+    # source backing a queue-mode pipeline. Live blob events are pushed to the
+    # Service Bus blob-events queue and consumed by BlobEventConsumer in the
+    # .NET ingestion service. Errors are non-fatal (pipeline creation still
+    # succeeds; falls back to BlobSourceWatcher poll loop).
+    auto_provision_results = []
+    if str(req.processing_mode or "").lower() == "queue":
+        for ps in (req.sources or []):
+            src_doc = store.get(ps.source_id, "source")
+            if not src_doc:
+                continue
+            src = _source_from_doc(src_doc)
+            if src.type != SourceType.AZURE_BLOB or not src.enabled:
+                continue
+            try:
+                res = await _provision_blob_eventgrid(src)
+                auto_provision_results.append({"source_id": ps.source_id, **res})
+            except Exception as e:  # lgtm[py/catch-base-exception]
+                auto_provision_results.append({
+                    "source_id": ps.source_id,
+                    "success": False,
+                    "error": f"auto-provision failed: {e}",
+                })
+
+    resp = {"success": True, "pipeline": pipeline}
+    if auto_provision_results:
+        resp["eventgrid_provisioning"] = auto_provision_results
+    return resp
 
 
 @app.put("/api/pipelines/{pipeline_id}")
@@ -4101,9 +4128,210 @@ class CreateEventGridRequest(BaseModel):
     subscription_name: Optional[str] = None
 
 
+async def _resolve_subscription_id() -> Optional[str]:
+    sub_id = os.getenv("AZURE_SUBSCRIPTION_ID")
+    if sub_id:
+        return sub_id
+    try:
+        resp = await http_client.get(
+            "http://169.254.169.254/metadata/instance/compute/subscriptionId?api-version=2021-02-01",
+            headers={"Metadata": "true"},
+            timeout=5.0,
+        )
+        return resp.text.strip('"')
+    except Exception:  # lgtm[py/catch-base-exception]
+        return None
+
+
+def _ensure_system_topic_for_storage(eventgrid_client, resource_group: str, storage_account):
+    """Ensure an EG system topic exists for the storage account with SystemAssigned identity.
+
+    Returns (system_topic_name, principal_id). Idempotent.
+    """
+    try:
+        for st in eventgrid_client.system_topics.list_by_resource_group(resource_group):
+            if (st.source or "").lower() == storage_account.id.lower():
+                if not (st.identity and getattr(st.identity, "principal_id", None)):
+                    st = eventgrid_client.system_topics.begin_create_or_update(
+                        resource_group_name=resource_group,
+                        system_topic_name=st.name,
+                        system_topic_info={
+                            "location": storage_account.location,
+                            "source": storage_account.id,
+                            "topicType": "microsoft.storage.storageaccounts",
+                            "identity": {"type": "SystemAssigned"},
+                        },
+                    ).result()
+                return st.name, (st.identity.principal_id if st.identity else None)
+    except Exception:
+        pass
+
+    topic_name = f"omnivec-stg-{storage_account.name}"
+    topic = eventgrid_client.system_topics.begin_create_or_update(
+        resource_group_name=resource_group,
+        system_topic_name=topic_name,
+        system_topic_info={
+            "location": storage_account.location,
+            "source": storage_account.id,
+            "topicType": "microsoft.storage.storageaccounts",
+            "identity": {"type": "SystemAssigned"},
+        },
+    ).result()
+    return topic.name, (topic.identity.principal_id if topic.identity else None)
+
+
+async def _provision_blob_eventgrid(source) -> dict:
+    """Provision (idempotently) an Event Grid subscription for a blob source.
+
+    Preferred mode: deliver to the Service Bus queue specified by
+    ``OMNIVEC_BLOB_EVENT_QUEUE_RESOURCE_ID`` (consumed by BlobEventConsumer).
+    Fallback mode (back-compat, no env var): WebHook to the in-cluster API.
+    """
+    from azure.identity import DefaultAzureCredential
+    from azure.mgmt.eventgrid import EventGridManagementClient
+    from azure.mgmt.storage import StorageManagementClient
+    from urllib.parse import urlparse
+
+    if source.type != SourceType.AZURE_BLOB:
+        return {"success": False, "error": "Event Grid is only for blob storage sources"}
+
+    account_url = source.config.get("account_url", "")
+    parsed = urlparse(account_url)
+    account_name = parsed.netloc.split(".")[0] if parsed.netloc else ""
+    container_name = source.config.get("container", "")
+    prefix = source.config.get("prefix", "")
+
+    if not account_name or not container_name:
+        return {"success": False, "error": "Source missing account_url or container"}
+
+    subscription_id = await _resolve_subscription_id()
+    if not subscription_id:
+        return {
+            "success": False,
+            "error": "AZURE_SUBSCRIPTION_ID not set",
+            "manual_setup": get_eventgrid_setup_commands(account_name, container_name, source.id),
+        }
+
+    credential = DefaultAzureCredential()
+    storage_client = StorageManagementClient(credential, subscription_id)
+    storage_account = None
+    resource_group = None
+    for account in storage_client.storage_accounts.list():
+        if account.name == account_name:
+            storage_account = account
+            parts = account.id.split("/")
+            rg_idx = parts.index("resourceGroups") + 1
+            resource_group = parts[rg_idx]
+            break
+    if not storage_account:
+        return {
+            "success": False,
+            "error": f"Storage account '{account_name}' not found in subscription",
+            "manual_setup": get_eventgrid_setup_commands(account_name, container_name, source.id),
+        }
+
+    eventgrid_client = EventGridManagementClient(credential, subscription_id)
+    subscription_name = f"omnivec-{source.id}"
+
+    subject_begins = f"/blobServices/default/containers/{container_name}/"
+    if prefix:
+        subject_begins = f"/blobServices/default/containers/{container_name}/blobs/{prefix}"
+    base_filter = {
+        "includedEventTypes": [
+            "Microsoft.Storage.BlobCreated",
+            "Microsoft.Storage.BlobDeleted",
+            "Microsoft.Storage.BlobRenamed",
+        ],
+        "subjectBeginsWith": subject_begins,
+        "subjectEndsWith": "",
+        "isSubjectCaseSensitive": False,
+    }
+
+    queue_resource_id = os.getenv("OMNIVEC_BLOB_EVENT_QUEUE_RESOURCE_ID", "").strip()
+
+    try:
+        if queue_resource_id:
+            # Identity-based Service Bus queue delivery (works with disableLocalAuth)
+            topic_name, _principal = _ensure_system_topic_for_storage(
+                eventgrid_client, resource_group, storage_account
+            )
+            sub_info = {
+                "deliveryWithResourceIdentity": {
+                    "identity": {"type": "SystemAssigned"},
+                    "destination": {
+                        "endpointType": "ServiceBusQueue",
+                        "properties": {"resourceId": queue_resource_id},
+                    },
+                },
+                "filter": base_filter,
+                "eventDeliverySchema": "EventGridSchema",
+            }
+            result = eventgrid_client.system_topic_event_subscriptions.begin_create_or_update(
+                resource_group_name=resource_group,
+                system_topic_name=topic_name,
+                event_subscription_name=subscription_name,
+                event_subscription_info=sub_info,
+            ).result()
+            destination_kind = "ServiceBusQueue"
+            destination_target = queue_resource_id
+        else:
+            # Legacy WebHook fallback
+            webhook_url = os.getenv("OMNIVEC_WEBHOOK_URL", "").strip()
+            if not webhook_url:
+                svc_ip = os.getenv("OMNIVEC_EXTERNAL_IP", "")
+                if svc_ip:
+                    webhook_url = f"http://{svc_ip}/api/webhooks/eventgrid"
+            if not webhook_url:
+                return {
+                    "success": False,
+                    "error": "Neither OMNIVEC_BLOB_EVENT_QUEUE_RESOURCE_ID nor OMNIVEC_WEBHOOK_URL/OMNIVEC_EXTERNAL_IP is set",
+                    "manual_setup": get_eventgrid_setup_commands(account_name, container_name, source.id),
+                }
+            sub_info = {
+                "destination": {
+                    "endpointType": "WebHook",
+                    "properties": {"endpointUrl": webhook_url},
+                },
+                "filter": base_filter,
+            }
+            result = eventgrid_client.event_subscriptions.begin_create_or_update(
+                scope=storage_account.id,
+                event_subscription_name=subscription_name,
+                event_subscription_info=sub_info,
+            ).result()
+            destination_kind = "WebHook"
+            destination_target = webhook_url
+
+        EVENT_GRID_SUBSCRIPTIONS[account_name] = subscription_name
+
+        store = get_store()
+        source.triggers = source.triggers or []
+        if "eventgrid" not in source.triggers:
+            source.triggers.append("eventgrid")
+        store.upsert(_to_doc(source, "source"))
+
+        return {
+            "success": True,
+            "message": f"Event Grid subscription '{subscription_name}' provisioned ({destination_kind})",
+            "subscription_id": result.id,
+            "subscription_name": subscription_name,
+            "storage_account": account_name,
+            "container": container_name,
+            "destination": destination_kind,
+            "target": destination_target,
+        }
+
+    except Exception as e:  # lgtm[py/stack-trace-exposure]
+        return {
+            "success": False,
+            "error": str(e),
+            "manual_setup": get_eventgrid_setup_commands(account_name, container_name, source.id),
+        }
+
+
 @app.post("/api/triggers/eventgrid/create")
 async def create_eventgrid_subscription(req: CreateEventGridRequest):
-    """Create an Event Grid subscription for a blob storage source."""
+    """Create (or update) an Event Grid subscription for a blob storage source."""
     store = get_store()
     doc = store.get(req.source_id, "source")
     if not doc:
@@ -4113,133 +4341,35 @@ async def create_eventgrid_subscription(req: CreateEventGridRequest):
     if source.type != SourceType.AZURE_BLOB:
         raise HTTPException(status_code=400, detail="Event Grid is only for blob storage sources")
 
-    try:
-        from azure.identity import DefaultAzureCredential
-        from azure.mgmt.eventgrid import EventGridManagementClient
-        from azure.mgmt.storage import StorageManagementClient
-        from urllib.parse import urlparse
+    return await _provision_blob_eventgrid(source)
 
-        credential = DefaultAzureCredential()
 
-        account_url = source.config.get("account_url", "")
-        parsed = urlparse(account_url)
-        account_name = parsed.netloc.split(".")[0]
-        container_name = source.config.get("container", "")
+@app.post("/api/triggers/eventgrid/bulk_provision")
+async def bulk_provision_eventgrid():
+    """Idempotently provision Event Grid subscriptions for every active blob source
+    that is referenced by a queue-mode pipeline. Useful for backfilling existing
+    deployments after enabling event-driven blob ingestion."""
+    store = get_store()
+    pipelines = [_pipeline_from_doc(d) for d in store.list("pipeline")]
+    source_ids = set()
+    for p in pipelines:
+        if str(getattr(p, "processing_mode", "") or "").lower() != "queue":
+            continue
+        for ps in (p.sources or []):
+            source_ids.add(ps.source_id)
 
-        subscription_id = os.getenv("AZURE_SUBSCRIPTION_ID")
-        if not subscription_id:
-            try:
-                resp = await http_client.get(
-                    "http://169.254.169.254/metadata/instance/compute/subscriptionId?api-version=2021-02-01",
-                    headers={"Metadata": "true"},
-                    timeout=5.0
-                )
-                subscription_id = resp.text.strip('"')
-            except:  # lgtm[py/empty-except]  # lgtm[py/catch-base-exception]
-                pass
+    results = []
+    for sid in source_ids:
+        doc = store.get(sid, "source")
+        if not doc:
+            continue
+        src = _source_from_doc(doc)
+        if src.type != SourceType.AZURE_BLOB or not src.enabled:
+            continue
+        res = await _provision_blob_eventgrid(src)
+        results.append({"source_id": sid, **res})
 
-        if not subscription_id:
-            return {
-                "success": False,
-                "error": "AZURE_SUBSCRIPTION_ID environment variable not set",
-                "manual_setup": get_eventgrid_setup_commands(account_name, container_name, source.id)
-            }
-
-        storage_client = StorageManagementClient(credential, subscription_id)
-
-        storage_account = None
-        resource_group = None
-        for account in storage_client.storage_accounts.list():
-            if account.name == account_name:
-                storage_account = account
-                parts = account.id.split("/")
-                rg_idx = parts.index("resourceGroups") + 1
-                resource_group = parts[rg_idx]  # lgtm[py/unused-local-variable]
-                break
-
-        if not storage_account:
-            return {
-                "success": False,
-                "error": f"Storage account '{account_name}' not found in subscription",
-                "manual_setup": get_eventgrid_setup_commands(account_name, container_name, source.id)
-            }
-
-        eventgrid_client = EventGridManagementClient(credential, subscription_id)
-
-        subscription_name = req.subscription_name or f"omnivec-{source.id}"
-
-        webhook_url = os.getenv("OMNIVEC_WEBHOOK_URL")
-        if not webhook_url:
-            svc_ip = os.getenv("OMNIVEC_EXTERNAL_IP", "")
-            if svc_ip:
-                webhook_url = f"http://{svc_ip}/api/webhooks/eventgrid"
-            else:
-                return {
-                    "success": False,
-                    "error": "OMNIVEC_WEBHOOK_URL or OMNIVEC_EXTERNAL_IP environment variable not set",
-                    "manual_setup": get_eventgrid_setup_commands(account_name, container_name, source.id)
-                }
-
-        subject_filter = {
-            "subjectBeginsWith": f"/blobServices/default/containers/{container_name}/",
-            "subjectEndsWith": "",
-            "isSubjectCaseSensitive": False
-        }
-
-        prefix = source.config.get("prefix", "")
-        if prefix:
-            subject_filter["subjectBeginsWith"] = f"/blobServices/default/containers/{container_name}/blobs/{prefix}"
-
-        event_subscription = {
-            "destination": {
-                "endpointType": "WebHook",
-                "properties": {
-                    "endpointUrl": webhook_url
-                }
-            },
-            "filter": {
-                "includedEventTypes": [
-                    "Microsoft.Storage.BlobCreated",
-                    "Microsoft.Storage.BlobDeleted"
-                ],
-                **subject_filter
-            }
-        }
-
-        result = eventgrid_client.event_subscriptions.begin_create_or_update(
-            scope=storage_account.id,
-            event_subscription_name=subscription_name,
-            event_subscription_info=event_subscription
-        ).result()
-
-        EVENT_GRID_SUBSCRIPTIONS[account_name] = subscription_name
-
-        source.triggers = source.triggers or []
-        if "eventgrid" not in source.triggers:
-            source.triggers.append("eventgrid")
-        store.upsert(_to_doc(source, "source"))
-
-        return {
-            "success": True,
-            "message": f"Event Grid subscription '{subscription_name}' created",
-            "subscription_id": result.id,
-            "storage_account": account_name,
-            "container": container_name,
-            "webhook_url": webhook_url
-        }
-
-    except Exception as e:
-        error_msg = str(e)
-        account_url = source.config.get("account_url", "")
-        parsed_url = urlparse(account_url) if account_url else None
-        account_name = parsed_url.netloc.split(".")[0] if parsed_url else "<storage-account>"
-        container_name = source.config.get("container", "<container>")
-
-        return {  # lgtm[py/stack-trace-exposure]
-            "success": False,
-            "error": error_msg,
-            "manual_setup": get_eventgrid_setup_commands(account_name, container_name, source.id)
-        }
+    return {"count": len(results), "results": results}
 
 
 @app.delete("/api/triggers/eventgrid/{source_id}")

--- a/api/api.py
+++ b/api/api.py
@@ -4306,8 +4306,8 @@ async def _provision_blob_eventgrid(source) -> dict:
 
         store = get_store()
         source.triggers = source.triggers or []
-        if "eventgrid" not in source.triggers:
-            source.triggers.append("eventgrid")
+        if "event-grid" not in source.triggers and "eventgrid" not in source.triggers:
+            source.triggers.append("event-grid")
         store.upsert(_to_doc(source, "source"))
 
         return {
@@ -4418,8 +4418,8 @@ async def delete_eventgrid_subscription(source_id: str):
 
         EVENT_GRID_SUBSCRIPTIONS.pop(account_name, None)
 
-        if source.triggers and "eventgrid" in source.triggers:
-            source.triggers.remove("eventgrid")
+        if source.triggers and ("eventgrid" in source.triggers or "event-grid" in source.triggers):
+            source.triggers = [t for t in source.triggers if t not in ("eventgrid", "event-grid")]
         store.upsert(_to_doc(source, "source"))
 
         return {"success": True, "message": f"Event Grid subscription '{subscription_name}' deleted"}

--- a/api/models.py
+++ b/api/models.py
@@ -204,6 +204,16 @@ class Source(BaseModel):
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 
+    @field_validator("triggers", mode="before")
+    @classmethod
+    def _normalize_triggers(cls, v):
+        # Tolerate legacy persisted form "eventgrid" (no hyphen) so existing
+        # documents created before the TriggerType enum was tightened still
+        # validate. New writes use the canonical "event-grid".
+        if isinstance(v, list):
+            return [("event-grid" if t == "eventgrid" else t) for t in v]
+        return v
+
 
 class Destination(BaseModel):
     id: Optional[str] = None

--- a/connectors/ingestion/dotnet/Configuration/ChangeFeedOptions.cs
+++ b/connectors/ingestion/dotnet/Configuration/ChangeFeedOptions.cs
@@ -68,4 +68,21 @@ public class ChangeFeedOptions
 
     /// <summary>When true, this process watches Azure Blob sources (default: true).</summary>
     public bool EnableBlobSources { get; set; } = true;
+
+    /// <summary>When true, BlobEventConsumer consumes blob events from the
+    /// <see cref="BlobEventQueueName"/> Service Bus queue (default: false).</summary>
+    public bool BlobEventConsumerEnabled { get; set; } = false;
+
+    /// <summary>Service Bus queue name receiving Event Grid blob events
+    /// (default: "blob-events"). Used when BlobEventConsumerEnabled=true.</summary>
+    public string BlobEventQueueName { get; set; } = "blob-events";
+
+    /// <summary>When false, BlobSourceWatcher skips the Phase 2 live polling
+    /// loop (still runs Phase 1 prefill). Set false once Event Grid push
+    /// (BlobEventConsumer) is taking over live updates. Default true for
+    /// back-compat.</summary>
+    public bool BlobLivePollingEnabled { get; set; } = true;
+
+    /// <summary>Max concurrent message handlers for BlobEventConsumer.</summary>
+    public int BlobEventConsumerConcurrency { get; set; } = 8;
 }

--- a/connectors/ingestion/dotnet/Models/EmbeddingMessage.cs
+++ b/connectors/ingestion/dotnet/Models/EmbeddingMessage.cs
@@ -90,4 +90,9 @@ public class EmbeddingMessage
     /// <summary>Blob name (path within container)</summary>
     [JsonPropertyName("blob_name")]
     public string? BlobName { get; set; }
+
+    /// <summary>"upsert" (default) or "delete". When "delete", the worker
+    /// removes all destination documents matching source_id + source_ref.</summary>
+    [JsonPropertyName("message_type")]
+    public string MessageType { get; set; } = "upsert";
 }

--- a/connectors/ingestion/dotnet/Program.cs
+++ b/connectors/ingestion/dotnet/Program.cs
@@ -61,6 +61,7 @@ builder.Services.AddSingleton<ContentHasher>();
 builder.Services.AddSingleton<ServiceBusPublisher>();
 builder.Services.AddSingleton<SourceWatcherManager>();
 builder.Services.AddHostedService<SourceDiscoveryService>();
+builder.Services.AddHostedService<BlobEventConsumer>();
 
 var host = builder.Build();
 

--- a/connectors/ingestion/dotnet/Services/BlobEventConsumer.cs
+++ b/connectors/ingestion/dotnet/Services/BlobEventConsumer.cs
@@ -1,0 +1,345 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Azure.Identity;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Options;
+using OmniVec.ChangeFeed.Configuration;
+using OmniVec.ChangeFeed.Models;
+
+namespace OmniVec.ChangeFeed.Services;
+
+/// <summary>
+/// Consumes Event Grid blob events from the configured Service Bus queue
+/// (default: "blob-events"), maps each event to active azure-blob sources +
+/// queue-mode pipelines, and republishes self-contained <see cref="EmbeddingMessage"/>s
+/// onto the existing embeddings topic for the worker to process.
+///
+/// Replaces the BlobSourceWatcher Phase 2 polling loop for live updates.
+/// (Phase 1 prefill still runs once on watcher start to backfill existing blobs.)
+///
+/// Event schema: Azure Event Grid native schema delivered to Service Bus.
+/// Each SB message body is a JSON array with a single EG event (Azure default).
+/// </summary>
+public class BlobEventConsumer : BackgroundService
+{
+    private readonly ChangeFeedOptions _options;
+    private readonly OmniVecApiClient _apiClient;
+    private readonly ServiceBusPublisher _publisher;
+    private readonly ContentHasher _hasher;
+    private readonly ILogger<BlobEventConsumer> _logger;
+
+    private ServiceBusClient? _client;
+    private ServiceBusProcessor? _processor;
+
+    // Live snapshots refreshed by background polling. Volatile reads are fine
+    // for whole-reference swaps.
+    private volatile List<Source> _blobSources = new();
+    private volatile List<Pipeline> _pipelines = new();
+    private volatile List<Destination> _destinations = new();
+
+    // Recent (url + etag) dedupe — protects against duplicate EG redeliveries
+    // and prefill/live overlap. Capacity-bounded.
+    private readonly ConcurrentDictionary<string, byte> _recent = new();
+    private const int RecentCap = 50_000;
+
+    public BlobEventConsumer(
+        IOptions<ChangeFeedOptions> options,
+        OmniVecApiClient apiClient,
+        ServiceBusPublisher publisher,
+        ContentHasher hasher,
+        ILogger<BlobEventConsumer> logger)
+    {
+        _options = options.Value;
+        _apiClient = apiClient;
+        _publisher = publisher;
+        _hasher = hasher;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken ct)
+    {
+        if (!_options.BlobEventConsumerEnabled)
+        {
+            _logger.LogInformation("BlobEventConsumer disabled (ChangeFeed__BlobEventConsumerEnabled=false)");
+            await Task.Delay(Timeout.Infinite, ct);
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(_options.ServiceBusNamespace))
+        {
+            _logger.LogWarning("BlobEventConsumer enabled but ServiceBusNamespace is empty — staying idle");
+            await Task.Delay(Timeout.Infinite, ct);
+            return;
+        }
+
+        await Task.Delay(TimeSpan.FromSeconds(5), ct); // let API come up
+
+        _client = new ServiceBusClient(_options.ServiceBusNamespace, new DefaultAzureCredential());
+        _processor = _client.CreateProcessor(_options.BlobEventQueueName, new ServiceBusProcessorOptions
+        {
+            MaxConcurrentCalls = Math.Max(1, _options.BlobEventConsumerConcurrency),
+            AutoCompleteMessages = false,
+            ReceiveMode = ServiceBusReceiveMode.PeekLock,
+            PrefetchCount = 32,
+        });
+        _processor.ProcessMessageAsync += HandleMessageAsync;
+        _processor.ProcessErrorAsync += HandleErrorAsync;
+
+        _ = Task.Run(() => RefreshLoopAsync(ct), ct);
+
+        await _processor.StartProcessingAsync(ct);
+        _logger.LogInformation(
+            "BlobEventConsumer started: {Ns}/{Queue} (concurrency={C})",
+            _options.ServiceBusNamespace, _options.BlobEventQueueName,
+            _options.BlobEventConsumerConcurrency);
+
+        try { await Task.Delay(Timeout.Infinite, ct); }
+        catch (OperationCanceledException) { }
+        finally
+        {
+            try { await _processor.StopProcessingAsync(CancellationToken.None); } catch { }
+            try { await _processor.DisposeAsync(); } catch { }
+            try { await _client.DisposeAsync(); } catch { }
+        }
+    }
+
+    private async Task RefreshLoopAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var sources = await _apiClient.GetSourcesByTypesAsync(new[] { "azure-blob" }, ct);
+                var pipelines = await _apiClient.GetActivePipelinesAsync(ct);
+                var destinations = await _apiClient.GetDestinationsAsync(ct);
+                _blobSources = sources;
+                _pipelines = pipelines;
+                _destinations = destinations;
+            }
+            catch (OperationCanceledException) { break; }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "BlobEventConsumer snapshot refresh failed");
+            }
+            try { await Task.Delay(TimeSpan.FromSeconds(_options.SourcePollIntervalSeconds), ct); }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+
+    private Task HandleErrorAsync(ProcessErrorEventArgs args)
+    {
+        _logger.LogError(args.Exception,
+            "BlobEventConsumer SB error src={Source} ent={Entity}",
+            args.ErrorSource, args.EntityPath);
+        return Task.CompletedTask;
+    }
+
+    private async Task HandleMessageAsync(ProcessMessageEventArgs args)
+    {
+        var ct = args.CancellationToken;
+        try
+        {
+            var body = args.Message.Body.ToString();
+            var events = ParseEvents(body);
+            if (events.Count == 0)
+            {
+                await args.CompleteMessageAsync(args.Message, ct);
+                return;
+            }
+
+            var batch = new List<EmbeddingMessage>();
+            foreach (var ev in events)
+            {
+                batch.AddRange(BuildEmbeddingMessages(ev));
+            }
+
+            if (batch.Count > 0)
+            {
+                await _publisher.PublishBatchAsync(batch, ct);
+                _logger.LogInformation(
+                    "BlobEventConsumer fanned out {Count} embedding message(s) from {Events} blob event(s) [msgId={Id}]",
+                    batch.Count, events.Count, args.Message.MessageId);
+            }
+            else
+            {
+                _logger.LogDebug("BlobEventConsumer: no matching sources/pipelines for {Events} event(s) [msgId={Id}]",
+                    events.Count, args.Message.MessageId);
+            }
+
+            await args.CompleteMessageAsync(args.Message, ct);
+        }
+        catch (OperationCanceledException) { /* shutdown */ }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "BlobEventConsumer handler failed for msg {Id}, abandoning", args.Message.MessageId);
+            try { await args.AbandonMessageAsync(args.Message, cancellationToken: ct); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// SB queue receives Event Grid native schema. Body can be either a single
+    /// EG event object or an array of events (Azure currently sends array form
+    /// for system topic SB deliveries). Also supports CloudEvents 1.0 schema as
+    /// a fallback in case the subscription is reconfigured.
+    /// </summary>
+    internal static List<BlobEventGridEvent> ParseEvents(string body)
+    {
+        var results = new List<BlobEventGridEvent>();
+        if (string.IsNullOrWhiteSpace(body)) return results;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            var root = doc.RootElement;
+            if (root.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in root.EnumerateArray())
+                {
+                    var ev = ParseOne(item);
+                    if (ev is not null) results.Add(ev);
+                }
+            }
+            else if (root.ValueKind == JsonValueKind.Object)
+            {
+                var ev = ParseOne(root);
+                if (ev is not null) results.Add(ev);
+            }
+        }
+        catch (JsonException) { /* malformed payload — caller logs */ }
+        return results;
+    }
+
+    private static BlobEventGridEvent? ParseOne(JsonElement el)
+    {
+        // EG schema fields: eventType, subject, data.{url,api,eTag,contentType,...}
+        // CloudEvents schema fields: type, subject, data.{...}
+        string? eventType = TryGetString(el, "eventType") ?? TryGetString(el, "type");
+        string? subject = TryGetString(el, "subject");
+        if (string.IsNullOrEmpty(eventType) || string.IsNullOrEmpty(subject)) return null;
+        if (!el.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Object)
+            return null;
+
+        return new BlobEventGridEvent
+        {
+            EventType = eventType!,
+            Subject = subject!,
+            Url = TryGetString(data, "url") ?? "",
+            ETag = TryGetString(data, "eTag") ?? "",
+            Api = TryGetString(data, "api") ?? "",
+            ContentType = TryGetString(data, "contentType") ?? "",
+        };
+    }
+
+    private static string? TryGetString(JsonElement el, string name)
+        => el.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    private List<EmbeddingMessage> BuildEmbeddingMessages(BlobEventGridEvent ev)
+    {
+        var output = new List<EmbeddingMessage>();
+        if (string.IsNullOrEmpty(ev.Url)) return output;
+
+        // Derive (account, container, blobName) from data.url
+        // e.g. https://acct.blob.core.windows.net/container/path/to/blob.pdf
+        if (!Uri.TryCreate(ev.Url, UriKind.Absolute, out var uri)) return output;
+        var accountName = uri.Host.Split('.').FirstOrDefault() ?? "";
+        var segments = uri.AbsolutePath.TrimStart('/').Split('/', 2);
+        if (segments.Length < 2 || string.IsNullOrEmpty(accountName)) return output;
+        var container = segments[0];
+        var blobName = Uri.UnescapeDataString(segments[1]);
+
+        var isDelete = string.Equals(ev.EventType, "Microsoft.Storage.BlobDeleted", StringComparison.OrdinalIgnoreCase);
+        var isRename = string.Equals(ev.EventType, "Microsoft.Storage.BlobRenamed", StringComparison.OrdinalIgnoreCase);
+
+        // Dedupe upsert events by (url + etag). Delete events always pass.
+        if (!isDelete)
+        {
+            var key = $"{ev.Url}:{ev.ETag}";
+            if (!_recent.TryAdd(key, 1)) return output;
+            if (_recent.Count > RecentCap)
+            {
+                // Cheap pruning: clear half on overflow (no LRU ordering needed)
+                foreach (var k in _recent.Keys.Take(RecentCap / 2))
+                    _recent.TryRemove(k, out _);
+            }
+        }
+
+        // Find matching sources (account_url host startsWith accountName + container match + optional prefix match)
+        var matchingSources = new List<Source>();
+        foreach (var s in _blobSources)
+        {
+            if (!s.Enabled) continue;
+            if (!string.Equals(s.BlobContainer, container, StringComparison.OrdinalIgnoreCase)) continue;
+            if (!string.IsNullOrEmpty(s.BlobAccountUrl) &&
+                !s.BlobAccountUrl.Contains(accountName + ".", StringComparison.OrdinalIgnoreCase))
+                continue;
+            var prefix = s.BlobPrefix ?? "";
+            if (!string.IsNullOrEmpty(prefix) &&
+                !blobName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                continue;
+            var fileExt = "." + (s.BlobFileType ?? "pdf").TrimStart('.');
+            if (!blobName.EndsWith(fileExt, StringComparison.OrdinalIgnoreCase)) continue;
+            matchingSources.Add(s);
+        }
+        if (matchingSources.Count == 0) return output;
+
+        foreach (var src in matchingSources)
+        {
+            var relevantPipelines = _pipelines
+                .Where(p => string.Equals(p.ProcessingMode, "queue", StringComparison.OrdinalIgnoreCase))
+                .Where(p => p.Sources.Any(ps => ps.SourceId == src.Id))
+                .ToList();
+            foreach (var pipeline in relevantPipelines)
+            {
+                var dest = _destinations.FirstOrDefault(d => d.Id == pipeline.DestinationId);
+                if (dest is null) continue;
+
+                var blobKey = $"{blobName}:{ev.ETag}";
+                var contentHash = _hasher.ComputeHash(blobKey);
+
+                output.Add(new EmbeddingMessage
+                {
+                    PipelineId = pipeline.Id,
+                    PipelineName = pipeline.Name,
+                    DocgrokPipeline = pipeline.DocgrokPipeline,
+                    SourceId = src.Id,
+                    SourceRef = blobName,
+                    DestinationId = dest.Id,
+                    DestinationType = dest.Type,
+                    DestinationConfig = dest.Config,
+                    Content = "",
+                    ContentHash = contentHash,
+                    PartitionKeyValue = blobName,
+                    PipelineGeneration = "eventgrid",
+                    StoreContent = pipeline.StoreContent,
+                    ContentField = pipeline.ContentField,
+                    MetadataFields = pipeline.MetadataFields,
+                    ContentType = "blob_ref",
+                    BlobAccountUrl = src.BlobAccountUrl,
+                    BlobConnectionString = src.BlobConnectionString,
+                    BlobContainer = src.BlobContainer,
+                    BlobName = blobName,
+                    MessageType = isDelete ? "delete" : "upsert",
+                });
+            }
+        }
+
+        if (isRename)
+        {
+            // BlobRenamed delivers the new url; if we wanted to also delete the
+            // old doc we'd need data.destinationUrl/sourceUrl handling. Skipping
+            // the old-name delete for now — orphans get cleaned by user reset.
+        }
+
+        return output;
+    }
+}
+
+/// <summary>Minimal projection of an Event Grid blob event needed by the consumer.</summary>
+internal class BlobEventGridEvent
+{
+    public string EventType { get; set; } = "";
+    public string Subject { get; set; } = "";
+    public string Url { get; set; } = "";
+    public string ETag { get; set; } = "";
+    public string Api { get; set; } = "";
+    public string ContentType { get; set; } = "";
+}

--- a/connectors/ingestion/dotnet/Services/BlobSourceWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/BlobSourceWatcher.cs
@@ -138,7 +138,16 @@ public class BlobSourceWatcher : ISourceWatcher
         if (_prefillDone)
             _logger.LogInformation("Blob prefill complete for {Source}, switching to live polling", _source.Name);
 
-        // Phase 2: Live polling — check for new/modified blobs
+        // Phase 2: Live polling — disabled when Event Grid push is taking over
+        // (BlobEventConsumer consumes BlobCreated/Renamed/Deleted from SB queue).
+        if (!_options.BlobLivePollingEnabled)
+        {
+            _logger.LogInformation(
+                "Blob live polling disabled for {Source} (BlobLivePollingEnabled=false); relying on Event Grid push",
+                _source.Name);
+            return;
+        }
+
         _lastPollTime = DateTimeOffset.UtcNow;
         while (!ct.IsCancellationRequested)
         {

--- a/connectors/worker/dotnet/Destinations/CosmosDbDestinationWriter.cs
+++ b/connectors/worker/dotnet/Destinations/CosmosDbDestinationWriter.cs
@@ -246,4 +246,86 @@ public class CosmosDbDestinationWriter : IDestinationWriter
                 MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(300),
             }));
     }
+
+    /// <summary>
+    /// Delete every destination document matching (source_id, source_ref).
+    /// Used by BlobEventConsumer to propagate BlobDeleted events.
+    /// Queries by source_id+source_ref so it removes all chunks
+    /// (doc_id is "{source_ref}" or "{source_ref}-chunk-N").
+    /// </summary>
+    public async Task DeleteByRefAsync(
+        Dictionary<string, object> config,
+        List<DeleteRequest> requests,
+        CancellationToken ct)
+    {
+        if (requests.Count == 0) return;
+        var endpoint = config["endpoint"]?.ToString() ?? "";
+        var database = config["database"]?.ToString() ?? "";
+        var containerName = config["container"]?.ToString() ?? "";
+        var client = GetOrCreateClient(endpoint);
+        var container = client.GetDatabase(database).GetContainer(containerName);
+
+        foreach (var req in requests)
+        {
+            try
+            {
+                var query = new QueryDefinition(
+                    "SELECT c.id FROM c WHERE c.source_id = @sid AND c.source_ref = @ref")
+                    .WithParameter("@sid", req.SourceId)
+                    .WithParameter("@ref", req.SourceRef);
+                var pk = new PartitionKey(req.PartitionKeyValue);
+                using var iter = container.GetItemQueryIterator<DeletedIdDoc>(
+                    query,
+                    requestOptions: new QueryRequestOptions { PartitionKey = pk });
+
+                var ids = new List<string>();
+                while (iter.HasMoreResults)
+                {
+                    var page = await iter.ReadNextAsync(ct);
+                    foreach (var d in page) if (!string.IsNullOrEmpty(d.Id)) ids.Add(d.Id);
+                }
+
+                if (ids.Count == 0)
+                {
+                    _logger.LogInformation(
+                        "Delete: no Cosmos docs for source_id={SrcId} source_ref={Ref}",
+                        req.SourceId, req.SourceRef);
+                    continue;
+                }
+
+                for (int i = 0; i < ids.Count; i += 100)
+                {
+                    var chunk = ids.Skip(i).Take(100).ToList();
+                    var batch = container.CreateTransactionalBatch(pk);
+                    foreach (var id in chunk) batch.DeleteItem(id);
+                    using var resp = await batch.ExecuteAsync(ct);
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        _logger.LogWarning(
+                            "Cosmos delete batch status={Status} for src={SrcId} ref={Ref}",
+                            resp.StatusCode, req.SourceId, req.SourceRef);
+                    }
+                }
+                _logger.LogInformation(
+                    "Deleted {Count} Cosmos doc(s) for source_id={SrcId} source_ref={Ref}",
+                    ids.Count, req.SourceId, req.SourceRef);
+            }
+            catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                // Already deleted — fine
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Cosmos delete failed for src={SrcId} ref={Ref}",
+                    req.SourceId, req.SourceRef);
+                throw;
+            }
+        }
+    }
+
+    private sealed class DeletedIdDoc
+    {
+        [Newtonsoft.Json.JsonProperty("id")]
+        public string Id { get; set; } = "";
+    }
 }

--- a/connectors/worker/dotnet/Destinations/IDestinationWriter.cs
+++ b/connectors/worker/dotnet/Destinations/IDestinationWriter.cs
@@ -33,4 +33,21 @@ public interface IDestinationWriter
         Dictionary<string, object> config,
         List<EmbeddingResult> results,
         CancellationToken ct);
+
+    /// <summary>
+    /// Remove all destination documents matching (source_id, source_ref) for the
+    /// given pipeline. Used by Event-Grid-driven blob delete propagation.
+    /// Default implementation is a no-op so existing writers compile without
+    /// change; destinations that can support deletes (e.g. Cosmos) override it.
+    /// </summary>
+    Task DeleteByRefAsync(
+        Dictionary<string, object> config,
+        List<DeleteRequest> requests,
+        CancellationToken ct) => Task.CompletedTask;
 }
+
+public record DeleteRequest(
+    string SourceId,
+    string SourceRef,
+    string PartitionKeyValue,
+    string PipelineId);

--- a/connectors/worker/dotnet/Models/EmbeddingMessage.cs
+++ b/connectors/worker/dotnet/Models/EmbeddingMessage.cs
@@ -98,4 +98,9 @@ public class EmbeddingMessage
     /// <summary>Blob name (path within container)</summary>
     [JsonPropertyName("blob_name")]
     public string? BlobName { get; set; }
+
+    /// <summary>"upsert" (default) or "delete". When "delete", the worker
+    /// removes all destination documents matching source_id + source_ref.</summary>
+    [JsonPropertyName("message_type")]
+    public string MessageType { get; set; } = "upsert";
 }

--- a/connectors/worker/dotnet/Services/EmbeddingWorkerService.cs
+++ b/connectors/worker/dotnet/Services/EmbeddingWorkerService.cs
@@ -125,6 +125,20 @@ public class EmbeddingWorkerService : BackgroundService
 
                 if (items.Count == 0) continue;
 
+                // Split out delete messages (BlobDeleted via Event Grid). Deletes
+                // are grouped by destination and dispatched to the writer's
+                // DeleteByRefAsync — no embedding / DocGrok call needed.
+                var deleteItems = items.Where(i => string.Equals(i.msg.MessageType, "delete",
+                    StringComparison.OrdinalIgnoreCase)).ToList();
+                items = items.Where(i => !string.Equals(i.msg.MessageType, "delete",
+                    StringComparison.OrdinalIgnoreCase)).ToList();
+                if (deleteItems.Count > 0)
+                {
+                    await ProcessDeleteBatchAsync(receiver, deleteItems, ct);
+                }
+
+                if (items.Count == 0) continue;
+
                 // Split blob_ref messages from text messages — they have different processing paths
                 var blobItems = items.Where(i => i.msg.ContentType == "blob_ref").ToList();
                 var textItems = items.Where(i => i.msg.ContentType != "blob_ref").ToList();
@@ -198,6 +212,55 @@ public class EmbeddingWorkerService : BackgroundService
             {
                 _logger.LogError(ex, "Error in receive loop, backing off 5s");
                 try { await Task.Delay(5000, ct); } catch { break; }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Group delete-type messages by destination and dispatch to the writer's
+    /// DeleteByRefAsync. Completes the SB messages on success.
+    /// </summary>
+    private async Task ProcessDeleteBatchAsync(
+        ServiceBusReceiver receiver,
+        List<(EmbeddingMessage msg, ServiceBusReceivedMessage sbMsg)> items,
+        CancellationToken ct)
+    {
+        var byDest = items.GroupBy(i => i.msg.DestinationId).ToList();
+        foreach (var grp in byDest)
+        {
+            var sample = grp.First().msg;
+            if (!_writers.TryGetValue(sample.DestinationType, out var writer))
+            {
+                _logger.LogWarning(
+                    "No writer for destination type {Type} — dead-lettering {Count} delete msg(s)",
+                    sample.DestinationType, grp.Count());
+                foreach (var (_, sbMsg) in grp)
+                    try { await receiver.DeadLetterMessageAsync(sbMsg, "UnknownDestinationType",
+                        $"No writer for {sample.DestinationType}", ct); } catch { }
+                continue;
+            }
+
+            var requests = grp.Select(i => new DeleteRequest(
+                SourceId: i.msg.SourceId,
+                SourceRef: i.msg.SourceRef,
+                PartitionKeyValue: string.IsNullOrEmpty(i.msg.PartitionKeyValue) ? i.msg.SourceRef : i.msg.PartitionKeyValue,
+                PipelineId: i.msg.PipelineId)).ToList();
+
+            try
+            {
+                await writer.DeleteByRefAsync(sample.DestinationConfig, requests, ct);
+                foreach (var (_, sbMsg) in grp)
+                    await receiver.CompleteMessageAsync(sbMsg, ct);
+                _logger.LogInformation(
+                    "Delete: processed {Count} ref(s) on dest {Dest}",
+                    requests.Count, sample.DestinationId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Delete batch failed for dest {Dest}, abandoning {Count} msg(s)",
+                    sample.DestinationId, grp.Count());
+                foreach (var (_, sbMsg) in grp)
+                    try { await receiver.AbandonMessageAsync(sbMsg, cancellationToken: ct); } catch { }
             }
         }
     }

--- a/docs/design/blob-eventgrid-push.md
+++ b/docs/design/blob-eventgrid-push.md
@@ -1,0 +1,107 @@
+# Blob ingestion: Event Grid push (replacing live-poll)
+
+## Why
+- Current `BlobSourceWatcher` does prefill scan + infinite live-polling on `LastModified`.
+- Polling does not scale to huge containers; misses deletes and renames; expensive in LIST calls.
+- Replace ongoing polling with Event Grid -> Service Bus -> in-cluster consumer.
+- Keep prefill (one-time) - Event Grid does not backfill.
+
+## Target architecture
+
+```
+Storage Account
+   |- Event Grid system topic
+         |- Subscription (per source) -> Service Bus queue "blob-events"
+                |- omnivec-blob-ingestor / BlobEventConsumer
+                      |- BlobCreated / BlobModified -> publish EmbeddingMessage to "embeddings" topic
+                      `- BlobDeleted / BlobRenamed  -> publish DeleteMessage -> worker -> Cosmos DeleteItem
+```
+
+## Phase A - infra + provisioning (~2h)
+1. **bicep**: `infra/modules/servicebus.bicep` - add `blob-events` queue (alongside `jobs`).
+   - `maxDeliveryCount: 10`, `lockDuration: PT5M`, DLQ on expiration.
+2. **bicep**: assign **EventGrid Data Sender** role on `blob-events` queue to the Event Grid identity.
+3. **bicep / helm**: assign **EventGrid Contributor** + **Storage Account Contributor** on each source storage account to omnivec MI - per-source provisioning at runtime. Document the RBAC requirement.
+4. **api/api.py**:
+   - Modify `create_eventgrid_subscription`: replace `endpointType: "WebHook"` with `endpointType: "ServiceBusQueue"`, target the `blob-events` queue (env `OMNIVEC_BLOB_EVENT_QUEUE_RESOURCE_ID`).
+   - Add auto-call from `create_pipeline` when source.type == azure-blob AND processing_mode == queue AND not already configured. Race-safe: provision EG **first**, then prefill - consumer dedupes by url+etag.
+   - Add `POST /api/triggers/eventgrid/bulk_provision` to backfill existing pipelines on wintest.
+5. **Manual setup on wintest** (until next bicep deploy):
+   ```pwsh
+   az servicebus queue create --namespace-name omnivec-sb-7jxfedtxkojmq -g rg-omnivec-wintest-3 --name blob-events --max-delivery-count 10
+   ```
+6. **Smoke test**: hit `/api/triggers/eventgrid/create` against an existing source, verify subscription in portal points to SB queue, upload blob, see message land in queue.
+
+## Phase B - consumer + delete propagation (~3h)
+7. **connectors/ingestion/dotnet/Services/BlobEventConsumer.cs** (new):
+   - SB receiver loop on `blob-events` using `ServiceBusProcessor`.
+   - Parse Event Grid envelope (both EG schema and CloudEvents schema).
+   - For each event:
+     - `Microsoft.Storage.BlobCreated` / `BlobModified`:
+       - Resolve source by matching account+container+prefix against active sources.
+       - For each active pipeline using that source, publish `EmbeddingMessage` to `embeddings` topic.
+       - Dedupe key: `url + etag` (in-memory LRU per source).
+     - `Microsoft.Storage.BlobDeleted` / `BlobRenamed`:
+       - Publish new `DeleteMessage` to worker.
+   - Backpressure: respect existing publisher flag.
+   - DLQ on parse failure / non-recoverable errors.
+
+8. **connectors/ingestion/dotnet/Services/SourceWatcherManager.cs**:
+   - When `BLOB_USE_EVENTGRID=true` (default false initially), skip Phase 2 polling in `BlobSourceWatcher` - keep prefill only.
+   - Start a single `BlobEventConsumer` per process (not per source).
+
+9. **connectors/worker/dotnet/Models/EmbeddingMessage.cs** + writers:
+   - Add `MessageType: "embed" | "delete"`.
+   - On `delete`: Cosmos `DeleteItemAsync(id, partitionKey)` matching `source_id + source_ref`. SQL: `DELETE FROM <table> WHERE source_id=@s AND source_ref=@r`.
+   - Scope delete by source_id to avoid clobbering other pipelines' docs.
+
+10. **helm/omnivec/templates/blob-ingestor-deployment.yaml**:
+    - Add `BlobSource__UseEventGrid=true`, `BlobSource__EventGridQueueName=blob-events`.
+
+11. **Smoke + flip**:
+    - Roll out with `UseEventGrid=true`, watch consumer logs.
+    - Upload, modify, delete blobs on wintest source - verify embed + delete propagate end-to-end.
+    - Confirm dot-net poll loop is quiet for that source.
+
+## Risks / decisions to confirm before starting
+- RBAC: probe storage account perms first; fall back gracefully and surface "needs RBAC" in pipeline status.
+- Filter granularity: EG sub per source with `subjectBeginsWith=/blobServices/default/containers/<c>/blobs/<prefix>`. Two sources on same container+prefix double-fan-out (acceptable, dedup at destination).
+- Backfill: existing pipelines on wintest need a one-time `bulk_provision` call.
+- Polling fallback: keep behind a flag for initial bake-in; remove after 1 week stable.
+
+## Out of scope
+- Cross-tenant storage accounts (require cred from another tenant) - document, allow opt-out.
+- Non-Azure blob backends - keep polling for S3/GCS if they appear.
+- UI changes - the existing "Create Event Grid Subscription" button can stay; just becomes redundant when auto-provision is on.
+
+## Files expected to change
+
+Phase A:
+- `infra/modules/servicebus.bicep` - add `blob-events` queue
+- `api/api.py` - swap EG endpoint; auto-call from `create_pipeline`; bulk_provision endpoint
+- `helm/omnivec/templates/blob-ingestor-deployment.yaml` - pass `BlobSource__EventGridQueueName`
+
+Phase B:
+- `connectors/ingestion/dotnet/Services/BlobEventConsumer.cs` (new)
+- `connectors/ingestion/dotnet/Services/SourceWatcherManager.cs`
+- `connectors/ingestion/dotnet/Services/BlobSourceWatcher.cs` (Phase 2 conditional)
+- `connectors/worker/dotnet/Models/EmbeddingMessage.cs`
+- `connectors/worker/dotnet/Destinations/CosmosDbDestinationWriter.cs`
+- `connectors/worker/dotnet/Destinations/PostgresDestinationWriter.cs`
+- `connectors/worker/dotnet/Destinations/MsSqlDestinationWriter.cs`
+- `connectors/worker/dotnet/Services/EmbeddingWorkerService.cs`
+- `helm/omnivec/templates/blob-ingestor-deployment.yaml`
+
+## Estimated effort
+- Phase A: ~2h
+- Phase B: ~3h
+- Total: ~5h, one PR.
+
+## Wintest context for the new session
+- AKS context: `omnivec-aks-7jxfedtxkojmq`
+- Resource group: `rg-omnivec-wintest-3`
+- SB namespace: `omnivec-sb-7jxfedtxkojmq.servicebus.windows.net` (existing queue `jobs`, topic `embeddings`, subscription `worker`)
+- ACR: `omnivecacr7jxfedtxkojmq.azurecr.io` (env) + `omnivecregistry.azurecr.io` (CI build output)
+- MI client id: `02ae9464-0e5e-4b68-9726-af8967ab637e`
+- Existing pipeline: `pip-29511bf3` (paused), `pip-4705eaa3` (paused, ui-test)
+- Test source: `src-b74b772f` (blob), dest: `dst-1e35d37d` (Cosmos), model: `mdl-ext-de45f285`

--- a/helm/omnivec/templates/api-deployment.yaml
+++ b/helm/omnivec/templates/api-deployment.yaml
@@ -54,6 +54,14 @@ spec:
               value: {{ .Values.azure.workloadIdentity.clientId | quote }}
             - name: ENABLE_BLOB_SOURCE
               value: {{ .Values.blobIngestor.enabled | default false | quote }}
+            {{- if .Values.azure.subscriptionId }}
+            - name: AZURE_SUBSCRIPTION_ID
+              value: {{ .Values.azure.subscriptionId | quote }}
+            {{- end }}
+            {{- if .Values.azure.serviceBus.blobEventsQueueResourceId }}
+            - name: OMNIVEC_BLOB_EVENT_QUEUE_RESOURCE_ID
+              value: {{ .Values.azure.serviceBus.blobEventsQueueResourceId | quote }}
+            {{- end }}
             {{- if .Values.api.adminToken }}
             - name: OMNIVEC_ADMIN_TOKEN
               value: {{ .Values.api.adminToken | quote }}

--- a/helm/omnivec/templates/blob-ingestor-deployment.yaml
+++ b/helm/omnivec/templates/blob-ingestor-deployment.yaml
@@ -47,6 +47,12 @@ spec:
               value: {{ .Values.azure.serviceBus.namespace | quote }}
             - name: ChangeFeed__ServiceBusTopicName
               value: {{ .Values.azure.serviceBus.embeddingsTopic | default "embeddings" | quote }}
+            - name: ChangeFeed__BlobEventConsumerEnabled
+              value: {{ .Values.blobIngestor.eventGrid.consumerEnabled | default false | quote }}
+            - name: ChangeFeed__BlobEventQueueName
+              value: {{ .Values.azure.serviceBus.blobEventsQueue | default "blob-events" | quote }}
+            - name: ChangeFeed__BlobLivePollingEnabled
+              value: {{ .Values.blobIngestor.livePollingEnabled | default true | quote }}
             {{- end }}
           resources:
             {{- toYaml .Values.blobIngestor.resources | nindent 12 }}

--- a/helm/omnivec/values.yaml
+++ b/helm/omnivec/values.yaml
@@ -188,6 +188,14 @@ blobIngestor:
     limits:
       memory: "512Mi"
       cpu: "500m"
+  # Event-Grid push consumption (see docs/design/blob-eventgrid-push.md).
+  # When enabled the ingestor consumes BlobCreated/BlobDeleted/BlobRenamed
+  # events from the SB blob-events queue (provisioned by api.py) and fans
+  # them out as embedding messages. Disable live polling once the consumer
+  # is healthy in production.
+  eventGrid:
+    consumerEnabled: false
+  livePollingEnabled: true
 
 # =============================================================================
 # DOTNET WORKER (.NET Service Bus worker for queue-mode embedding)

--- a/infra/modules/servicebus.bicep
+++ b/infra/modules/servicebus.bicep
@@ -27,6 +27,20 @@ resource jobsQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-preview' =
   }
 }
 
+// Blob events queue — Event Grid subscriptions on blob storage accounts deliver
+// BlobCreated/BlobDeleted/BlobRenamed events here. BlobEventConsumer in the
+// .NET ingestion service consumes and fans out to active pipelines.
+resource blobEventsQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-preview' = {
+  parent: sbNamespace
+  name: 'blob-events'
+  properties: {
+    maxDeliveryCount: 10
+    lockDuration: 'PT5M'
+    deadLetteringOnMessageExpiration: true
+    defaultMessageTimeToLive: 'P1D'
+  }
+}
+
 // Embeddings topic — changefeed publishes, .NET worker subscribes
 resource embeddingsTopic 'Microsoft.ServiceBus/namespaces/topics@2022-10-01-preview' = {
   parent: sbNamespace
@@ -62,3 +76,5 @@ resource sbDataOwnerRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = 
 
 output namespaceName string = sbNamespace.name
 output endpoint string = '${sbNamespace.name}.servicebus.windows.net'
+output blobEventsQueueName string = blobEventsQueue.name
+output blobEventsQueueResourceId string = blobEventsQueue.id


### PR DESCRIPTION
## Summary
Replaces `BlobSourceWatcher`'s live-polling loop with an event-driven path:
**Storage → Event Grid system topic → Service Bus queue (`blob-events`) → `BlobEventConsumer` (in blob-ingestor) → embeddings topic → worker → Cosmos**.

Also adds **delete propagation**: `Microsoft.Storage.BlobDeleted` events now remove the corresponding chunks from the destination (Cosmos transactional batch by `source_id` + `source_ref`).

## Changes
### Infra
- `infra/modules/servicebus.bicep` — new `blobEventsQueue` (lockDuration PT5M, maxDelivery 10, P1D TTL, DLQ on expiration) + outputs.

### API (`api/`)
- `_provision_blob_eventgrid()` helper — uses `system_topic_event_subscriptions` with `deliveryWithResourceIdentity` + `ServiceBusQueue` destination when `OMNIVEC_BLOB_EVENT_QUEUE_RESOURCE_ID` is set; falls back to legacy WebHook otherwise (required because the SB namespace has `disableLocalAuth: true`).
- `_ensure_system_topic_for_storage()` — idempotent system topic lookup/create per storage account.
- Auto-provisions EG subscription from `create_pipeline` when `source.type=azure-blob` and `processing_mode=queue`.
- New endpoint: `POST /api/triggers/eventgrid/bulk_provision`.
- `models.py`: `Source.triggers` validator normalizes legacy `"eventgrid"` → `"event-grid"` on read so pre-existing source docs don't 500 `/api/sources`.

### .NET ingestion
- **New** `Services/BlobEventConsumer.cs` (~330 lines): hosted `ServiceBusProcessor` on `blob-events`; parses EG native + CloudEvents schemas; matches events to active sources by (account+container+prefix+ext); publishes `blob_ref` `EmbeddingMessage` with `MessageType=upsert|delete`; refresh loop for source/pipeline snapshot.
- `BlobSourceWatcher`: Phase-2 live-polling gated on `ChangeFeed:BlobLivePollingEnabled`.
- `ChangeFeedOptions`: `BlobEventConsumerEnabled`, `BlobEventQueueName`, `BlobLivePollingEnabled`, `BlobEventConsumerConcurrency`.
- `EmbeddingMessage`: `MessageType` field.

### .NET worker
- `IDestinationWriter.DeleteByRefAsync` (default no-op) + `DeleteRequest`.
- `CosmosDbDestinationWriter.DeleteByRefAsync`: query by `source_id` + `source_ref`, transactional batch delete (handles chunked `{source_ref}#chunk{i}` docs).
- `EmbeddingWorkerService.ProcessDeleteBatchAsync`: splits delete messages from the receive batch and routes them to the destination writer.

### Helm
- `blob-ingestor-deployment.yaml` / `api-deployment.yaml`: env wiring for EG/SB consumer + queue resource id.
- `values.yaml`: `blobIngestor.eventGrid.consumerEnabled`, `blobIngestor.livePollingEnabled`.

### Docs
- `docs/design/blob-eventgrid-push.md` (added earlier in branch).

## Test evidence (wintest)
- `GET /api/sources` → 200.
- Upload `eg-realpdf-20260602161119.pdf` →
  - ingestor: `BlobEventConsumer fanned out 1 embedding message(s)`
  - worker: `Blob processed → 1 chunks`
  - Cosmos query returns the doc. ✅
- `az storage blob delete` same blob →
  - second fan-out
  - Cosmos query returns 0 docs. ✅

## Operational notes
- SB namespace has `disableLocalAuth: true` → identity-based EG delivery required; the EG system topic must have `SystemAssigned` MI with `Azure Service Bus Data Sender` on the queue.
- API MI needs `Reader` + `EventGrid Contributor` at RG scope (system topic eventSubscriptions/write is RG-level, not on the storage account).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>