### PR TITLE
ci(binskim): fix 'expected a result message' SARIF upload errors

### DIFF
--- a/scripts/security/filter_binskim_sarif.py
+++ b/scripts/security/filter_binskim_sarif.py
@@ -39,6 +39,56 @@ def matches(result: dict, supp: dict) -> bool:
     return False
 
 
+def _resolve_message_text(result: dict, rule: dict | None) -> str:
+    """Resolve SARIF message.text from message.id + arguments when the tool
+    only emitted a message reference. GitHub Code Scanning requires
+    message.text directly; missing text yields the upload error
+    "expected a result message".
+    """
+    msg = result.get("message") or {}
+    text = msg.get("text")
+    if text:
+        return text
+    msg_id = msg.get("id")
+    args = msg.get("arguments") or []
+    template = ""
+    if rule and msg_id:
+        strings = rule.get("messageStrings") or {}
+        entry = strings.get(msg_id) or {}
+        template = entry.get("text") or ""
+    if not template:
+        # Fall back to a deterministic placeholder so SARIF stays uploadable.
+        return f"{result.get('ruleId', 'rule')}: {msg_id or 'no message text'}"
+    try:
+        # SARIF templates use {0}, {1}, ... placeholders.
+        return template.format(*args)
+    except (IndexError, KeyError):
+        return template
+
+
+def _ensure_message_text(sarif: dict) -> int:
+    """Walk all results and synthesize message.text if missing. Returns
+    the number of results that were patched."""
+    patched = 0
+    for run in sarif.get("runs", []) or []:
+        rules = ((run.get("tool") or {}).get("driver") or {}).get("rules") or []
+        for r in run.get("results", []) or []:
+            msg = r.get("message") or {}
+            if msg.get("text"):
+                continue
+            idx = r.get("ruleIndex")
+            rule = None
+            if isinstance(idx, int) and 0 <= idx < len(rules):
+                rule = rules[idx]
+            if rule is None:
+                rid = r.get("ruleId")
+                rule = next((x for x in rules if x.get("id") == rid), None)
+            msg["text"] = _resolve_message_text(r, rule)
+            r["message"] = msg
+            patched += 1
+    return patched
+
+
 def main(argv: list[str]) -> int:
     if len(argv) < 3:
         print(__doc__, file=sys.stderr)
@@ -84,6 +134,7 @@ def main(argv: list[str]) -> int:
         run["results"] = new_results
 
     outp.parent.mkdir(parents=True, exist_ok=True)
+    patched = _ensure_message_text(sarif)
     with outp.open("w", encoding="utf-8") as fh:
         json.dump(sarif, fh, indent=2)
 
@@ -95,7 +146,7 @@ def main(argv: list[str]) -> int:
     )
     print(
         f"BinSkim filter: kept={kept} suppressed={dropped} "
-        f"unsuppressed_fails_or_warnings={fails} -> {outp}"
+        f"unsuppressed_fails_or_warnings={fails} message_text_patched={patched} -> {outp}"
     )
     return 0 if fails == 0 else 1
 


### PR DESCRIPTION
Fixes the BinSkim "Code Scanning failed - 2 errors" banner on the `binskim-rust` configuration page (https://github.com/AzureCosmosDB/OmniVec/security/code-scanning).

### Root cause

BinSkim emits SARIF results that reference rule `messageStrings` by id (e.g. `message.id = "Warning_NativeWithInsecureStaticLibraryCompilands"` plus `arguments`), without an inlined `message.text` field.

GitHub Code Scanning's SARIF ingester requires `message.text` to be present directly on every result, so the upload was failing with:

```
expected a result message, expected a result message
```

The 2 errors correspond to the 2 suppressed BinSkim results on `docgrok-router.exe` (rules `BA2004` and `BA2024`, both with documented upstream-toolchain justifications in `scripts/security/binskim_suppressions.json`).

### Fix

`scripts/security/filter_binskim_sarif.py` already walked the SARIF to suppress documented findings. Extended it to also synthesize `message.text` when missing:

1. For each result without `message.text`, look up `tool.driver.rules[ruleIndex].messageStrings[message.id].text`.
2. Substitute `arguments` into the `{0}`, `{1}`, … placeholders.
3. Write the resolved text back to `message.text`.

Falls back to a deterministic placeholder (`<ruleId>: <messageId>`) if the template cannot be resolved, so the SARIF always uploads.

### Verification

Tested locally against the actual SARIF artifact downloaded from the most recent main-branch run:

```
BinSkim filter: kept=0 suppressed=2 unsuppressed_fails_or_warnings=0 message_text_patched=2
results without message.text: 0
```

No security findings change — the 2 results remain suppressed at `level: note` with their existing justifications. This PR only fixes the SARIF format so the upload succeeds and the BinSkim configuration page shows clean instead of "2 errors".
