### PR TITLE
fix(hooks): persist OmniVec API URL into azd env post-provision

### DIFF
--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -875,6 +875,15 @@ if (-not $LOCATION) { $LOCATION = Get-AzdValue "AZURE_LOCATION" }
 if (-not $LOCATION) { $LOCATION = "eastus2" }
 $FQDN = "${INSTANCE_ID}.${LOCATION}.cloudapp.azure.com"
 
+# Persist the OmniVec server URL into the azd env so subsequent CLI
+# invocations / tooling can pick it up without re-deriving from the cluster.
+$OMNIVEC_API_URL = "http://$FQDN"
+azd env set OMNIVEC_API_URL $OMNIVEC_API_URL 2>$null | Out-Null
+azd env set OMNIVEC_UI_URL  "$OMNIVEC_API_URL/ui" 2>$null | Out-Null
+if ($externalIp) {
+    azd env set OMNIVEC_API_IP "http://$externalIp" 2>$null | Out-Null
+}
+
 if ($externalIp) {
     Write-Host ""
     Write-Host "  OmniVec FQDN:  `e[36mhttp://${FQDN}/ui`e[0m"

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -1034,6 +1034,15 @@ if [ -z "$LOCATION" ]; then LOCATION=$(get_azd_value "AZURE_LOCATION"); fi
 if [ -z "$LOCATION" ]; then LOCATION="eastus2"; fi
 FQDN="${INSTANCE_ID}.${LOCATION}.cloudapp.azure.com"
 
+# Persist the OmniVec server URL into the azd env so subsequent CLI
+# invocations / tooling can pick it up without re-deriving from the cluster.
+OMNIVEC_API_URL="http://${FQDN}"
+azd env set OMNIVEC_API_URL "$OMNIVEC_API_URL" </dev/null 2>/dev/null || true
+azd env set OMNIVEC_UI_URL  "${OMNIVEC_API_URL}/ui" </dev/null 2>/dev/null || true
+if [ -n "${EXTERNAL_IP}" ]; then
+  azd env set OMNIVEC_API_IP "http://${EXTERNAL_IP}" </dev/null 2>/dev/null || true
+fi
+
 if [ -n "${EXTERNAL_IP}" ]; then
   echo ""
   printf "  OmniVec FQDN:  ${CYAN}http://${FQDN}/ui${NC}\n"


### PR DESCRIPTION
Persists `OMNIVEC_API_URL`, `OMNIVEC_UI_URL` and `OMNIVEC_API_IP` via `azd env set` in both `hooks/postprovision.sh` and `hooks/postprovision.ps1`. Previously these were only `printf`'d to console and lost after the deploy session.

Addresses the feedback that the OmniVec server URL is not part of the .env post-deployment.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>