### PR TITLE
security: stricter sanitizers for partial-ssrf and log-injection follow-ups

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -51,8 +51,8 @@ from models import (  # lgtm[py/unused-import]
     ModelCategory, Assistant, CreateAssistantRequest, AssistantChatRequest
 )
 from store import init_store, get_store
-from security_utils import safe_url_segment, validate_outbound_url, validate_sql_identifier  # lgtm[py/unused-import]
-from urllib.parse import quote as _urlquote
+from security_utils import safe_agent_segment, safe_url_segment, validate_outbound_url, validate_sql_identifier  # lgtm[py/unused-import]
+from urllib.parse import quote as _urlquote  # noqa: F401 — kept for downstream callers
 
 logger = logging.getLogger(__name__)
 
@@ -1140,8 +1140,11 @@ async def agent_session_approvals(session_id: str, request: Request):
     if not _INTERNAL_API_TOKEN:
         raise HTTPException(status_code=503, detail="agent: INTERNAL_API_TOKEN not configured")
     user = _caller_id(request)
-    safe_user = _urlquote(user, safe="")
-    safe_sid = _urlquote(session_id, safe="")
+    try:
+        safe_user = safe_agent_segment(user)
+        safe_sid = safe_agent_segment(session_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     async with httpx.AsyncClient(timeout=httpx.Timeout(15.0)) as client:
         r = await client.get(f"{_AGENT_URL}/v1/sessions/{safe_user}/{safe_sid}/approvals", headers=_agent_headers(request))
         return JSONResponse(status_code=r.status_code, content=r.json())
@@ -1166,7 +1169,10 @@ async def agent_sessions_list(request: Request):
     if not _INTERNAL_API_TOKEN:
         raise HTTPException(status_code=503, detail="agent: INTERNAL_API_TOKEN not configured")
     user = _caller_id(request)
-    safe_user = _urlquote(user, safe="")
+    try:
+        safe_user = safe_agent_segment(user)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     async with httpx.AsyncClient(timeout=httpx.Timeout(15.0)) as client:
         r = await client.get(f"{_AGENT_URL}/v1/sessions/{safe_user}", headers=_agent_headers(request))
         return JSONResponse(status_code=r.status_code, content=r.json())
@@ -1177,8 +1183,11 @@ async def agent_session_get(session_id: str, request: Request):
     if not _INTERNAL_API_TOKEN:
         raise HTTPException(status_code=503, detail="agent: INTERNAL_API_TOKEN not configured")
     user = _caller_id(request)
-    safe_user = _urlquote(user, safe="")
-    safe_sid = _urlquote(session_id, safe="")
+    try:
+        safe_user = safe_agent_segment(user)
+        safe_sid = safe_agent_segment(session_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     async with httpx.AsyncClient(timeout=httpx.Timeout(15.0)) as client:
         r = await client.get(f"{_AGENT_URL}/v1/sessions/{safe_user}/{safe_sid}", headers=_agent_headers(request))
         return JSONResponse(status_code=r.status_code, content=r.json())
@@ -1189,8 +1198,11 @@ async def agent_session_delete(session_id: str, request: Request):
     if not _INTERNAL_API_TOKEN:
         raise HTTPException(status_code=503, detail="agent: INTERNAL_API_TOKEN not configured")
     user = _caller_id(request)
-    safe_user = _urlquote(user, safe="")
-    safe_sid = _urlquote(session_id, safe="")
+    try:
+        safe_user = safe_agent_segment(user)
+        safe_sid = safe_agent_segment(session_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     async with httpx.AsyncClient(timeout=httpx.Timeout(15.0)) as client:
         r = await client.delete(f"{_AGENT_URL}/v1/sessions/{safe_user}/{safe_sid}", headers=_agent_headers(request))
         return JSONResponse(status_code=r.status_code, content=r.json())

--- a/api/security_utils.py
+++ b/api/security_utils.py
@@ -155,6 +155,26 @@ def validate_sql_identifier(name: str, *, allow_dot: bool = False) -> str:
 # pip-*, trp-*, asst-*) plus user-defined transform/pipeline names.
 _SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.\-]{1,128}$")
 
+# Caller-id / agent-session segments — also allow '@' and '+' for UPNs / emails.
+_AGENT_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.+@\-]{1,256}$")
+
+
+def safe_agent_segment(value: str) -> str:
+    """Validate a caller-id or session-id for use as a URL path segment.
+
+    Accepts the union of IDs, GUIDs, emails and UPNs. Rejects anything
+    that could escape the segment (``/``, ``?``, ``#``, control chars,
+    or path traversal). Returns the value unchanged on success — the
+    regex guarantees it is already safe to interpolate into a URL.
+    """
+    if not isinstance(value, str) or not value:
+        raise ValueError("segment must be a non-empty string")
+    if not _AGENT_SEGMENT_RE.match(value):
+        raise ValueError(f"unsafe agent segment: {value!r}")
+    if value in (".", ".."):
+        raise ValueError("segment must not be '.' or '..'")
+    return value
+
 
 def safe_url_segment(value: str) -> str:
     """Validate and percent-encode ``value`` for use as a single URL path

--- a/docgrok/admin.py
+++ b/docgrok/admin.py
@@ -325,7 +325,8 @@ async def healthcheck_model(model_id: str):
             token = cred.get_token("https://cognitiveservices.azure.com/.default").token
             headers["Authorization"] = f"Bearer {token}"
         except Exception:
-            logger.exception("failed to acquire MI token for model %s", model_id)
+            safe_id = str(model_id).replace("\r", " ").replace("\n", " ")[:128]
+            logger.exception("failed to acquire MI token for model %s", safe_id)
             return {"ok": False, "status": 0, "detail": "failed to acquire managed-identity token; see server logs"}
     else:
         if not api_key:
@@ -337,7 +338,8 @@ async def healthcheck_model(model_id: str):
         try:
             r = await c.post(url, headers=headers, json={"input": "health check", "model": deployment})
         except Exception:
-            logger.exception("healthcheck request failed for model %s", model_id)
+            safe_id = str(model_id).replace("\r", " ").replace("\n", " ")[:128]
+            logger.exception("healthcheck request failed for model %s", safe_id)
             return {"ok": False, "status": 0, "detail": "request failed; see server logs"}
 
     body = r.text[:200]


### PR DESCRIPTION
Follow-up to #173. The CodeQL re-scan on `main` after #173 merged closed all 15 original alerts but opened **5 new ones** at the same locations because the fix patterns weren't strict enough:

- 3x `py/partial-ssrf` at `api/api.py:1146/1183/1195` — `urllib.parse.quote(value, safe='')` percent-encodes but CodeQL doesn't treat it as a sanitizer (the value still flows into the URL).
- 2x `py/log-injection` at `docgrok/admin.py:328/340` — new `logger.exception(...)` calls pass `model_id` (user-controlled) directly into the log format string.

### Fix

- **`api/security_utils.py`**: new `safe_agent_segment(value)` helper that validates against a strict regex allowlist (`^[A-Za-z0-9_.+@-]{1,256}$`) and raises ValueError otherwise. Accepts UPNs/emails/GUIDs/IDs but rejects `/?#` and control chars. Returns the value unchanged — the regex itself is the sanitizer CodeQL recognizes.
- **`api/api.py`**: all 4 agent-proxy endpoints (sessions list/get/delete/approvals) now use `safe_agent_segment` wrapped in try/except → HTTP 400 on bad input.
- **`docgrok/admin.py`**: `model_id` is sanitized via `.replace('\r',' ').replace('\n',' ')[:128]` before being passed to `logger.exception`.

### Verification

Will be confirmed by the post-merge CodeQL re-scan: expected = 0 open alerts on `main`.
