### PR TITLE
ci(binskim): drop invalid 'suppressions' field on notifications

### DIFF
--- a/scripts/security/filter_binskim_sarif.py
+++ b/scripts/security/filter_binskim_sarif.py
@@ -126,13 +126,19 @@ def _normalize_invocations(sarif: dict, notif_suppressions: list[dict]) -> int:
                 if not matched:
                     continue
                 notif["level"] = "note"
-                notif.setdefault("suppressions", []).append(
-                    {
-                        "kind": "external",
-                        "status": "accepted",
-                        "justification": matched.get("reason", ""),
-                    }
-                )
+                # NOTE: SARIF 2.1.0 does not allow `suppressions` on
+                # toolConfigurationNotifications (only on results). The audit
+                # trail lives in binskim_suppressions.json; here we just record
+                # the justification in the notification message for visibility.
+                reason = matched.get("reason", "")
+                if reason:
+                    msg = notif.setdefault("message", {})
+                    base_text = msg.get("text") or msg.get("id", "")
+                    msg["text"] = (
+                        f"{base_text}\n[binskim_suppressions.json] {reason}"
+                        if base_text
+                        else f"[binskim_suppressions.json] {reason}"
+                    )
                 demoted += 1
             remaining_errors = sum(
                 1


### PR DESCRIPTION
PR #176 added a `suppressions` array to demoted `toolConfigurationNotifications` for audit-trail purposes, but **SARIF 2.1.0 only allows `suppressions` on `result` objects, not on notifications**. The binskim-go SARIF upload on the PR #176 merge commit (sha 26e00cb9) failed with:

```r
instance.runs[0].invocations[0].toolConfigurationNotifications[0] is not allowed to have the additional property 'suppressions'
```

This PR moves the justification text into the notification's `message.text` (visible inline) and keeps the canonical audit record in `binskim_suppressions.json`. Level demotion to `note` and `executionSuccessful=true` flip are unchanged.

Verified locally against the failed go SARIF — schema validates clean against the OASIS SARIF 2.1.0 JSON schema.