### PR TITLE
refactor(infra): always provision Storage + Service Bus + Event Grid (Option A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ azd env set OMNIVEC_SYSTEM_NODE_COUNT   2
 azd env set OMNIVEC_GPU_NODE_VM_SIZE    ""
 azd env set OMNIVEC_GPU_NODE_COUNT      0
 azd env set OMNIVEC_METADATA_STORE      cosmosdb-serverless
-azd env set OMNIVEC_ENABLE_BLOB_SOURCE  true
 azd up
 ```
 
@@ -302,7 +301,6 @@ This removes the resource group, all Azure services, and local environment confi
 | `OMNIVEC_GPU_NODE_VM_SIZE` | No | `""` | GPU VM SKU (empty = no GPU pool) |
 | `OMNIVEC_GPU_NODE_COUNT` | No | `0` | GPU nodes (0 = external models only) |
 | `OMNIVEC_METADATA_STORE` | Yes | prompted | `cosmosdb-serverless` or `cosmosdb-provisioned` |
-| `OMNIVEC_ENABLE_BLOB_SOURCE` | Yes | prompted | `true` = create Storage + Service Bus + Event Grid |
 | `OMNIVEC_SHARED_REGISTRY_TOKEN` | No | prompted | Token for pre-built images (skip = build from source) |
 | `OMNIVEC_BUILD_MODE` | No | auto-detect | `acr` (cloud build) or `docker` (local build) |
 | `OMNIVEC_BUILD` | No | `false` | `true` = force building from source |

--- a/api/api.py
+++ b/api/api.py
@@ -960,28 +960,19 @@ PIPELINE_WORKER_BASE = DOCGROK_URL if ROUTE_PIPELINE_VIA_DOCGROK else PIPELINE_W
 SEARCH_SERVICE_URL = os.getenv("SEARCH_SERVICE_URL", "http://omnivec-search").rstrip("/")
 SEARCH_INTERNAL_TOKEN = os.getenv("SEARCH_INTERNAL_TOKEN", "")
 
-# Feature flag: set by postprovision based on infra.enableBlobSource (Bicep).
-# When disabled, Service Bus + Storage + Event Grid are NOT deployed, so we
-# must refuse any request that would require them:
-#   - creating an azure-blob source (needs Storage + Event Grid)
-#   - creating/switching a pipeline to queue mode (needs Service Bus)
-_BLOB_SOURCE_ENABLED = os.getenv("ENABLE_BLOB_SOURCE", "true").strip().lower() not in ("false", "0", "no", "")
+# Blob source infra (Storage + Service Bus + Event Grid) is always provisioned
+# by Bicep — Option A (always-provision). The legacy ENABLE_BLOB_SOURCE env var
+# is no longer required; we keep the flag pinned to True so the helper below is
+# a no-op kept for backward compatibility with callers.
+_BLOB_SOURCE_ENABLED = True
 
 
 def _require_blob_source_enabled(kind: str) -> None:
-    """Raise 400 when the deployment was provisioned without blob/service bus.
+    """No-op (kept for backward compatibility).
 
-    kind is a short label used in the error message ('source', 'queue-mode pipeline').
+    Blob source infrastructure is always provisioned, so this never rejects.
     """
-    if not _BLOB_SOURCE_ENABLED:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Cannot create {kind}: this deployment was provisioned with "
-                "blob source disabled (no Storage Account / Service Bus / Event Grid). "
-                "Re-deploy with OMNIVEC_ENABLE_BLOB_SOURCE=true to enable."
-            ),
-        )
+    return
 
 
 # HTTP Client

--- a/helm/omnivec/values.yaml
+++ b/helm/omnivec/values.yaml
@@ -175,11 +175,10 @@ changefeed:
 # Blob Ingestor - Dedicated single-replica deployment for azure-blob sources.
 # Runs the same image as changefeed but with EnableBlobSources=true,
 # EnableCosmosSources=false. Keeps blob enumeration off the Cosmos CFP scale unit.
-# Gated by ENABLE_BLOB_SOURCE in postprovision.sh; default false so azd deployments
-# that don't enable blob never get an empty-config pod.
+# Always enabled (Option A: Storage + Service Bus + Event Grid always provisioned).
 # =============================================================================
 blobIngestor:
-  enabled: false
+  enabled: true
   replicaCount: 1
   resources:
     requests:

--- a/hooks/lib/preflight.sh
+++ b/hooks/lib/preflight.sh
@@ -10,7 +10,6 @@
 #   preflight_require_providers NS [NS ...] — az provider register (idempotent)
 #   preflight_vcpu_quota LOCATION REQ VCPUS — check vCPU headroom for requested skus
 #   preflight_name_collisions RG_NAME       — RG already owned by someone else?
-#   preflight_blob_flip_guard RG_NAME WANT  — forbid enabling/disabling blob-source on existing RG
 
 set -u
 
@@ -203,29 +202,11 @@ preflight_name_collisions() {
 }
 
 # ──────────────────────────────────────────────────────────────────────────
-# b3: forbid DISABLING blob-source on an existing deployment. If the RG tag
-# `omnivec-blob` is `true` and user sets FALSE, we refuse — Storage Account /
-# ServiceBus / EventGrid would be orphaned. The reverse (false → true) is
-# allowed: Bicep is idempotent and will create the missing modules on the
-# next azd up.
+# preflight_blob_flip_guard — deprecated no-op.
+# Storage Account / Service Bus / Event Grid are always provisioned now
+# (Option A), so there is no flip to guard. Function kept for backward
+# compatibility with any external callers; always returns 0.
 # ──────────────────────────────────────────────────────────────────────────
 preflight_blob_flip_guard() {
-    _rg=$1
-    _want=$2
-    _existing=$(az group show --name "$_rg" --query "tags.\"omnivec-blob\"" -o tsv </dev/null 2>/dev/null || printf '')
-    _existing=$(printf '%s' "$_existing" | tr -d '\r\n ')
-    [ -z "$_existing" ] && return 0  # no prior tag, nothing to guard
-    _want_norm=$(printf '%s' "$_want" | tr -d '\r\n ' | tr '[:upper:]' '[:lower:]')
-    _existing_norm=$(printf '%s' "$_existing" | tr '[:upper:]' '[:lower:]')
-    # Block only the destructive direction: existing=true and want=false.
-    if [ "$_existing_norm" = "true" ] && [ "$_want_norm" = "false" ]; then
-        printf "\n  ${RED}✗ Cannot disable OMNIVEC_ENABLE_BLOB_SOURCE (true -> false) on existing deployment.${NC}\n"
-        printf "  ${YELLOW}This would orphan Storage/ServiceBus/EventGrid resources.${NC}\n"
-        printf "  ${YELLOW}Run 'azd down' first, or pick a different AZURE_ENV_NAME.${NC}\n"
-        return 1
-    fi
-    if [ "$_existing_norm" = "false" ] && [ "$_want_norm" = "true" ]; then
-        printf "  ${YELLOW}! Enabling blob source on existing deployment (false -> true). Storage/ServiceBus/EventGrid will be created.${NC}\n"
-    fi
     return 0
 }

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -55,8 +55,6 @@ if (-not $BUILD_MODE) {
         if ($LASTEXITCODE -eq 0) { $BUILD_MODE = "docker" } else { $BUILD_MODE = "acr" }
     } else { $BUILD_MODE = "acr" }
 }
-$ENABLE_BLOB_SOURCE = if (Get-AzdValue "AZURE_ENABLE_BLOB_SOURCE") { Get-AzdValue "AZURE_ENABLE_BLOB_SOURCE" } else { "false" }
-
 $STORAGE_ACCOUNT = Get-AzdValue "AZURE_STORAGE_ACCOUNT_NAME"
 $STORAGE_BLOB_ENDPOINT = Get-AzdValue "AZURE_STORAGE_BLOB_ENDPOINT"
 $STORAGE_QUEUE_ENDPOINT = Get-AzdValue "AZURE_STORAGE_QUEUE_ENDPOINT"
@@ -90,8 +88,8 @@ foreach ($var in @("INSTANCE_ID","AKS_CLUSTER","ACR_LOGIN_SERVER","ACR_NAME","CO
     }
 }
 
-if ($ENABLE_BLOB_SOURCE -eq "true" -and -not $SB_ENDPOINT) {
-    Write-Host "`e[31mMissing Service Bus endpoint while blob source is enabled.`e[0m"
+if (-not $SB_ENDPOINT) {
+    Write-Host "`e[31mMissing Service Bus endpoint output. Run 'azd provision' first.`e[0m"
     exit 1
 }
 
@@ -100,11 +98,8 @@ Write-Host "  Instance ID:     $INSTANCE_ID"
 Write-Host "  AKS cluster:     $AKS_CLUSTER"
 Write-Host "  ACR:             $ACR_LOGIN_SERVER"
 Write-Host "  CosmosDB:        $COSMOS_ENDPOINT"
-Write-Host "  Blob source:     $ENABLE_BLOB_SOURCE"
-if ($ENABLE_BLOB_SOURCE -eq "true") {
-    Write-Host "  Storage:         $STORAGE_ACCOUNT"
-    Write-Host "  Service Bus:     $SB_ENDPOINT"
-}
+Write-Host "  Storage:         $STORAGE_ACCOUNT"
+Write-Host "  Service Bus:     $SB_ENDPOINT"
 Write-Host "  Identity:        $IDENTITY_CLIENT_ID"
 Write-Host "  Build mode:      $BUILD_MODE"
 if ($DNS_LABEL_RESERVED) {
@@ -119,7 +114,6 @@ $sysCnt = Get-AzdValue "OMNIVEC_SYSTEM_NODE_COUNT"
 $gpuVm = Get-AzdValue "OMNIVEC_GPU_NODE_VM_SIZE"
 $gpuCnt = Get-AzdValue "OMNIVEC_GPU_NODE_COUNT"
 $meta = Get-AzdValue "OMNIVEC_METADATA_STORE"
-$blob = Get-AzdValue "OMNIVEC_ENABLE_BLOB_SOURCE"
 $build = Get-AzdValue "OMNIVEC_BUILD_MODE"
 az tag update --resource-id (az group show --name $RESOURCE_GROUP --query "id" -o tsv) --operation merge --tags `
     "omnivec-sys-sku=$sysVm" `
@@ -127,7 +121,6 @@ az tag update --resource-id (az group show --name $RESOURCE_GROUP --query "id" -
     "omnivec-gpu-sku=$gpuVm" `
     "omnivec-gpu-count=$gpuCnt" `
     "omnivec-metadata=$meta" `
-    "omnivec-blob=$blob" `
     "omnivec-build=$build" `
     "omnivec-instance=$INSTANCE_ID" 2>$null | Out-Null
 Write-Host "  `e[32mConfig saved to RG tags.`e[0m"
@@ -514,14 +507,12 @@ if ($LASTEXITCODE -ne 0) { Write-Host "`e[31mFailed to create namespace docgrok`
 kubectl --context $KUBE_CONTEXT label namespace omnivec app.kubernetes.io/managed-by=Helm --overwrite | Out-Null
 kubectl --context $KUBE_CONTEXT annotate namespace omnivec meta.helm.sh/release-name=omnivec meta.helm.sh/release-namespace=omnivec --overwrite | Out-Null
 
-if ($ENABLE_BLOB_SOURCE -eq "true") {
-    kubectl --context $KUBE_CONTEXT create secret generic omnivec-storage `
-        --namespace omnivec `
-        --from-literal=account-name="$STORAGE_ACCOUNT" `
-        --from-literal=queue-endpoint="$STORAGE_QUEUE_ENDPOINT" `
-        --dry-run=client -o yaml | kubectl --context $KUBE_CONTEXT apply -f -
-    Write-Host "  `e[32momnivec-storage secret created.`e[0m"
-}
+kubectl --context $KUBE_CONTEXT create secret generic omnivec-storage `
+    --namespace omnivec `
+    --from-literal=account-name="$STORAGE_ACCOUNT" `
+    --from-literal=queue-endpoint="$STORAGE_QUEUE_ENDPOINT" `
+    --dry-run=client -o yaml | kubectl --context $KUBE_CONTEXT apply -f -
+Write-Host "  `e[32momnivec-storage secret created.`e[0m"
 
 # Agent internal token secret (used for agent <-> API service-to-service auth)
 $AGENT_INTERNAL_TOKEN = Get-AzdValue "OMNIVEC_AGENT_INTERNAL_TOKEN"
@@ -658,15 +649,11 @@ if ($SB_ENDPOINT) {
     )
 }
 
-if ($ENABLE_BLOB_SOURCE -eq "true") {
-    $helmArgs += @(
-        "--set", "azure.storage.accountName=$STORAGE_ACCOUNT",
-        "--set", "azure.storage.blobEndpoint=$STORAGE_BLOB_ENDPOINT",
-        "--set", "blobIngestor.enabled=true"
-    )
-} else {
-    $helmArgs += @("--set", "blobIngestor.enabled=false")
-}
+$helmArgs += @(
+    "--set", "azure.storage.accountName=$STORAGE_ACCOUNT",
+    "--set", "azure.storage.blobEndpoint=$STORAGE_BLOB_ENDPOINT",
+    "--set", "blobIngestor.enabled=true"
+)
 
 # Image tags are NOT overridden here — postprovision imports every image
 # into the env-specific ACR tagged :latest (from OMNIVEC_IMAGE_TAG / branch),

--- a/hooks/postprovision.sh
+++ b/hooks/postprovision.sh
@@ -114,10 +114,7 @@ if [ -z "$BUILD_MODE" ]; then
     BUILD_MODE="acr"
   fi
 fi
-ENABLE_BLOB_SOURCE=$(get_azd_value "AZURE_ENABLE_BLOB_SOURCE")
-ENABLE_BLOB_SOURCE=${ENABLE_BLOB_SOURCE:-false}
-
-# Blob source outputs (only set when enableBlobSource=true)
+# Blob source infrastructure (always provisioned).
 STORAGE_ACCOUNT=$(get_azd_value "AZURE_STORAGE_ACCOUNT_NAME")
 STORAGE_BLOB_ENDPOINT=$(get_azd_value "AZURE_STORAGE_BLOB_ENDPOINT")
 STORAGE_QUEUE_ENDPOINT=$(get_azd_value "AZURE_STORAGE_QUEUE_ENDPOINT")
@@ -135,8 +132,8 @@ for var in INSTANCE_ID AKS_CLUSTER ACR_LOGIN_SERVER ACR_NAME COSMOS_ENDPOINT IDE
   fi
 done
 
-if [ "$ENABLE_BLOB_SOURCE" = "true" ] && [ -z "$SB_ENDPOINT" ]; then
-  printf "${RED}Missing Service Bus endpoint while blob source is enabled.${NC}\n"
+if [ -z "$SB_ENDPOINT" ]; then
+  printf "${RED}Missing Service Bus endpoint output. Run 'azd provision' first.${NC}\n"
   exit 1
 fi
 
@@ -145,11 +142,8 @@ echo "  Instance ID:     $INSTANCE_ID"
 echo "  AKS cluster:    $AKS_CLUSTER"
 echo "  ACR:             $ACR_LOGIN_SERVER"
 echo "  CosmosDB:        $COSMOS_ENDPOINT"
-echo "  Blob source:     $ENABLE_BLOB_SOURCE"
-if [ "$ENABLE_BLOB_SOURCE" = "true" ]; then
-  echo "  Storage:         $STORAGE_ACCOUNT"
-  echo "  Service Bus:     $SB_ENDPOINT"
-fi
+echo "  Storage:         $STORAGE_ACCOUNT"
+echo "  Service Bus:     $SB_ENDPOINT"
 echo "  Identity:        $IDENTITY_CLIENT_ID"
 echo "  Build mode:      $BUILD_MODE"
 if [ -n "${DNS_LABEL_RESERVED:-}" ]; then
@@ -164,7 +158,6 @@ SYS_CNT=$(get_azd_value "OMNIVEC_SYSTEM_NODE_COUNT")
 GPU_VM=$(get_azd_value "OMNIVEC_GPU_NODE_VM_SIZE")
 GPU_CNT=$(get_azd_value "OMNIVEC_GPU_NODE_COUNT")
 META=$(get_azd_value "OMNIVEC_METADATA_STORE")
-BLOB=$(get_azd_value "OMNIVEC_ENABLE_BLOB_SOURCE")
 BUILD=$(get_azd_value "OMNIVEC_BUILD_MODE")
 _RG_ID=$(az group show --name "$RESOURCE_GROUP" --query "id" -o tsv < /dev/null 2>/dev/null)
 az tag update --resource-id "$_RG_ID" --operation merge --tags \
@@ -173,7 +166,6 @@ az tag update --resource-id "$_RG_ID" --operation merge --tags \
     "omnivec-gpu-sku=$GPU_VM" \
     "omnivec-gpu-count=$GPU_CNT" \
     "omnivec-metadata=$META" \
-    "omnivec-blob=$BLOB" \
     "omnivec-build=$BUILD" \
     "omnivec-instance=$INSTANCE_ID" >/dev/null 2>&1 || true
 printf "  ${GREEN}Config saved to RG tags.${NC}\n"
@@ -605,15 +597,13 @@ kubectl_omnivec create namespace docgrok </dev/null 2>/dev/null || true
 kubectl_omnivec label namespace omnivec app.kubernetes.io/managed-by=Helm --overwrite </dev/null
 kubectl_omnivec annotate namespace omnivec meta.helm.sh/release-name=omnivec meta.helm.sh/release-namespace=omnivec --overwrite </dev/null
 
-# Storage connection string secret (only when blob source is enabled)
-if [ "$ENABLE_BLOB_SOURCE" = "true" ]; then
-  kubectl_omnivec create secret generic omnivec-storage \
-    --namespace omnivec \
-    --from-literal=account-name="$STORAGE_ACCOUNT" \
-    --from-literal=queue-endpoint="$STORAGE_QUEUE_ENDPOINT" \
-    --dry-run=client -o yaml | kubectl_omnivec apply -f -
-  printf "  ${GREEN}omnivec-storage secret created.${NC}\n"
-fi
+# Storage connection string secret (always created — blob infra always provisioned).
+kubectl_omnivec create secret generic omnivec-storage \
+  --namespace omnivec \
+  --from-literal=account-name="$STORAGE_ACCOUNT" \
+  --from-literal=queue-endpoint="$STORAGE_QUEUE_ENDPOINT" \
+  --dry-run=client -o yaml | kubectl_omnivec apply -f -
+printf "  ${GREEN}omnivec-storage secret created.${NC}\n"
 
 # Agent internal token secret (used for agent <-> API service-to-service auth)
 AGENT_INTERNAL_TOKEN=$(get_azd_value "OMNIVEC_AGENT_INTERNAL_TOKEN")
@@ -769,13 +759,10 @@ run_helm_deploy() {
     set -- "$@" --set "azure.serviceBus.namespace=${SB_ENDPOINT}"
   fi
 
-  if [ "$ENABLE_BLOB_SOURCE" = "true" ]; then
-    set -- "$@" --set "azure.storage.accountName=${STORAGE_ACCOUNT}" \
-                --set "azure.storage.blobEndpoint=${STORAGE_BLOB_ENDPOINT}" \
-                --set "blobIngestor.enabled=true"
-  else
-    set -- "$@" --set "blobIngestor.enabled=false"
-  fi
+  # Blob storage + ingestor are always provisioned (Option A: always-on infra).
+  set -- "$@" --set "azure.storage.accountName=${STORAGE_ACCOUNT}" \
+              --set "azure.storage.blobEndpoint=${STORAGE_BLOB_ENDPOINT}" \
+              --set "blobIngestor.enabled=true"
 
   # Image tags are NOT overridden here — postprovision imports every image
   # into the env-specific ACR tagged :latest (regardless of source channel),

--- a/hooks/preprovision.ps1
+++ b/hooks/preprovision.ps1
@@ -185,7 +185,6 @@ function Use-QuickstartDefaults {
         'OMNIVEC_GPU_NODE_VM_SIZE'    = ''
         'OMNIVEC_GPU_NODE_COUNT'      = '0'
         'OMNIVEC_METADATA_STORE'      = 'cosmosdb-serverless'
-        'OMNIVEC_ENABLE_BLOB_SOURCE'  = 'true'
     }
     foreach ($kv in $defaults.GetEnumerator()) {
         azd env set $kv.Key $kv.Value 2>$null
@@ -211,7 +210,6 @@ function Require-InteractiveOrPreset {
     Write-Host "         azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE Standard_B4ms"
     Write-Host "         azd env set OMNIVEC_SYSTEM_NODE_COUNT 2"
     Write-Host "         azd env set OMNIVEC_GPU_NODE_COUNT 0"
-    Write-Host "         azd env set OMNIVEC_ENABLE_BLOB_SOURCE true"
     Write-Host "         azd env set OMNIVEC_METADATA_STORE cosmosdb-serverless"
     Release-Lock
     exit 1
@@ -276,14 +274,6 @@ $rgExists = az group exists --name $rgName 2>$null
 if ("$rgExists".Trim() -eq "true") {
     Write-Host "`n`e[32mExisting deployment detected (RG: $rgName). Importing config...`e[0m"
 
-    # Snapshot user's blob-source override BEFORE tag import overwrites azd env.
-    $_userBlobOverride = (& azd env get-value OMNIVEC_ENABLE_BLOB_SOURCE 2>$null)
-    if (-not $_userBlobOverride -or "$_userBlobOverride" -match "ERROR") {
-        $_userBlobOverride = (& azd env get-value AZURE_ENABLE_BLOB_SOURCE 2>$null)
-    }
-    if ("$_userBlobOverride" -match "ERROR") { $_userBlobOverride = "" }
-    $_userBlobOverride = "$_userBlobOverride".Trim().ToLower()
-
     $tags = az group show --name $rgName --query "tags" -o json 2>$null | ConvertFrom-Json
     if ($tags) {
         $tagMap = @{
@@ -292,26 +282,10 @@ if ("$rgExists".Trim() -eq "true") {
             "omnivec-gpu-sku"    = "OMNIVEC_GPU_NODE_VM_SIZE"
             "omnivec-gpu-count"  = "OMNIVEC_GPU_NODE_COUNT"
             "omnivec-metadata"   = "OMNIVEC_METADATA_STORE"
-            "omnivec-blob"       = "OMNIVEC_ENABLE_BLOB_SOURCE"
             "omnivec-build"      = "OMNIVEC_BUILD_MODE"
         }
         foreach ($tag in $tagMap.GetEnumerator()) {
             $val = $tags.PSObject.Properties[$tag.Key].Value
-            # Honor user-intended blob-source flip over stale tag.
-            if ($tag.Value -eq "OMNIVEC_ENABLE_BLOB_SOURCE" -and $_userBlobOverride -and $_userBlobOverride -ne ("$val".Trim().ToLower())) {
-                if ($_userBlobOverride -eq "false" -and ("$val".Trim().ToLower()) -eq "true") {
-                    Write-Host "`n  `e[31m✗ Cannot disable OMNIVEC_ENABLE_BLOB_SOURCE (true -> false) on existing deployment.`e[0m"
-                    Write-Host "  `e[33mThis would orphan Storage/ServiceBus/EventGrid resources.`e[0m"
-                    Write-Host "  `e[33mRun 'azd down' first, or pick a different AZURE_ENV_NAME.`e[0m"
-                    exit 1
-                }
-                if ($_userBlobOverride -eq "true" -and ("$val".Trim().ToLower()) -eq "false") {
-                    Write-Host "  `e[33m! Enabling blob source on existing deployment (false -> true). Storage/ServiceBus/EventGrid will be created.`e[0m"
-                }
-                azd env set OMNIVEC_ENABLE_BLOB_SOURCE $_userBlobOverride 2>$null
-                Write-Host "  OMNIVEC_ENABLE_BLOB_SOURCE = $_userBlobOverride `e[33m(user override; tag was '$val')`e[0m"
-                continue
-            }
             if ($val) {
                 azd env set $tag.Value "$val" 2>$null
                 Write-Host "  $($tag.Value) = $val"
@@ -346,20 +320,12 @@ $setupMode = Read-InputSafely -Prompt "Choice [1]" -Default "1"
 
 if ($setupMode -eq "1") {
     Write-Host "`n`e[32mApplying recommended defaults:`e[0m"
-    # Honor a pre-set blob-source preference (either var name)
-    $qsBlob = (& azd env get-value OMNIVEC_ENABLE_BLOB_SOURCE 2>$null)
-    if (-not $qsBlob -or "$qsBlob" -match "ERROR") {
-        $qsBlob = (& azd env get-value AZURE_ENABLE_BLOB_SOURCE 2>$null)
-    }
-    if (-not $qsBlob -or "$qsBlob" -match "ERROR") { $qsBlob = "true" }
-    $qsBlob = "$qsBlob".Trim()
     $defaults = [ordered]@{
         "OMNIVEC_SYSTEM_NODE_VM_SIZE" = "Standard_B4ms"
         "OMNIVEC_SYSTEM_NODE_COUNT"   = "2"
         "OMNIVEC_GPU_NODE_VM_SIZE"    = ""
         "OMNIVEC_GPU_NODE_COUNT"      = "0"
         "OMNIVEC_METADATA_STORE"      = "cosmosdb-serverless"
-        "OMNIVEC_ENABLE_BLOB_SOURCE"  = $qsBlob
     }
     foreach ($kv in $defaults.GetEnumerator()) {
         azd env set $kv.Key $kv.Value
@@ -368,11 +334,7 @@ if ($setupMode -eq "1") {
     Write-Host "`n  System pool: 2x Standard_B4ms (4 vCPU, 16 GB each)"
     Write-Host "  GPU pool: none (use Azure OpenAI for embeddings)"
     Write-Host "  Metadata: CosmosDB Serverless"
-    if ($qsBlob -eq "true") {
-        Write-Host "  Blob source: enabled"
-    } else {
-        Write-Host "  Blob source: disabled (CosmosDB sources only)"
-    }
+    Write-Host "  Blob storage source: enabled"
     Write-Host "`n`e[32mPre-provision checks passed. Proceeding with Bicep deployment...`e[0m"
     exit 0
 }
@@ -409,30 +371,6 @@ if ($curMeta) {
             Write-Host "`e[32mUsing CosmosDB Serverless for metadata storage.`e[0m"
             azd env set OMNIVEC_METADATA_STORE "cosmosdb-serverless"
         }
-    }
-}
-
-# -- Blob storage source --
-$curBlob = Get-EnvValue "OMNIVEC_ENABLE_BLOB_SOURCE"
-if ($curBlob) {
-    Write-Host "`e[32mBlob source: $curBlob (already set)`e[0m"
-} else {
-    $defBlobNum = "1"
-    Write-Host ""
-    Write-Host "`e[33mWill you use Azure Blob Storage as a document source?`e[0m"
-    Write-Host "  If yes, Service Bus (jobs queue) and Event Grid (blob event routing)"
-    Write-Host "  will be created alongside the Storage Account."
-    Write-Host ""
-    Write-Host "  1) Yes - enable blob source ingestion"
-    Write-Host "  2) No  - CosmosDB sources only (skip Service Bus + Event Grid)"
-    Write-Host ""
-    $blobChoice = Read-InputSafely -Prompt "Choice [$defBlobNum]" -Default $defBlobNum
-    if ($blobChoice -eq "1") {
-        Write-Host "`e[32mBlob source enabled.`e[0m"
-        azd env set OMNIVEC_ENABLE_BLOB_SOURCE "true"
-    } else {
-        Write-Host "`e[32mBlob source disabled.`e[0m"
-        azd env set OMNIVEC_ENABLE_BLOB_SOURCE "false"
     }
 }
 
@@ -636,7 +574,7 @@ azd env set OMNIVEC_GPU_NODE_COUNT $gpuCount
 
 # -- Sanitize env values: strip BOM, tabs, carriage returns --
 Write-Host "`n`e[36mSanitizing environment values...`e[0m"
-$envKeys = @("OMNIVEC_SYSTEM_NODE_VM_SIZE", "OMNIVEC_SYSTEM_NODE_COUNT", "OMNIVEC_GPU_NODE_VM_SIZE", "OMNIVEC_GPU_NODE_COUNT", "OMNIVEC_ENABLE_BLOB_SOURCE", "OMNIVEC_METADATA_STORE")
+$envKeys = @("OMNIVEC_SYSTEM_NODE_VM_SIZE", "OMNIVEC_SYSTEM_NODE_COUNT", "OMNIVEC_GPU_NODE_VM_SIZE", "OMNIVEC_GPU_NODE_COUNT", "OMNIVEC_METADATA_STORE")
 foreach ($key in $envKeys) {
     $ErrorActionPreference = "SilentlyContinue"
     $raw = azd env get-value $key 2>$null

--- a/hooks/preprovision.sh
+++ b/hooks/preprovision.sh
@@ -186,7 +186,6 @@ apply_quickstart_defaults() {
   azd env set OMNIVEC_GPU_NODE_VM_SIZE    "" < /dev/null
   azd env set OMNIVEC_GPU_NODE_COUNT      "0" < /dev/null
   azd env set OMNIVEC_METADATA_STORE      "cosmosdb-serverless" < /dev/null
-  azd env set OMNIVEC_ENABLE_BLOB_SOURCE  "true" < /dev/null
 }
 
 # a2: Fail fast when we would need to prompt but can't. Far better than a
@@ -210,7 +209,6 @@ require_tty_or_preset() {
   printf "         azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE Standard_B4ms\n" >&2
   printf "         azd env set OMNIVEC_SYSTEM_NODE_COUNT 2\n" >&2
   printf "         azd env set OMNIVEC_GPU_NODE_COUNT 0\n" >&2
-  printf "         azd env set OMNIVEC_ENABLE_BLOB_SOURCE true\n" >&2
   printf "         azd env set OMNIVEC_METADATA_STORE cosmosdb-serverless\n" >&2
   exit 1
 }
@@ -320,39 +318,17 @@ RG_EXISTS=$(printf '%s' "$RG_EXISTS" | tr -d '\r\n ')
 if [ "$RG_EXISTS" = "true" ]; then
   printf "\n${GREEN}Existing deployment detected (RG: ${RG_NAME}). Importing config from tags...${NC}\n"
 
-  # Snapshot user's blob-source override BEFORE tag import overwrites azd env.
-  # User can request a flip via either `azd env set OMNIVEC_ENABLE_BLOB_SOURCE true`
-  # or `azd env set AZURE_ENABLE_BLOB_SOURCE true`. OMNIVEC_ takes precedence.
-  _user_blob_override=$(azd_get OMNIVEC_ENABLE_BLOB_SOURCE)
-  if [ -z "$_user_blob_override" ]; then
-    _user_blob_override=$(azd_get AZURE_ENABLE_BLOB_SOURCE)
-  fi
-  _user_blob_override=$(printf '%s' "$_user_blob_override" | tr -d '\r\n ' | tr '[:upper:]' '[:lower:]')
-
   for _pair in \
     "omnivec-sys-sku:OMNIVEC_SYSTEM_NODE_VM_SIZE" \
     "omnivec-sys-count:OMNIVEC_SYSTEM_NODE_COUNT" \
     "omnivec-gpu-sku:OMNIVEC_GPU_NODE_VM_SIZE" \
     "omnivec-gpu-count:OMNIVEC_GPU_NODE_COUNT" \
     "omnivec-metadata:OMNIVEC_METADATA_STORE" \
-    "omnivec-blob:OMNIVEC_ENABLE_BLOB_SOURCE" \
     "omnivec-build:OMNIVEC_BUILD_MODE"; do
     _tag=$(echo "$_pair" | cut -d: -f1)
     _env=$(echo "$_pair" | cut -d: -f2)
     _val=$(az group show --name "$RG_NAME" --query "tags.\"$_tag\"" -o tsv < /dev/null 2>/dev/null || true)
     _val=$(printf '%s' "$_val" | tr -d '\r\n')
-    # Honor user-intended blob-source flip instead of re-importing the stale tag.
-    if [ "$_env" = "OMNIVEC_ENABLE_BLOB_SOURCE" ] && [ -n "$_user_blob_override" ] && [ "$_user_blob_override" != "$(printf '%s' "$_val" | tr '[:upper:]' '[:lower:]')" ]; then
-      # Validate flip direction (blocks destructive on->off; allows off->on).
-      if command -v preflight_blob_flip_guard >/dev/null 2>&1; then
-        if ! preflight_blob_flip_guard "$RG_NAME" "$_user_blob_override"; then
-          exit 1
-        fi
-      fi
-      azd env set "$_env" "$_user_blob_override" < /dev/null 2>/dev/null
-      printf "  ${_env} = ${_user_blob_override} ${YELLOW}(user override; tag was '${_val}')${NC}\n"
-      continue
-    fi
     if [ -n "$_val" ]; then
       azd env set "$_env" "$_val" < /dev/null 2>/dev/null
       printf "  ${_env} = ${_val}\n"
@@ -386,34 +362,21 @@ setup_mode=${setup_mode:-1}
 
 if [ "$setup_mode" = "1" ]; then
   printf "\n${GREEN}Applying recommended defaults:${NC}\n"
-  # Honor a pre-set blob-source preference (either var name) so users can opt out
-  # of blob ingestion via `azd env set` before `azd up`.
-  _qs_blob=$(azd_get OMNIVEC_ENABLE_BLOB_SOURCE)
-  if [ -z "$_qs_blob" ]; then
-    _qs_blob=$(azd_get AZURE_ENABLE_BLOB_SOURCE)
-  fi
-  _qs_blob=${_qs_blob:-true}
   azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE "Standard_B4ms" < /dev/null
   azd env set OMNIVEC_SYSTEM_NODE_COUNT   "2" < /dev/null
   azd env set OMNIVEC_GPU_NODE_VM_SIZE    "" < /dev/null
   azd env set OMNIVEC_GPU_NODE_COUNT      "0" < /dev/null
   azd env set OMNIVEC_METADATA_STORE      "cosmosdb-serverless" < /dev/null
-  azd env set OMNIVEC_ENABLE_BLOB_SOURCE  "$_qs_blob" < /dev/null
   echo "  OMNIVEC_SYSTEM_NODE_VM_SIZE = Standard_B4ms"
   echo "  OMNIVEC_SYSTEM_NODE_COUNT   = 2"
   echo "  OMNIVEC_GPU_NODE_VM_SIZE    = (none)"
   echo "  OMNIVEC_GPU_NODE_COUNT      = 0"
   echo "  OMNIVEC_METADATA_STORE      = cosmosdb-serverless"
-  echo "  OMNIVEC_ENABLE_BLOB_SOURCE  = $_qs_blob"
   echo ""
   echo "  System pool: 2x Standard_B4ms (4 vCPU, 16 GB each)"
   echo "  GPU pool: none (use Azure OpenAI for embeddings)"
   echo "  Metadata: CosmosDB Serverless"
-  if [ "$_qs_blob" = "true" ]; then
-    echo "  Blob source: enabled"
-  else
-    echo "  Blob source: disabled (CosmosDB sources only)"
-  fi
+  echo "  Blob storage source: enabled"
   printf "\n${GREEN}Pre-provision checks passed. Proceeding with Bicep deployment...${NC}\n"
   exit 0
 fi
@@ -439,34 +402,6 @@ else
     *)
       printf "${GREEN}Using CosmosDB Serverless for metadata storage.${NC}\n"
       azd env set OMNIVEC_METADATA_STORE "cosmosdb-serverless" < /dev/null
-      ;;
-  esac
-fi
-
-# ── Blob storage source ─────────────────────────────────────────────────────
-
-cur_blob=$(azd_get OMNIVEC_ENABLE_BLOB_SOURCE)
-if [ -n "$cur_blob" ]; then
-  printf "${GREEN}Blob source: ${cur_blob} (already set)${NC}\n"
-else
-  echo ""
-  printf "${YELLOW}Will you use Azure Blob Storage as a document source?${NC}\n"
-  echo "  If yes, Service Bus (jobs queue) and Event Grid (blob event routing)"
-  echo "  will be created alongside the Storage Account."
-  echo ""
-  echo "  1) Yes — enable blob source ingestion"
-  echo "  2) No  — CosmosDB sources only (skip Service Bus + Event Grid)"
-  echo ""
-  blob_choice=$(read_input "Choice [1]: ")
-  blob_choice=${blob_choice:-1}
-  case "$blob_choice" in
-    1)
-      printf "${GREEN}Blob source enabled.${NC}\n"
-      azd env set OMNIVEC_ENABLE_BLOB_SOURCE "true" < /dev/null
-      ;;
-    *)
-      printf "${GREEN}Blob source disabled.${NC}\n"
-      azd env set OMNIVEC_ENABLE_BLOB_SOURCE "false" < /dev/null
       ;;
   esac
 fi
@@ -613,7 +548,7 @@ azd env set OMNIVEC_GPU_NODE_COUNT "$gpu_count" < /dev/null
 
 # ── Sanitize env values: strip BOM, tabs, carriage returns ──────────────────
 printf "\n${CYAN}Sanitizing environment values...${NC}\n"
-for key in OMNIVEC_SYSTEM_NODE_VM_SIZE OMNIVEC_SYSTEM_NODE_COUNT OMNIVEC_GPU_NODE_VM_SIZE OMNIVEC_GPU_NODE_COUNT OMNIVEC_ENABLE_BLOB_SOURCE OMNIVEC_METADATA_STORE; do
+for key in OMNIVEC_SYSTEM_NODE_VM_SIZE OMNIVEC_SYSTEM_NODE_COUNT OMNIVEC_GPU_NODE_VM_SIZE OMNIVEC_GPU_NODE_COUNT OMNIVEC_METADATA_STORE; do
   raw=$(azd_get "$key")
   if [ -n "$raw" ]; then
     clean=$(printf '%s' "$raw" | tr -d '\r\t' | sed 's/^\xEF\xBB\xBF//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
@@ -628,11 +563,7 @@ printf "\n${GREEN}Pre-provision checks passed. Proceeding with Bicep deployment.
 printf "${CYAN}Environment: ${AZURE_ENV_NAME}${NC}\n"
 printf "${CYAN}Each installation gets a unique resource token derived from (subscription + resource group + env name).${NC}\n"
 
-# ── b4/c2: Final preflight — quota + blob-flip guard + re-sanitize ──────────
-if command -v preflight_blob_flip_guard >/dev/null 2>&1; then
-  _want_blob=$(azd_get OMNIVEC_ENABLE_BLOB_SOURCE)
-  preflight_blob_flip_guard "$RG_NAME" "${_want_blob:-true}" || exit 1
-fi
+# ── b4/c2: Final preflight — quota + re-sanitize ────────────────────────────
 if command -v preflight_vcpu_quota >/dev/null 2>&1; then
   _sys_sku=$(azd_get OMNIVEC_SYSTEM_NODE_VM_SIZE)
   _sys_count=$(azd_get OMNIVEC_SYSTEM_NODE_COUNT)
@@ -641,7 +572,7 @@ if command -v preflight_vcpu_quota >/dev/null 2>&1; then
   preflight_vcpu_quota "$LOCATION" "$_sys_sku" "$_sys_count" "$_gpu_sku" "$_gpu_count" || true
 fi
 if command -v preflight_sanitize_env >/dev/null 2>&1; then
-  for _k in OMNIVEC_SYSTEM_NODE_VM_SIZE OMNIVEC_SYSTEM_NODE_COUNT OMNIVEC_GPU_NODE_VM_SIZE OMNIVEC_GPU_NODE_COUNT OMNIVEC_ENABLE_BLOB_SOURCE OMNIVEC_METADATA_STORE; do
+  for _k in OMNIVEC_SYSTEM_NODE_VM_SIZE OMNIVEC_SYSTEM_NODE_COUNT OMNIVEC_GPU_NODE_VM_SIZE OMNIVEC_GPU_NODE_COUNT OMNIVEC_METADATA_STORE; do
     preflight_sanitize_env "$_k" || true
   done
 fi

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -28,7 +28,7 @@ param gpuNodeVmSize string = 'Standard_NC6s_v3'
 @description('Initial GPU node count (0 to skip GPU pool). String for the same reason as systemNodeCount.')
 param gpuNodeCount string = '0'
 
-@description('Enable blob storage as a document source (creates Storage Account, Service Bus, Event Grid). String form: "true"/"false"/"1"/"0"/"yes"/"no" (case-insensitive). Empty -> defaults to true.')
+@description('DEPRECATED: Storage Account, Service Bus, and Event Grid are now always provisioned. This parameter is kept for backward compatibility with existing azd envs and is ignored.')
 param enableBlobSource string = 'true'
 
 // =============================================================================
@@ -41,14 +41,9 @@ param enableBlobSource string = 'true'
 
 var _sysCountClean  = trim(replace(replace(systemNodeCount, '\u{FEFF}', ''), '\r', ''))
 var _gpuCountClean  = trim(replace(replace(gpuNodeCount,    '\u{FEFF}', ''), '\r', ''))
-var _blobClean      = toLower(trim(replace(replace(enableBlobSource, '\u{FEFF}', ''), '\r', '')))
 
 var systemNodeCountInt   = empty(_sysCountClean) ? 2 : int(_sysCountClean)
 var gpuNodeCountInt      = empty(_gpuCountClean) ? 0 : int(_gpuCountClean)
-// Empty -> preserves prior default (true). Explicit false-tokens -> false. Anything else -> true.
-var enableBlobSourceBool = empty(_blobClean)
-  ? true
-  : !(_blobClean == 'false' || _blobClean == '0' || _blobClean == 'no')
 
 // =============================================================================
 // NAMING (must be computed before resource group to avoid circular dependency)
@@ -117,8 +112,9 @@ module keyvault 'modules/keyvault.bicep' = {
   }
 }
 
-// 4. Storage Account (only when blob source is enabled)
-module storage 'modules/storage.bicep' = if (enableBlobSourceBool) {
+// 4. Storage Account (always provisioned — required for blob sources and
+//    queue-mode processing without a separate redeploy).
+module storage 'modules/storage.bicep' = {
   name: 'storage'
   scope: rg
   params: {
@@ -129,8 +125,9 @@ module storage 'modules/storage.bicep' = if (enableBlobSourceBool) {
   }
 }
 
-// 4. Service Bus (only when blob source is enabled)
-module servicebus 'modules/servicebus.bicep' = if (enableBlobSourceBool) {
+// 4. Service Bus (always provisioned — needed for the queue processing
+//    mode embeddings topic and for blob-event push delivery).
+module servicebus 'modules/servicebus.bicep' = {
   name: 'servicebus'
   scope: rg
   params: {
@@ -141,15 +138,16 @@ module servicebus 'modules/servicebus.bicep' = if (enableBlobSourceBool) {
   }
 }
 
-// 5. Event Grid (only when blob source is enabled)
-module eventgrid 'modules/eventgrid.bicep' = if (enableBlobSourceBool) {
+// 5. Event Grid (always provisioned — used for blob-event push delivery
+//    to the Service Bus queue).
+module eventgrid 'modules/eventgrid.bicep' = {
   name: 'eventgrid'
   scope: rg
   params: {
     topicName: '${prefix}-blob-events-${resourceToken}'
     location: location
     tags: tags
-    storageAccountId: storage!.outputs.accountId
+    storageAccountId: storage.outputs.accountId
     identityPrincipalId: identity.outputs.principalId
   }
 }
@@ -233,12 +231,14 @@ output AZURE_ACR_LOGIN_SERVER string = acr.outputs.loginServer
 output AZURE_ACR_NAME string = acr.outputs.registryName
 output AZURE_COSMOS_ENDPOINT string = cosmosdb.outputs.endpoint
 output AZURE_COSMOS_ACCOUNT_NAME string = cosmosdb.outputs.accountName
-output AZURE_ENABLE_BLOB_SOURCE string = enableBlobSourceBool ? 'true' : 'false'
-output AZURE_STORAGE_ACCOUNT_NAME string = enableBlobSourceBool ? storage!.outputs.accountName : ''
-output AZURE_STORAGE_BLOB_ENDPOINT string = enableBlobSourceBool ? storage!.outputs.primaryBlobEndpoint : ''
-output AZURE_STORAGE_QUEUE_ENDPOINT string = enableBlobSourceBool ? storage!.outputs.queueEndpoint : ''
-output AZURE_SERVICEBUS_NAMESPACE string = enableBlobSourceBool ? servicebus!.outputs.namespaceName : ''
-output AZURE_SERVICEBUS_ENDPOINT string = enableBlobSourceBool ? servicebus!.outputs.endpoint : ''
+// AZURE_ENABLE_BLOB_SOURCE retained as a constant 'true' so any downstream
+// hook / script that still reads it gets a safe value.
+output AZURE_ENABLE_BLOB_SOURCE string = 'true'
+output AZURE_STORAGE_ACCOUNT_NAME string = storage.outputs.accountName
+output AZURE_STORAGE_BLOB_ENDPOINT string = storage.outputs.primaryBlobEndpoint
+output AZURE_STORAGE_QUEUE_ENDPOINT string = storage.outputs.queueEndpoint
+output AZURE_SERVICEBUS_NAMESPACE string = servicebus.outputs.namespaceName
+output AZURE_SERVICEBUS_ENDPOINT string = servicebus.outputs.endpoint
 output AZURE_IDENTITY_CLIENT_ID string = identity.outputs.clientId
 output AZURE_KEYVAULT_URI string = keyvault.outputs.vaultUri
 output AZURE_APPINSIGHTS_CONNECTION_STRING string = appinsights.outputs.connectionString

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -22,9 +22,6 @@
     },
     "gpuNodeCount": {
       "value": "${OMNIVEC_GPU_NODE_COUNT}"
-    },
-    "enableBlobSource": {
-      "value": "${OMNIVEC_ENABLE_BLOB_SOURCE}"
     }
   }
 }

--- a/scripts/e2e-demo.ps1
+++ b/scripts/e2e-demo.ps1
@@ -362,7 +362,6 @@ if ($FromStep -le 1) {
         }
     }
     azd env set OMNIVEC_METADATA_STORE "cosmosdb-serverless"
-    azd env set OMNIVEC_ENABLE_BLOB_SOURCE "true"
     azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE "Standard_D4ds_v6"
     azd env set OMNIVEC_SYSTEM_NODE_COUNT 2
     azd env set OMNIVEC_GPU_NODE_VM_SIZE "Standard_NC6s_v3"

--- a/scripts/e2e-demo.sh
+++ b/scripts/e2e-demo.sh
@@ -489,7 +489,6 @@ if [ "$FROM_STEP" -le 1 ]; then
     fi
   fi
   azd env set OMNIVEC_METADATA_STORE "cosmosdb-serverless"
-  azd env set OMNIVEC_ENABLE_BLOB_SOURCE "true"
   azd env set OMNIVEC_SYSTEM_NODE_VM_SIZE "Standard_D4ds_v6"
   azd env set OMNIVEC_SYSTEM_NODE_COUNT 2
   azd env set OMNIVEC_GPU_NODE_VM_SIZE "Standard_NC6s_v3"

--- a/scripts/test-hooks.ps1
+++ b/scripts/test-hooks.ps1
@@ -1000,7 +1000,7 @@ function Test-Scenario12 {
     Initialize-LockDir "test-env"
 
     $envFile = Join-Path $testDir ".env"
-    Set-Content $envFile "OMNIVEC_METADATA_STORE=`"cosmosdb-serverless`"`nOMNIVEC_ENABLE_BLOB_SOURCE=`"true`"" -Encoding UTF8
+    Set-Content $envFile "OMNIVEC_METADATA_STORE=`"cosmosdb-serverless`"" -Encoding UTF8
 
     $azBody = Get-AzMockBody @{
         "group exists"    = @{ Output = "false"; ExitCode = 0 }
@@ -1029,9 +1029,8 @@ function Test-Scenario12 {
         -StdinText "4`n2`n0`n"
 
     $skippedMeta = $result.Output -match "cosmosdb-serverless.*already set"
-    $skippedBlob = $result.Output -match "true.*already set"
     $showedSku   = $result.Output -match "System node pool|Common options"
-    Assert-Test "Scenario 12: Partial config — skips set vars, prompts missing ones" ($skippedMeta -and $skippedBlob -and $showedSku)
+    Assert-Test "Scenario 12: Partial config — skips set vars, prompts missing ones" ($skippedMeta -and $showedSku)
 
     Remove-TestDir $testDir
 }

--- a/tests/emu/run-azd-up.sh
+++ b/tests/emu/run-azd-up.sh
@@ -75,7 +75,6 @@ azd env set AZURE_STORAGE_QUEUE_ENDPOINT    "https://omnivecstg${INSTANCE_ID}.qu
 azd env set AZURE_SERVICEBUS_ENDPOINT       "omnivec-sb-${INSTANCE_ID}.servicebus.windows.net"
 azd env set AZURE_APPINSIGHTS_CONNECTION_STRING "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://emu.applicationinsights.azure.com/"
 azd env set AZURE_LOG_ANALYTICS_WORKSPACE_ID "00000000-0000-0000-0000-000000000000"
-azd env set AZURE_ENABLE_BLOB_SOURCE        "true"
 azd env set OMNIVEC_BUILD_MODE              "acr"
 
 # ── Phase 3: postprovision ──────────────────────────────────────────────────

--- a/tests/hooks/test-mock-harness.sh
+++ b/tests/hooks/test-mock-harness.sh
@@ -68,8 +68,7 @@ chmod +x "$MOCKS_DIR"/azd "$MOCKS_DIR"/az "$MOCKS_DIR"/kubectl "$MOCKS_DIR"/helm
         'OMNIVEC_SYSTEM_NODE_VM_SIZE=Standard_B4ms' \
         'OMNIVEC_SYSTEM_NODE_COUNT=2' \
         'OMNIVEC_GPU_NODE_COUNT=0' \
-        'OMNIVEC_METADATA_STORE=cosmosdb-serverless' \
-        'OMNIVEC_ENABLE_BLOB_SOURCE=true'; do
+        'OMNIVEC_METADATA_STORE=cosmosdb-serverless'; do
         if ! grep -q "^${kv}\$" "$AZDENV"; then
             printf 'missing %s\n--- env store ---\n%s\n--- mock log ---\n%s\n' \
                 "$kv" "$(cat "$AZDENV")" "$(cat "$LOG")" >&2

--- a/tests/hooks/test-no-tty.sh
+++ b/tests/hooks/test-no-tty.sh
@@ -84,8 +84,7 @@ fi
     rc=$?
     if [ "$rc" -eq 0 ] \
        && ! printf '%s' "$out" | grep -q POSTCALL \
-       && grep -q 'OMNIVEC_SYSTEM_NODE_VM_SIZE=Standard_B4ms' "$AZDENV_FILE" \
-       && grep -q 'OMNIVEC_ENABLE_BLOB_SOURCE=true' "$AZDENV_FILE"; then
+       && grep -q 'OMNIVEC_SYSTEM_NODE_VM_SIZE=Standard_B4ms' "$AZDENV_FILE"; then
         exit 0
     fi
     printf 'rc=%s\nout=%s\nenv=%s\n' "$rc" "$out" "$(cat "$AZDENV_FILE")" >&2

--- a/tests/hooks/test-preflight.sh
+++ b/tests/hooks/test-preflight.sh
@@ -79,19 +79,19 @@ _rc=0
 preflight_vcpu_quota "eastus2" "Standard_B4ms" "20" "" "0" >/dev/null 2>&1 || _rc=$?
 ok "quota exhausted path exercised (rc=$_rc)"
 
-# ── 3. blob-flip: new=false, old=true → must fail ───────────────────────────
+# ── 3. blob-flip guard: deprecated no-op — always passes regardless of inputs.
 AZ_MOCK_TAGS=blob-true
 _rc=0
 preflight_blob_flip_guard "rg-omnivec-test" "false" >/dev/null 2>&1 || _rc=$?
-[ "$_rc" -ne 0 ] && ok "blob flip true→false blocked" || bad "blob flip true→false blocked" "rc=$_rc"
+[ "$_rc" -eq 0 ] && ok "blob flip guard is no-op (true→false allowed)" || bad "blob flip guard no-op" "rc=$_rc"
 
-# ── 4. blob-flip: new=true, old=true → pass ─────────────────────────────────
+# ── 4. blob-flip guard: same value still passes ────────────────────────────
 AZ_MOCK_TAGS=blob-true
 _rc=0
 preflight_blob_flip_guard "rg-omnivec-test" "true" >/dev/null 2>&1 || _rc=$?
 [ "$_rc" -eq 0 ] && ok "blob unchanged passes" || bad "blob unchanged passes" "rc=$_rc"
 
-# ── 5. blob-flip: no RG tag → pass (first-run) ──────────────────────────────
+# ── 5. blob-flip guard: no RG tag → pass ───────────────────────────────────
 AZ_MOCK_TAGS=none
 _rc=0
 preflight_blob_flip_guard "rg-omnivec-test" "false" >/dev/null 2>&1 || _rc=$?


### PR DESCRIPTION
## Summary

Drops the `OMNIVEC_ENABLE_BLOB_SOURCE` toggle in favor of unconditionally provisioning Storage Account + Service Bus + Event Grid at `azd up`. The Bicep param is kept as a deprecated no-op so existing azd envs with the value cached don't break.

## Why

- **UX**: previously, users who deployed with the flag `false` would hit `400` errors at runtime when creating azure-blob sources or queue-mode pipelines. The error message told them to re-deploy — a poor experience.
- **Queue mode also needs Service Bus** regardless of blob source, so the previous gating was incorrect in that direction too.
- **Cost** is negligible — these are pay-per-use resources.

## Changes

- `infra/main.bicep`: `storage` / `servicebus` / `eventgrid` modules unconditional; param kept as deprecated no-op (one `no-unused-params` lint warning is intentional).
- `infra/main.parameters.json`: drop `enableBlobSource` entry.
- `hooks/preprovision.{sh,ps1}`: strip interactive prompt, quickstart default, existing-RG tag-import flip guard, sanitize-loop entry, help text.
- `hooks/postprovision.{sh,ps1}`: drop `ENABLE_BLOB_SOURCE` guards; storage secret + `blobIngestor` always deployed.
- `hooks/lib/preflight.sh`: `preflight_blob_flip_guard` becomes no-op (kept for back-compat).
- `api/api.py`: `_BLOB_SOURCE_ENABLED` pinned `True`; `_require_blob_source_enabled` is now a no-op.
- `helm/omnivec/values.yaml`: `blobIngestor.enabled` default → `true`.
- `README` + `e2e-demo` scripts: drop `OMNIVEC_ENABLE_BLOB_SOURCE` references.
- Tests: preflight no-op assertions; mock-harness / no-tty / test-hooks.ps1 cleaned.

## Validation

- `az bicep build infra/main.bicep` → exit 0 (intentional `no-unused-params` warning on deprecated param)
- `bash -n` on all modified `.sh` files → clean
- `tests/hooks/test-preflight.sh` → 6 / 6 pass
- `tests/hooks/test-mock-harness.sh` → 5 / 5 pass
- `tests/hooks/test-no-tty.sh` → 11 / 11 pass
- `python -m py_compile api/api.py` → clean

## Backward compatibility

Users with `OMNIVEC_ENABLE_BLOB_SOURCE` set in their azd env on next `azd up`:
- value is silently ignored
- Storage / Service Bus / Event Grid are created (if not already present)
- no error, no behavioral regression