### PR TITLE
Add Cosmos DB user agent suffixes

### DIFF
--- a/api/sitecustomize.py
+++ b/api/sitecustomize.py
@@ -1,0 +1,34 @@
+"""Process-wide Cosmos DB user-agent suffixes for OmniVec API services."""
+
+from __future__ import annotations
+
+import inspect
+import os
+
+import azure.cosmos
+import azure.cosmos.cosmos_client as _cosmos_client
+from azure.cosmos import CosmosClient as _CosmosClient
+
+
+COSMOS_METADATA_USER_AGENT = "OmniVec-MetadataCosmos/1.0"
+COSMOS_DATA_USER_AGENT = "OmniVec-DataCosmos/1.0"
+
+
+def _cosmos_user_agent_suffix() -> str:
+    for frame in inspect.stack(context=0)[2:]:
+        filename = os.path.basename(frame.filename)
+        if filename == "store.py":
+            return COSMOS_METADATA_USER_AGENT
+        if filename == "api.py" and frame.function == "get_changefeed_leases":
+            return COSMOS_METADATA_USER_AGENT
+    return COSMOS_DATA_USER_AGENT
+
+
+class OmniVecCosmosClient(_CosmosClient):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("user_agent_suffix", _cosmos_user_agent_suffix())
+        super().__init__(*args, **kwargs)
+
+
+azure.cosmos.CosmosClient = OmniVecCosmosClient
+_cosmos_client.CosmosClient = OmniVecCosmosClient

--- a/connectors/ingestion/dotnet/Program.cs
+++ b/connectors/ingestion/dotnet/Program.cs
@@ -9,6 +9,8 @@ using OmniVec.ChangeFeed.Services;
 // 500 threads for 100K RU/s provisioned throughput
 ThreadPool.SetMinThreads(1000, 1000);
 
+const string CosmosMetadataUserAgent = "OmniVec-MetadataCosmos/1.0";
+
 var builder = Host.CreateApplicationBuilder(args);
 
 // Bind configuration from env vars: ChangeFeed__OmniVecCosmosEndpoint, etc.
@@ -23,6 +25,7 @@ builder.Services.AddSingleton(sp =>
     return new CosmosClient(opts.OmniVecCosmosEndpoint, new DefaultAzureCredential(),
         new CosmosClientOptions
         {
+            ApplicationName = CosmosMetadataUserAgent,
             ConnectionMode = ConnectionMode.Direct,
             MaxRetryAttemptsOnRateLimitedRequests = int.MaxValue,
             MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(300),
@@ -40,6 +43,7 @@ builder.Services.AddKeyedSingleton<CosmosClient>("lease", (sp, _) =>
     return new CosmosClient(leaseEndpoint, new DefaultAzureCredential(),
         new CosmosClientOptions
         {
+            ApplicationName = CosmosMetadataUserAgent,
             ConnectionMode = ConnectionMode.Direct,
             MaxRetryAttemptsOnRateLimitedRequests = int.MaxValue,
             MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(300),

--- a/connectors/ingestion/dotnet/Services/SourceWatcher.cs
+++ b/connectors/ingestion/dotnet/Services/SourceWatcher.cs
@@ -16,6 +16,8 @@ namespace OmniVec.ChangeFeed.Services;
 /// </summary>
 public class SourceWatcher : ISourceWatcher
 {
+    private const string CosmosDataUserAgent = "OmniVec-DataCosmos/1.0";
+
     private readonly Source _source;
     private readonly ChangeFeedOptions _options;
     private readonly OmniVecApiClient _apiClient;
@@ -106,6 +108,7 @@ public class SourceWatcher : ISourceWatcher
             new DefaultAzureCredential(),
             new CosmosClientOptions
             {
+                ApplicationName = CosmosDataUserAgent,
                 ConnectionMode = ConnectionMode.Direct,
                 ConsistencyLevel = ConsistencyLevel.Eventual,
                 MaxRetryAttemptsOnRateLimitedRequests = int.MaxValue,

--- a/connectors/worker/dotnet/Destinations/CosmosDbDestinationWriter.cs
+++ b/connectors/worker/dotnet/Destinations/CosmosDbDestinationWriter.cs
@@ -6,6 +6,8 @@ namespace OmniVec.Worker.Destinations;
 
 public class CosmosDbDestinationWriter : IDestinationWriter
 {
+    private const string CosmosDataUserAgent = "OmniVec-DataCosmos/1.0";
+
     private readonly ILogger<CosmosDbDestinationWriter> _logger;
     private static readonly ConcurrentDictionary<string, CosmosClient> _clients = new();
     private static readonly ConcurrentDictionary<string, string> _pkPathCache = new();
@@ -241,6 +243,7 @@ public class CosmosDbDestinationWriter : IDestinationWriter
         return _clients.GetOrAdd(endpoint, ep =>
             new CosmosClient(ep, new DefaultAzureCredential(), new CosmosClientOptions
             {
+                ApplicationName = CosmosDataUserAgent,
                 ConnectionMode = ConnectionMode.Direct,
                 MaxRetryAttemptsOnRateLimitedRequests = int.MaxValue,
                 MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(300),


### PR DESCRIPTION
## Summary
- add OmniVec-MetadataCosmos/1.0 for metadata and lease Cosmos clients
- add OmniVec-DataCosmos/1.0 for data Cosmos clients
- keep the code diff additive-only: 44 insertions, 0 deletions

## Validation
- python -m compileall -q api
- dotnet build connectors\\ingestion\\dotnet\\OmniVec.ChangeFeed.csproj -v:minimal
- dotnet build connectors\\worker\\dotnet\\OmniVec.Worker.csproj -v:minimal