### PR TITLE
feat(playground): add full-text and hybrid search modes

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -5495,11 +5495,29 @@ class PlaygroundSearchRequest(BaseModel):
     destination_ids: List[str]
     top_k: int = 5
     merge_strategy: str = "rrf"  # rrf | interleave | score
+    search_mode: str = "vector"  # vector | fts | hybrid
+    fts_field: Optional[str] = None  # full-text path; defaults to first content field
 
 
-async def _build_index_specs(destination_ids: List[str]) -> tuple[List[Dict[str, Any]], List[str]]:
+async def _build_index_specs(
+    destination_ids: List[str],
+    search_mode: str = "vector",
+    fts_field: Optional[str] = None,
+) -> tuple[List[Dict[str, Any]], List[str]]:
     """Build IndexSpec[] for a set of destination ids by joining with pipelines.
+
+    search_mode controls which index specs are emitted per destination:
+      - "vector": ANN over the embedding column (default).
+      - "fts":    Cosmos full-text search over the content field.
+      - "hybrid": both a vector and an fts spec per destination, combined via RRF.
+    In hybrid mode the two specs get suffixed ids ("<dest>::vec" / "<dest>::fts")
+    so the merge layer treats them as distinct indexes.
+
     Returns (indexes, warnings)."""
+    search_mode = (search_mode or "vector").lower()
+    want_vector = search_mode in ("vector", "hybrid")
+    want_fts = search_mode in ("fts", "hybrid")
+    hybrid = search_mode == "hybrid"
     warnings: List[str] = []
     indexes: List[Dict[str, Any]] = []
     store = get_store()
@@ -5571,21 +5589,40 @@ async def _build_index_specs(destination_ids: List[str]) -> tuple[List[Dict[str,
                             if vi_path == vf:
                                 break
             dims = dims or 1024
-            indexes.append({
-                "id": dest_id,
-                "store": {
-                    "type": "cosmosdb",
-                    "endpoint": inline_override_endpoint or cfg.get("endpoint", ""),
-                    "database": inline_override_database or cfg.get("database", ""),
-                    "container": inline_override_container or cfg.get("container", ""),
-                    "auth": {"mode": "managed_identity"},
-                },
-                "vector": {"field": vf, "dims": dims, "metric": "cosine"},
-                "embedding": embedding,
-                "content_fields": cf,
-                "pipeline_id": matched_pip.get("id"),
-            })
+            cosmos_store = {
+                "type": "cosmosdb",
+                "endpoint": inline_override_endpoint or cfg.get("endpoint", ""),
+                "database": inline_override_database or cfg.get("database", ""),
+                "container": inline_override_container or cfg.get("container", ""),
+                "auth": {"mode": "managed_identity"},
+            }
+            if want_vector:
+                indexes.append({
+                    "id": f"{dest_id}::vec" if hybrid else dest_id,
+                    "store": cosmos_store,
+                    "mode": "vector",
+                    "vector": {"field": vf, "dims": dims, "metric": "cosine"},
+                    "embedding": embedding,
+                    "content_fields": cf,
+                    "pipeline_id": matched_pip.get("id"),
+                    **({"fusion_group": dest_id} if hybrid else {}),
+                })
+            if want_fts:
+                indexes.append({
+                    "id": f"{dest_id}::fts" if hybrid else dest_id,
+                    "store": cosmos_store,
+                    "mode": "fts",
+                    "fts_field": fts_field or (cf[0] if cf else "content"),
+                    "content_fields": cf,
+                    "pipeline_id": matched_pip.get("id"),
+                    **({"fusion_group": dest_id} if hybrid else {}),
+                })
         elif dtype == "pgvector":
+            if want_fts and not want_vector:
+                warnings.append(f"destination {dest_id} (pgvector) does not support full-text search")
+                continue
+            if want_fts:
+                warnings.append(f"destination {dest_id} (pgvector) does not support full-text search; using vector only")
             indexes.append({
                 "id": dest_id,
                 "store": {
@@ -5600,6 +5637,7 @@ async def _build_index_specs(destination_ids: List[str]) -> tuple[List[Dict[str,
                     "id_column": cfg.get("id_column", "id"),
                     "content_column": cfg.get("content_column", "content"),
                 },
+                "mode": "vector",
                 "vector": {"field": cfg.get("vector_column", "embedding"), "dims": cfg.get("vector_dimensions", 1024), "metric": "cosine"},
                 "embedding": embedding,
                 "content_fields": cf,
@@ -5624,11 +5662,29 @@ async def playground_search(req: PlaygroundSearchRequest):
     if not SEARCH_INTERNAL_TOKEN:
         raise HTTPException(status_code=503, detail="Search service not configured (SEARCH_INTERNAL_TOKEN missing)")
 
-    indexes, warnings = await _build_index_specs(req.destination_ids)
+    search_mode = (req.search_mode or "vector").lower()
+    if search_mode not in ("vector", "fts", "hybrid"):
+        raise HTTPException(status_code=400, detail=f"invalid search_mode '{req.search_mode}'")
+    # FTS needs a text query; image-only queries can't drive full-text search.
+    if search_mode == "fts" and not has_text:
+        raise HTTPException(status_code=400, detail="full-text search requires a text query")
+
+    indexes, warnings = await _build_index_specs(req.destination_ids, search_mode, req.fts_field)
     if not indexes:
         raise HTTPException(
             status_code=400,
             detail="No searchable indexes resolved from destination_ids: " + "; ".join(warnings))
+    # Hybrid emits two specs (vector + fts) per Cosmos destination; the search
+    # service caps a request at 10 indexes.
+    if len(indexes) > 10:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Too many indexes for one search "
+                f"({len(indexes)} > 10). "
+                + ("Hybrid mode uses 2 indexes per destination; select fewer destinations."
+                   if search_mode == "hybrid" else "Select fewer destinations.")
+            ))
 
     # Map UI merge strategy to search-service merge spec.
     # Search service accepts: rrf | score | round_robin | per_index
@@ -5642,15 +5698,32 @@ async def playground_search(req: PlaygroundSearchRequest):
         "per_index": "per_index",
     }
     merge_strategy = strategy_map.get(ui_strategy, "rrf")
+    # FTS hits carry no comparable native score, and hybrid fuses heterogeneous
+    # vector + FTS rankings; RRF is the only strategy that ranks these correctly.
+    if search_mode in ("fts", "hybrid") and merge_strategy != "rrf":
+        merge_strategy = "rrf"
     merge_spec = {"strategy": merge_strategy}
 
     # Build lookup of destination metadata for enriching the response with names.
+    # In hybrid mode index ids are suffixed ("<dest>::vec" / "<dest>::fts"); strip
+    # the suffix to resolve the destination name and append a mode label.
     store = get_store()
     dest_name_map: Dict[str, str] = {}
     for dest_id in req.destination_ids:
         dd = await asyncio.to_thread(store.get, dest_id, "destination")
         if dd:
             dest_name_map[dest_id] = dd.get("name") or dest_id
+
+    def _resolve_index_name(idx_id: Optional[str]) -> Optional[str]:
+        if not idx_id:
+            return idx_id
+        base, _, suffix = idx_id.partition("::")
+        name = dest_name_map.get(base, base)
+        if suffix == "vec":
+            return f"{name} (vector)"
+        if suffix == "fts":
+            return f"{name} (full-text)"
+        return name
 
     payload = {
         "query": req.query,
@@ -5685,13 +5758,14 @@ async def playground_search(req: PlaygroundSearchRequest):
     # Enrich each result with a friendly index_name (destination name).
     for r in results:
         idx_id = r.get("index_id")
-        if idx_id and idx_id in dest_name_map:
-            r["index_name"] = dest_name_map[idx_id]
+        name = _resolve_index_name(idx_id)
+        if name:
+            r["index_name"] = name
 
     indexes_searched = [
         {
             "index_id": pi.get("index_id"),
-            "index_name": dest_name_map.get(pi.get("index_id"), pi.get("index_id")),
+            "index_name": _resolve_index_name(pi.get("index_id")),
             "result_count": pi.get("result_count", 0),
             "search_time_ms": pi.get("search_ms", 0),
             "error": pi.get("error"),

--- a/search/schemas.py
+++ b/search/schemas.py
@@ -163,6 +163,16 @@ class IndexSpec(BaseModel):
     filter: Optional[IndexFilter] = None
     top_k: Optional[int] = Field(default=None, ge=1, le=500)
     pipeline_id: Optional[str] = Field(default=None, description="Source pipeline id; surfaced into result metadata for blob preview")
+    fusion_group: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional grouping key for rank fusion. Indexes sharing the same "
+            "fusion_group are treated as one logical source during RRF merge, so a "
+            "document returned by several of them (e.g. a vector spec and an fts spec "
+            "over the same container in hybrid search) is fused into a single result "
+            "with combined RRF score instead of appearing once per index."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_mode(self):

--- a/search/searcher.py
+++ b/search/searcher.py
@@ -627,9 +627,16 @@ async def _search_one_index(
 
 
 def _merge(
-    per_index_hits: List[Tuple[str, List[dict]]], cfg: MergeConfig, top_k: int
+    per_index_hits: List[Tuple[str, List[dict]]], cfg: MergeConfig, top_k: int,
+    fusion_groups: Optional[Dict[str, str]] = None,
 ) -> List[dict]:
-    """Return merged list of hit dicts with fields: index_id, id, rank, score, rrf_score, ..."""
+    """Return merged list of hit dicts with fields: index_id, id, rank, score, rrf_score, ...
+
+    fusion_groups maps index_id -> fusion_group. Under rrf, indexes sharing a
+    fusion_group are fused on (fusion_group, doc_id) so the same document found by
+    a vector spec and an fts spec over the same container (hybrid search) collapses
+    into one result with a combined RRF score."""
+    fusion_groups = fusion_groups or {}
     if cfg.strategy == "per_index":
         out: List[dict] = []
         for idx_id, hits in per_index_hits:
@@ -643,12 +650,13 @@ def _merge(
     if cfg.strategy == "rrf":
         scores: Dict[Tuple[str, Any], Dict[str, Any]] = {}
         for idx_id, hits in per_index_hits:
+            group = fusion_groups.get(idx_id) or idx_id
             for rank, h in enumerate(hits, start=1):
-                key = (idx_id, h.get("id"))
+                key = (group, h.get("id"))
                 contrib = 1.0 / (cfg.rrf_k + rank)
                 if key not in scores:
                     entry = dict(h)
-                    entry["index_id"] = idx_id
+                    entry["index_id"] = group
                     entry["rrf_score"] = contrib
                     scores[key] = entry
                 else:
@@ -748,7 +756,8 @@ async def run_search(http: httpx.AsyncClient, req: SearchRequest) -> SearchRespo
         )
 
     t_merge = time.time()
-    merged = _merge(per_index_hits, req.merge, req.top_k)
+    fusion_groups = {ix.id: ix.fusion_group for ix in req.indexes if ix.fusion_group}
+    merged = _merge(per_index_hits, req.merge, req.top_k, fusion_groups)
     merge_ms = int((time.time() - t_merge) * 1000)
 
     # Build index_id -> input_modality map for entity_type tagging.

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1727,7 +1727,7 @@
 
             <section id="section-playground" class="section" style="display: none;">
                 <header class="header">
-                    <h2 class="header-title">Vector Search Playground</h2>
+                    <h2 class="header-title">Search Playground</h2>
                 </header>
 
                 <div class="content">
@@ -1755,6 +1755,14 @@
                             </div>
                             <div style="margin-top: 16px; display: flex; gap: 16px; align-items: center;">
                                 <div class="form-group" style="margin-bottom: 0; display: flex; align-items: center; gap: 8px;">
+                                    <label class="form-label" style="margin-bottom: 0; white-space: nowrap;">Mode:</label>
+                                    <select class="form-input" id="playground-search-mode" style="width: 130px; padding: 6px 10px;" onchange="onPlaygroundModeChange()">
+                                        <option value="vector" selected>Vector</option>
+                                        <option value="fts">Full-Text</option>
+                                        <option value="hybrid">Hybrid</option>
+                                    </select>
+                                </div>
+                                <div class="form-group" style="margin-bottom: 0; display: flex; align-items: center; gap: 8px;">
                                     <label class="form-label" style="margin-bottom: 0; white-space: nowrap;">Top K:</label>
                                     <input type="number" class="form-input" id="playground-topk" value="5" min="1" max="20" style="width: 70px; text-align: center;">
                                 </div>
@@ -1764,6 +1772,7 @@
                                         <option value="interleave" selected>Interleave by Score</option>
                                         <option value="round_robin">Round Robin</option>
                                         <option value="per_index">Per-Index Cap</option>
+                                        <option value="rrf">RRF (rank fusion)</option>
                                     </select>
                                 </div>
                                 <div class="form-group" style="margin-bottom: 0; display: flex; align-items: center; gap: 8px;">
@@ -11952,12 +11961,27 @@
             });
         }
 
+        function onPlaygroundModeChange() {
+            const mode = document.getElementById('playground-search-mode').value;
+            const mergeEl = document.getElementById('playground-merge-strategy');
+            const imageEl = document.getElementById('playground-image-file');
+            // Hybrid fuses vector + full-text rankings; RRF is the right merge.
+            if (mode === 'hybrid' && mergeEl) {
+                mergeEl.value = 'rrf';
+            }
+            // Full-text search is text-only; disable the image input.
+            if (imageEl) {
+                imageEl.disabled = (mode === 'fts');
+            }
+        }
+
         async function performVectorSearch() {
             const query = document.getElementById('playground-query').value.trim();
             const destIds = getSelectedDestIds();
             const destInfo = getSelectedDestInfo();
             const topK = parseInt(document.getElementById('playground-topk').value) || 5;
             const mergeStrategy = document.getElementById('playground-merge-strategy').value;
+            const searchMode = document.getElementById('playground-search-mode').value;
             const statusEl = document.getElementById('playground-status');
             const resultsEl = document.getElementById('playground-results');
 
@@ -11965,8 +11989,12 @@
                 alert('Please enter a search query or upload an image');
                 return;
             }
+            if (searchMode === 'fts' && !query) {
+                alert('Full-Text mode requires a text query');
+                return;
+            }
             if (destIds.length === 0) {
-                alert('Please select at least one vector index');
+                alert('Please select at least one index');
                 return;
             }
 
@@ -11983,7 +12011,8 @@
                         query_image_b64: _playgroundImageB64,
                         destination_ids: destIds,
                         top_k: topK,
-                        merge_strategy: mergeStrategy
+                        merge_strategy: mergeStrategy,
+                        search_mode: searchMode
                     })
                 });
 
@@ -12021,11 +12050,13 @@
                 }
 
                 // Per-index breakdown (if multiple indexes)
+                const baseIndexId = (id) => String(id || '').split('::')[0];
                 let breakdownHtml = '';
                 if (searched.length > 1) {
                     breakdownHtml = `<div style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:16px;">` +
                         searched.map(idx => {
-                            const info = indexColorMap[idx.index_id] || { color: '#6b7280', name: idx.index_name };
+                            const base = indexColorMap[baseIndexId(idx.index_id)];
+                            const info = { color: (base && base.color) || '#6b7280', name: idx.index_name || (base && base.name) || idx.index_id };
                             const statusBadge = idx.error
                                 ? `<span style="color:var(--error);font-size:11px;">Failed</span>`
                                 : `<span style="font-size:11px;color:var(--text-tertiary);">${idx.result_count} results, ${idx.search_time_ms}ms</span>`;
@@ -12038,7 +12069,10 @@
 
                 const multiIndex = searched.length > 1;
                 resultsEl.innerHTML = breakdownHtml + data.results.map((r, i) => {
-                    const idxInfo = indexColorMap[r.index_id] || { color: '#6b7280', name: r.index_name || 'Unknown' };
+                    const idxInfo = (() => {
+                        const base = indexColorMap[baseIndexId(r.index_id)];
+                        return { color: (base && base.color) || '#6b7280', name: r.index_name || (base && base.name) || 'Unknown' };
+                    })();
                     const indexBadge = multiIndex
                         ? `<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:500;background:${idxInfo.color}20;color:${idxInfo.color};border:1px solid ${idxInfo.color}40;">
                             <span style="width:6px;height:6px;border-radius:50%;background:${idxInfo.color};"></span>

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -1767,16 +1767,8 @@
                                     <input type="number" class="form-input" id="playground-topk" value="5" min="1" max="20" style="width: 70px; text-align: center;">
                                 </div>
                                 <div class="form-group" style="margin-bottom: 0; display: flex; align-items: center; gap: 8px;">
-                                    <label class="form-label" style="margin-bottom: 0; white-space: nowrap;">Merge:</label>
-                                    <select class="form-input" id="playground-merge-strategy" style="width: 170px; padding: 6px 10px;">
-                                        <option value="interleave" selected>Interleave by Score</option>
-                                        <option value="round_robin">Round Robin</option>
-                                        <option value="per_index">Per-Index Cap</option>
-                                        <option value="rrf">RRF (rank fusion)</option>
-                                    </select>
-                                </div>
-                                <div class="form-group" style="margin-bottom: 0; display: flex; align-items: center; gap: 8px;">
                                     <label class="form-label" style="margin-bottom: 0; white-space: nowrap;">Image:</label>
+                                    <input type="hidden" id="playground-merge-strategy" value="rrf">
                                     <input type="file" id="playground-image-file" accept="image/*" style="font-size: 12px;" onchange="onPlaygroundImageChange(event)">
                                     <span id="playground-image-status" style="font-size: 12px; color: var(--text-tertiary);"></span>
                                     <button type="button" class="btn btn-ghost" style="padding: 4px 10px; font-size: 12px;" onclick="clearPlaygroundImage()">Clear</button>


### PR DESCRIPTION
## Summary
Adds **Full-Text** and **Hybrid** search modes to the Search Playground, which was previously vector-only. The search service already supported FTS (#180) and RRF merge — this exposes them in the playground UI/API and adds rank fusion so hybrid results from the same source are combined rather than duplicated.

## Changes
**Frontend** (web/static/index.html)
- New **Mode** selector: Vector / Full-Text / Hybrid.
- Added an **RRF (rank fusion)** merge option; Hybrid auto-selects RRF; Full-Text disables the image input.
- Sends search_mode; result/breakdown rendering tolerates hybrid's suffixed index ids; header renamed to "Search Playground".

**Backend API** (pi/api.py)
- `PlaygroundSearchRequest` gains `search_mode` (vector|fts|hybrid) and optional `fts_field`.
- `_build_index_specs` emits vector and/or FTS `IndexSpec`s per destination. Hybrid produces two specs (ids suffixed `::vec` / `::fts`) sharing a `fusion_group` so a document found by both fuses into one result.
- Forces `rrf` merge whenever FTS is involved (FTS hits have no comparable native score), rejects FTS without a text query, caps a request at 10 indexes, and resolves friendly per-index names (`X (vector)` / `X (full-text)`).
- pgvector destinations warn/skip for FTS (Cosmos-only in v1).

**Search service** (search/schemas.py, search/searcher.py)
- `IndexSpec` gains an optional `fusion_group`.
- `_merge` fuses indexes sharing a `fusion_group` under RRF on `(fusion_group, doc_id)` instead of `(index_id, doc_id)`, so hybrid vector+FTS hits for the same document collapse into one result with a combined RRF score. Behavior is unchanged when `fusion_group` is unset.

## Testing
- `tests/unit/test_search_fts.py`: 17 passed.
- Unit-verified `_merge` fusion: a doc returned by both `::vec` and `::fts` fuses to a single result with summed RRF score and ranks first; without fusion groups it appears twice (prior behavior).
- Deployed all three images to an isolated environment and verified Vector, Full-Text, and Hybrid modes return results via `/api/playground/search`; hybrid shows a per-index breakdown of `(vector)` and `(full-text)`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
